### PR TITLE
Add live pilot presence on shared maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A wormhole mapping tool for EVE Online. Track systems, signatures, structures, k
 - **Chain exit summary** — sidebar widget that counts every K-space exit currently on the map by security class (HS / LS / NS) as coloured chips, and pinpoints the nearest gate route to Jita ("Nearest Jita: 7j via Amarr") so loot runs and logistics planning don't need a manual route check.
 - **Route planner** — server-side BFS over stargates + your live chain, so a route through a wormhole hop is a single click.
 - **Location tracking** — opt-in live character location dot in the toolbar plus per-map "you are here" indicator.
+- **Pilot presence** — see where everyone *viewing the same map* is right now: a blue dot (pilot name on hover) marks each other viewer's current system, live as they jump. Unlike fleet dots it covers anyone with the map open, not just your fleet. Opt-in via location sharing, scoped to maps you can see, and ephemeral (nothing stored).
 - **Online status** — toolbar dot shows whether each user is currently logged into EVE Online.
 
 #### Productivity & UX

--- a/presence_feature.md
+++ b/presence_feature.md
@@ -1,0 +1,117 @@
+# Map Presence — Design
+
+## 1. Goal
+
+Show a live dot for **anyone viewing the same map** (opt-in), placed on the
+system they're currently in — not limited to fleet members. Answers "who in the
+corp is in/around this chain right now." Rides the SSE transport from
+[realtime_sync_feature.md]; presence is **ephemeral** (never persisted).
+
+Complements the existing fleet dots: presence covers *Nexum users with the map
+open*; fleet covers *everyone in the fleet incl. non-users* (read via the boss).
+Different sets — both can run.
+
+## 2. Core model
+
+ESI has no push and you can't poll someone else's location, so presence works by
+**each client reporting its own location, and the server fanning it out** to the
+map room:
+
+1. A client viewing map X, **with location tracking opted in**, reports its
+   current `eveSystemId` to the server (on location change + a periodic
+   heartbeat). It already knows this from `useLocationTracking`/
+   `useCharacterLocation`.
+2. The server upserts it into an in-memory per-map roster and broadcasts a
+   `presence.update` to map X's SSE room.
+3. Every viewer of map X renders the dot on the matching node.
+
+**Gating (both already exist):** the SSE room is access-checked (you only see
+presence for maps you can see), and location tracking is **opt-in** — a viewer
+with tracking off still sees others but doesn't broadcast themselves.
+
+## 3. Server
+
+### 3.1 Registry — `services/presence.ts`
+- `Map<mapId, Map<characterId, Entry>>` where
+  `Entry = { characterId, characterName, eveSystemId, shipTypeId?, ts }`.
+- `report(mapId, entry)` — upsert with `ts = now`, then
+  `publishToMap(mapId, { type: 'presence.update', actor, ...entry })`.
+- `remove(mapId, characterId)` — delete, then publish `presence.leave`.
+- `snapshot(mapId)` — current roster (for a newly-connecting client).
+- **TTL sweep**: `setInterval` (~30 s) drops entries older than ~60 s and
+  publishes `presence.leave` for each. Single-process, same as the SSE registry.
+
+### 3.2 Endpoints
+- `POST /api/maps/:mapId/presence` — body `{ eveSystemId, shipTypeId? }`.
+  `getMapAccess` only (viewing is enough — even a readonly corp member can show
+  presence). Server attaches `characterId`/`characterName` from the session
+  (client never asserts identity). Calls `report(...)`. Returns 204.
+- `DELETE /api/maps/:mapId/presence` — best-effort leave (sent via
+  `navigator.sendBeacon` on unload / map switch). Calls `remove(...)`.
+
+### 3.3 Snapshot on connect
+In the existing `GET /:mapId/events` handler, right after `subscribeMap`, write a
+`presence.snapshot` event with `snapshot(mapId)` so a new viewer sees who's
+already present immediately (rather than waiting for the next heartbeat).
+
+### 3.4 Clear on disconnect
+On the SSE `req.close`, also `remove(mapId, <that user's characterId>)` for a
+snappy "left" (TTL is the backstop for multi-tab / missed closes).
+
+## 4. Client
+
+### 4.1 Reporting own location
+Extend `useLocationTracking` (it already tracks the player's `eveSystemId`): when
+there's an active map **and** tracking is on, `POST …/presence` on each location
+change and on a ~25 s heartbeat. On unmount / map switch, fire the
+`sendBeacon` leave.
+
+### 4.2 Presence store (ephemeral, separate from mapStore)
+A small store — `Map<characterId, Entry>` for the active map. The
+`useMapEventStream` hook dispatches the new events to it:
+- `presence.snapshot` → replace roster.
+- `presence.update` → upsert (skip our **own** characterId — the existing
+  "you are here" indicator covers self).
+- `presence.leave` → remove.
+- Reset the store on map switch.
+
+These are **not** routed through `mapStore.applyRemote` — presence is transient
+UI state, not map data.
+
+### 4.3 Rendering
+Reuse the fleet-dot pattern: a `usePresence()` selector exposes
+`Map<eveSystemId, viewers[]>`; `SystemNode` renders presence dots for its system,
+in a **distinct colour from fleet** (e.g. teal vs purple), hover → character
+name(s), co-located viewers stacked/counted.
+
+- **On-map only**: a dot renders only when the viewer's `eveSystemId` matches a
+  node on the map. Viewers elsewhere in New Eden (e.g. sitting in Jita) don't get
+  a dot.
+- **Off-map viewers (optional, v1.1)**: a small sidebar roster — "Viewing: 4
+  (2 in chain, 2 elsewhere)" — for the ones whose system isn't a node.
+
+## 5. Privacy / scope
+- Opt-in via the existing location-tracking toggle; off → you see others, don't
+  broadcast.
+- Room-scoped + access-checked → only people who can see the map.
+- Ephemeral — nothing written to the DB; in-memory, expires on disconnect/TTL.
+
+## 6. Phased rollout
+1. **Server**: `presence.ts` (registry + report/remove/snapshot + TTL sweep),
+   the POST/DELETE endpoints, snapshot on SSE connect, clear on disconnect.
+2. **Client**: report-own-location (heartbeat + on-change + leave beacon),
+   presence store, dispatch the three events, render on-map dots (distinct
+   colour, self-suppressed, co-located stacking).
+3. **(Optional)** off-map "viewing" roster in the sidebar.
+4. **(Later, if scaling)** move the roster fan-out behind Postgres
+   `LISTEN/NOTIFY`, same as the edit stream.
+
+## 7. Notes / risks
+- **No extra ESI load**: each user already polls their own location; presence
+  just reports the result. It unlocks a capability polling can't (seeing others),
+  not an optimization.
+- **Heartbeat cadence**: ~25 s report + ~60 s TTL keeps the roster fresh without
+  chatter; location itself is ESI-cached ~5 s so dots track jumps closely.
+- **Fleet stays**: presence is additive; a viewer who's also a fleet member may
+  show both a fleet and a presence dot — fine, or dedupe later.
+- **Single instance** assumption, identical to the SSE edit stream.

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -9,6 +9,7 @@ import { recordGhostSiteIfMatch } from '../services/ghostSites.js';
 import { resolveEntityNames } from '../services/entityNames.js';
 import { audit } from '../services/audit.js';
 import { subscribeMap, publishToMap } from '../services/mapEvents.js';
+import { reportPresence, removePresence, presenceSnapshot } from '../services/presence.js';
 
 const log = createLogger('maps');
 
@@ -1160,7 +1161,40 @@ mapsRouter.get('/:mapId/events', async (req, res) => {
   // Heartbeat keeps intermediaries from closing an idle stream.
   const heartbeat = setInterval(() => { try { res.write(': ping\n\n'); } catch { /* closed */ } }, 25_000);
 
-  req.on('close', () => { clearInterval(heartbeat); unsubscribe(); });
+  // Hand the new viewer the current presence roster so it sees who's already
+  // here without waiting for the next heartbeat round.
+  try {
+    res.write(`data: ${JSON.stringify({ type: 'presence.snapshot', viewers: presenceSnapshot(mapId) })}\n\n`);
+  } catch { /* closed */ }
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+    // Closing the stream = left the map → drop this viewer's presence (TTL is
+    // the backstop for unclean disconnects / multiple tabs).
+    if (req.session.characterId) removePresence(mapId, req.session.characterId);
+  });
+});
+
+// POST /api/maps/:mapId/presence — a viewer reports its current location.
+// Identity comes from the session (never trusted from the body). Viewing access
+// is enough (even readonly corp members show presence). See presence_feature.md.
+mapsRouter.post('/:mapId/presence', async (req, res) => {
+  const { mapId } = req.params;
+  const access = await getMapAccess(mapId, req);
+  if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
+  const characterId   = req.session.characterId;
+  const characterName = req.session.characterName;
+  if (!characterId || !characterName) { res.status(401).json({ error: 'No character on session' }); return; }
+
+  const body = req.body as { eveSystemId?: unknown; shipTypeId?: unknown };
+  reportPresence(mapId, {
+    characterId,
+    characterName,
+    eveSystemId: typeof body.eveSystemId === 'number' ? body.eveSystemId : null,
+    shipTypeId:  typeof body.shipTypeId  === 'number' ? body.shipTypeId  : null,
+  }, req.get('x-client-id') ?? null);
+  res.status(204).end();
 });
 
 // PATCH /api/maps/:mapId  — rename (corp/owner only), lock (admin only), or

--- a/server/src/services/presence.ts
+++ b/server/src/services/presence.ts
@@ -1,0 +1,61 @@
+import { publishToMap } from './mapEvents.js';
+
+// Ephemeral "who's viewing this map and where are they" roster. Never
+// persisted — in-memory per map, expired by TTL / disconnect. Rides the same
+// SSE fan-out as map edits. See presence_feature.md.
+export interface PresenceEntry {
+  characterId:   number;
+  characterName: string;
+  eveSystemId:   number | null;  // current system; null = unknown / docked elsewhere
+  shipTypeId:    number | null;
+  ts:            number;          // last heartbeat (ms)
+}
+
+const TTL_MS    = 60_000;
+const SWEEP_MS  = 30_000;
+
+const rosters = new Map<string, Map<number, PresenceEntry>>();
+
+// Upsert a viewer's location and fan it out to the map room.
+export function reportPresence(
+  mapId: string,
+  entry: Omit<PresenceEntry, 'ts'>,
+  actor: string | null,
+): void {
+  let roster = rosters.get(mapId);
+  if (!roster) { roster = new Map(); rosters.set(mapId, roster); }
+  const full: PresenceEntry = { ...entry, ts: Date.now() };
+  roster.set(entry.characterId, full);
+  publishToMap(mapId, { type: 'presence.update', actor, ...full });
+}
+
+// Drop a viewer (left the map / disconnected) and notify the room.
+export function removePresence(mapId: string, characterId: number): void {
+  const roster = rosters.get(mapId);
+  if (!roster || !roster.has(characterId)) return;
+  roster.delete(characterId);
+  if (roster.size === 0) rosters.delete(mapId);
+  publishToMap(mapId, { type: 'presence.leave', characterId });
+}
+
+// Current roster for a map — sent to a client when it first connects.
+export function presenceSnapshot(mapId: string): PresenceEntry[] {
+  const roster = rosters.get(mapId);
+  return roster ? [...roster.values()] : [];
+}
+
+// Expire stale entries (a client that stopped heart-beating without a clean
+// disconnect). The backstop behind the SSE close handler.
+const sweep = setInterval(() => {
+  const cutoff = Date.now() - TTL_MS;
+  for (const [mapId, roster] of rosters) {
+    for (const [characterId, entry] of roster) {
+      if (entry.ts < cutoff) {
+        roster.delete(characterId);
+        publishToMap(mapId, { type: 'presence.leave', characterId });
+      }
+    }
+    if (roster.size === 0) rosters.delete(mapId);
+  }
+}, SWEEP_MS);
+sweep.unref?.();

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1783,6 +1783,55 @@
   display: block;
 }
 
+/* Presence: other pilots viewing this map who are in this system. Blue, to
+   distinguish from the purple fleet dot; hover reveals their names. */
+.system-node__presence-dot-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-right: 4px;
+}
+
+.system-node__presence-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4d9de0;
+  box-shadow: 0 0 5px #4d9de0;
+  flex-shrink: 0;
+  cursor: help;
+}
+
+.system-node__presence-tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  background: #111827;
+  border: 1px solid #2e3f60;
+  border-radius: 6px;
+  padding: 5px 8px;
+  white-space: nowrap;
+  z-index: 9999;
+  flex-direction: column;
+  gap: 2px;
+  pointer-events: none;
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #c8d4f0;
+}
+
+.system-node__presence-dot-wrap:hover .system-node__presence-tooltip {
+  display: flex;
+}
+
+.react-flow__node:has(.system-node__presence-dot-wrap:hover) {
+  z-index: 9999 !important;
+}
+
+.system-node__presence-tooltip-row {
+  display: block;
+}
+
 .system-node__lock-icon {
   font-size: calc(13px * var(--font-scale, 1));
   opacity: 0.7;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { SharedMapView } from './components/ui/SharedMapView';
 import { useMapStore } from './store/mapStore';
 import { useLocationTracking } from './hooks/useLocationTracking';
 import { useMapEventStream } from './hooks/useMapEventStream';
+import { useMapPresence } from './hooks/useMapPresence';
 import { useHashRoute } from './hooks/useHashRoute';
 import './App.css';
 
@@ -77,6 +78,7 @@ function MapApp() {
 
   useLocationTracking(!!mapId);
   useMapEventStream();
+  useMapPresence();
 
   return (
     <ReactFlowProvider>

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -8,6 +8,7 @@ import type { NodeProps } from '@xyflow/react';
 import type { MapSystem } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS, EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
 import { useMapStore } from '../../store/mapStore';
+import { usePresenceStore } from '../../store/presenceStore';
 import { useSovData } from '../../hooks/useSovData';
 import { useStandings } from '../../hooks/useStandings';
 import { useFleet } from '../../hooks/useFleet';
@@ -60,6 +61,18 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
     const myId = user?.characterId;
     return myId ? all.filter((m) => m.characterId !== myId) : all;
   }, [showFleetMembers, fleet.bySystem, sys.eveSystemId, user?.characterId]);
+
+  // Other people viewing this map who are currently in this system (presence).
+  // Excludes self — the green you-are-here dot covers that.
+  const presenceViewers = usePresenceStore((s) => s.viewers);
+  const presenceHere    = useMemo(() => {
+    if (sys.eveSystemId == null) return undefined;
+    const myId = user?.characterId;
+    const here = Object.values(presenceViewers).filter(
+      (v) => v.eveSystemId === sys.eveSystemId && v.characterId !== myId,
+    );
+    return here.length ? here : undefined;
+  }, [presenceViewers, sys.eveSystemId, user?.characterId]);
 
   // Halo around any sov-holder system based on the user's contact bands.
   // Threshold is just "negative or positive" rather than the strict ≤-5
@@ -193,6 +206,18 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
               {fleetHere.map((m) => (
                 <span key={m.characterId} className="system-node__fleet-tooltip-row">
                   {m.characterName ?? `Character ${m.characterId}`}
+                </span>
+              ))}
+            </span>
+          </span>
+        )}
+        {presenceHere && (
+          <span className="system-node__presence-dot-wrap">
+            <span className="system-node__presence-dot" />
+            <span className="system-node__presence-tooltip">
+              {presenceHere.map((v) => (
+                <span key={v.characterId} className="system-node__presence-tooltip-row">
+                  {v.characterName || `Character ${v.characterId}`}
                 </span>
               ))}
             </span>

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -184,6 +184,11 @@ const FEATURE_SECTIONS: FeatureSection[] = [
         desc: 'Opt-in live character location dot in the toolbar, plus a per-map "you are here" indicator that updates every 10 seconds via ESI.',
       },
       {
+        icon: UsersIcon,
+        title: 'Pilot presence',
+        desc: 'See where everyone viewing the same map is right now — a blue dot (pilot name on hover) marks each other viewer\'s current system, live as they jump. Covers anyone with the map open, not just your fleet; opt-in and nothing is stored.',
+      },
+      {
         icon: BroadcastIcon,
         title: 'Online status',
         desc: 'Toolbar dot shows whether each logged-in user is currently signed into EVE Online, so you can see at a glance who\'s actually on grid.',

--- a/web/src/hooks/useMapEventStream.ts
+++ b/web/src/hooks/useMapEventStream.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useMapStore, type RemoteEvent } from '../store/mapStore';
+import { usePresenceStore, type PresenceViewer } from '../store/presenceStore';
 import { apiUrl } from '../api/client';
 import { CLIENT_ID } from '../api/clientId';
 
@@ -15,6 +16,7 @@ export function useMapEventStream(): void {
   useEffect(() => {
     if (!activeMapId) return;
     openedOnce.current = false;
+    usePresenceStore.getState().reset(); // clear last map's roster; snapshot repopulates
 
     const es = new EventSource(apiUrl(`/api/maps/${activeMapId}/events`), { withCredentials: true });
 
@@ -30,9 +32,24 @@ export function useMapEventStream(): void {
 
     es.onmessage = (e) => {
       try {
-        const data = JSON.parse(e.data) as RemoteEvent & { actor?: string | null };
+        const data = JSON.parse(e.data) as { type: string; actor?: string | null } & Record<string, unknown>;
+        const presence = usePresenceStore.getState();
+        // Presence events are ephemeral UI state — route to the presence store,
+        // not mapStore. (snapshot/leave carry no actor; only update is echoed.)
+        switch (data.type) {
+          case 'presence.snapshot':
+            presence.snapshot((data.viewers as PresenceViewer[] | undefined) ?? []);
+            return;
+          case 'presence.update':
+            if (data.actor !== CLIENT_ID) presence.upsert(data as unknown as PresenceViewer);
+            return;
+          case 'presence.leave':
+            presence.remove(data.characterId as number);
+            return;
+        }
+
         if (data.actor === CLIENT_ID) return; // our own echo — already applied
-        useMapStore.getState().applyRemote(data);
+        useMapStore.getState().applyRemote(data as unknown as RemoteEvent);
       } catch { /* ignore malformed frame */ }
     };
 

--- a/web/src/hooks/useMapPresence.ts
+++ b/web/src/hooks/useMapPresence.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useMapStore } from '../store/mapStore';
+import { useCharacterLocation } from './useCharacterLocation';
+import { api } from '../api/client';
+
+// Reports the viewer's own location to the active map so the server can fan it
+// out as presence. Only reports when we actually have a location (online + in a
+// known system) — inheriting the location opt-in. Heartbeats to keep the
+// server-side TTL alive; the SSE disconnect handles "left". See
+// presence_feature.md.
+const HEARTBEAT_MS = 25_000;
+
+export function useMapPresence(): void {
+  const activeMapId = useMapStore((s) => s.activeMapId);
+  const location = useCharacterLocation();
+  const eveSystemId = location.online && location.system ? location.system.eveSystemId : null;
+
+  useEffect(() => {
+    if (!activeMapId || eveSystemId == null) return;
+    const report = () => {
+      api(`/api/maps/${activeMapId}/presence`, {
+        method: 'POST',
+        body: JSON.stringify({ eveSystemId }),
+      }).catch(() => { /* presence is best-effort */ });
+    };
+    report();
+    const hb = setInterval(report, HEARTBEAT_MS);
+    return () => clearInterval(hb);
+  }, [activeMapId, eveSystemId]);
+}

--- a/web/src/store/presenceStore.ts
+++ b/web/src/store/presenceStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+// Live "who's viewing this map and where" — ephemeral, fed by the SSE stream.
+// Kept out of mapStore because it isn't map data and is reset on every switch.
+export interface PresenceViewer {
+  characterId:   number;
+  characterName: string;
+  eveSystemId:   number | null;
+  shipTypeId?:   number | null;
+}
+
+interface PresenceState {
+  viewers: Record<number, PresenceViewer>; // keyed by characterId
+  snapshot: (list: PresenceViewer[]) => void;
+  upsert:   (v: PresenceViewer) => void;
+  remove:   (characterId: number) => void;
+  reset:    () => void;
+}
+
+export const usePresenceStore = create<PresenceState>((set) => ({
+  viewers: {},
+  snapshot: (list) => set({ viewers: Object.fromEntries(list.map((v) => [v.characterId, v])) }),
+  upsert:   (v) => set((s) => ({ viewers: { ...s.viewers, [v.characterId]: v } })),
+  remove:   (characterId) => set((s) => {
+    if (!(characterId in s.viewers)) return s;
+    const next = { ...s.viewers };
+    delete next[characterId];
+    return { viewers: next };
+  }),
+  reset: () => set({ viewers: {} }),
+}));


### PR DESCRIPTION
Show where everyone viewing the same map is, in real time — a blue dot (pilot name on hover) on each other viewer's current system, live as they jump. Rides the existing per-map SSE stream; ephemeral, never persisted. Distinct from fleet dots: covers anyone with the map open, not just your fleet.

Server:
- services/presence.ts — in-memory per-map roster (report / remove / snapshot) with a 60s TTL sweep; fans out via publishToMap.
- POST /api/maps/:mapId/presence — viewer reports its location; identity taken from the session, not the body.
- SSE endpoint sends a presence.snapshot on connect and drops the viewer on disconnect.

Client:
- useMapPresence — reports own location on change + 25s heartbeat, only when actually on grid (inherits the location opt-in).
- presenceStore — ephemeral roster fed by presence.snapshot/update/leave from useMapEventStream; reset on map switch; own echo suppressed.
- SystemNode renders a blue presence dot (self excluded) with a hover tooltip of pilot names.

Docs: presence_feature.md, README + landing-page feature.