### PR TITLE
feat: corp structures ESI integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,4 +73,7 @@ CORP_MAP_SHARED=false
 #       DISCORD_WEBHOOK_URL=98000001=https://discord.com/api/webhooks/1/a,98000002=https://discord.com/api/webhooks/2/b
 # DISCORD_WEBHOOK_URL=
 
+# Hours before fuel runs out to trigger alerts (default: 72).
+FUEL_ALERT_HOURS=72
+
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -12,6 +12,7 @@ const CORP_IDS: number[] = (process.env.CORP_ID ?? '')
 const ADMIN_CHAR_ID = process.env.ADMIN_CHAR_ID ? parseInt(process.env.ADMIN_CHAR_ID, 10) : null;
 const REPORTS_CHAR_ID = process.env.RV_REPORT_ID ? parseInt(process.env.RV_REPORT_ID, 10) : null;
 const CORP_MAP_TIME = parseInt(process.env.CORP_MAP_TIME ?? '30', 10);
+const FUEL_ALERT_HOURS = Math.max(1, parseInt(process.env.FUEL_ALERT_HOURS ?? '72', 10) || 72);
 
 // When true, every member of any listed corp can see every corp map regardless
 // of which corp created it. When false (default), corp maps are visible only
@@ -94,6 +95,7 @@ export const config = {
   maxUserMaps:         parseInt(process.env.MAX_USER_MAPS ?? '5', 10),
   maxCorpMaps:         parseInt(process.env.MAX_CORP_MAPS ?? '5', 10),
   discord:             DISCORD_WEBHOOKS,
+  fuelAlertHours:      FUEL_ALERT_HOURS,
   sessionSecret:       process.env.SESSION_SECRET ?? 'dev-secret-change-me',
   tokenEncryptionKey,
   isProd,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -23,10 +23,12 @@ import scoutRouter        from './routes/scout.js';
 import routeRouter        from './routes/route.js';
 import wormholesRouter    from './routes/wormholes.js';
 import { loadRouteGraph } from './services/routeGraph.js';
+import { initCorpStructures } from './services/corpStructures.js';
 import { adminRouter, adminReadRouter, reportsRouter } from './routes/admin.js';
 import { standingsRouter } from './routes/standings.js';
 import { shareRouter } from './routes/share.js';
 import searchRouter from './routes/search.js';
+import corpStructuresRouter from './routes/corpStructures.js';
 import { authLimiter, esiLimiter, publicLimiter, appLimiter } from './middleware/rateLimits.js';
 import { originGuard } from './middleware/originGuard.js';
 import { createLogger } from './utils/logger.js';
@@ -103,6 +105,7 @@ app.use('/api/admin',             appLimiter, adminReadRouter);
 app.use('/api/admin',             appLimiter, adminRouter);
 app.use('/api/standings',         appLimiter, standingsRouter);
 app.use('/api/search',            esiLimiter, searchRouter);
+app.use('/api/corp-structures',   esiLimiter, corpStructuresRouter);
 
 app.get('/health', (_req, res) => res.json({ ok: true }));
 
@@ -139,6 +142,7 @@ migrate()
     await expireMaps();
     setInterval(expireMaps, 60 * 60 * 1000); // re-check hourly
     await initActivity();
+    await initCorpStructures();
     await loadRouteGraph();
     app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));
   })

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -452,6 +452,30 @@ export async function migrate() {
     CREATE UNIQUE INDEX IF NOT EXISTS uq_map_shares_corp ON map_shares (map_id, target_corp_id)      WHERE target_corp_id      IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_map_shares_char ON map_shares (target_character_id) WHERE target_character_id IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_map_shares_corp ON map_shares (target_corp_id)      WHERE target_corp_id      IS NOT NULL;
+
+    -- ── Corp structures (ESI-sourced) ──────────────────────────────────
+    CREATE TABLE IF NOT EXISTS corp_structures (
+      structure_id      BIGINT      PRIMARY KEY,
+      corporation_id    INT         NOT NULL,
+      system_id         INT         NOT NULL,
+      type_id           INT         NOT NULL,
+      name              TEXT        NOT NULL DEFAULT '',
+      state             TEXT        NOT NULL DEFAULT 'unknown',
+      fuel_expires      TIMESTAMPTZ,
+      services          JSONB       NOT NULL DEFAULT '[]',
+      reinforce_hour    INT,
+      state_timer_start TIMESTAMPTZ,
+      state_timer_end   TIMESTAMPTZ,
+      unanchors_at      TIMESTAMPTZ,
+      last_polled       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      removed_at        TIMESTAMPTZ,
+      fuel_alert_sent_at TIMESTAMPTZ
+    );
+    CREATE INDEX IF NOT EXISTS idx_corp_structures_corp   ON corp_structures (corporation_id);
+    CREATE INDEX IF NOT EXISTS idx_corp_structures_system ON corp_structures (system_id);
+
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS has_structures_scope BOOLEAN NOT NULL DEFAULT FALSE;
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS has_station_manager  BOOLEAN NOT NULL DEFAULT FALSE;
   `);
 
   await encryptLegacyTokens();

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -19,6 +19,23 @@ const FRONTEND_URL  = process.env.FRONTEND_URL ?? 'http://localhost:5174';
 const EVE_AUTH_URL  = 'https://login.eveonline.com/v2/oauth/authorize';
 const EVE_TOKEN_URL = 'https://login.eveonline.com/v2/oauth/token';
 
+const BASE_SCOPES = [
+  'esi-location.read_location.v1',
+  'esi-location.read_ship_type.v1',
+  'esi-structures.read_structures.v1',
+  'esi-corporations.read_corporation_membership.v1',
+  'esi-ui.open_window.v1',
+  'esi-ui.write_waypoint.v1',
+  'esi-characters.read_corporation_roles.v1',
+  'esi-location.read_online.v1',
+  'esi-characters.read_contacts.v1',
+  'esi-corporations.read_contacts.v1',
+  'esi-alliances.read_contacts.v1',
+  'esi-fleets.read_fleet.v1',
+];
+
+const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1';
+
 // GET /auth/login  — redirect to EVE SSO
 authRouter.get('/login', (req, res) => {
   const state = randomBytes(32).toString('hex');
@@ -28,28 +45,32 @@ authRouter.get('/login', (req, res) => {
     response_type: 'code',
     redirect_uri:  CALLBACK_URL,
     client_id:     CLIENT_ID,
-    scope: [
-          'esi-location.read_location.v1',
-          'esi-location.read_ship_type.v1',
-          'esi-universe.read_structures.v1',
-          'esi-corporations.read_corporation_membership.v1',
-          'esi-ui.open_window.v1',
-          'esi-ui.write_waypoint.v1',
-          'esi-characters.read_corporation_roles.v1',
-          'esi-location.read_online.v1',
-          // Read player standings (contacts) so the UI can colour-tag
-          // structures / killboard / sov by your standing toward each
-          // entity. Corp / alliance reads only succeed for characters with
-          // the Contact Manager role; reads gracefully no-op otherwise.
-          'esi-characters.read_contacts.v1',
-          'esi-corporations.read_contacts.v1',
-          'esi-alliances.read_contacts.v1',
-          // Fleet member tracking — show fleet-mate locations on the map as
-          // purple dots. Requires the character to be the fleet boss or a
-          // wing/squad commander; ESI returns 403 to everyone else and the
-          // UI degrades silently to "no fleet visibility".
-          'esi-fleets.read_fleet.v1',
-        ].join(' '),
+    scope: BASE_SCOPES.join(' '),
+    state,
+  });
+
+  req.session.save((err) => {
+    if (err) { res.status(500).json({ error: 'Session error' }); return; }
+    res.redirect(`${EVE_AUTH_URL}?${params}`);
+  });
+});
+
+// GET /auth/grant-structures — optional scope grant for ESI corp structures
+authRouter.get('/grant-structures', (req, res) => {
+  if (!req.session.userId) {
+    res.redirect(`${FRONTEND_URL}?error=not_logged_in`);
+    return;
+  }
+
+  const state = randomBytes(32).toString('hex');
+  req.session.oauthState = state;
+  req.session.scopeGrant = true;
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    redirect_uri:  CALLBACK_URL,
+    client_id:     CLIENT_ID,
+    scope:         [...BASE_SCOPES, STRUCTURES_SCOPE].join(' '),
     state,
   });
 
@@ -69,6 +90,8 @@ authRouter.get('/callback', async (req, res) => {
     return;
   }
   delete req.session.oauthState;
+  const isScopeGrant = req.session.scopeGrant === true;
+  delete req.session.scopeGrant;
 
   try {
     // Exchange code for tokens
@@ -97,6 +120,18 @@ authRouter.get('/callback', async (req, res) => {
       refresh_token: string;
       expires_in: number;
     };
+
+    if (isScopeGrant && req.session.userId) {
+      await db.query(
+        `UPDATE users SET access_token = $1, refresh_token = $2, token_expires_at = $3,
+                has_structures_scope = TRUE, updated_at = NOW()
+         WHERE id = $4`,
+        [encryptToken(tokens.access_token), encryptToken(tokens.refresh_token),
+         new Date(Date.now() + tokens.expires_in * 1000), req.session.userId],
+      );
+      res.redirect(FRONTEND_URL);
+      return;
+    }
 
     // Decode the JWT payload to extract character info (EVE SSO v2)
     const jwtPayload = JSON.parse(
@@ -141,6 +176,23 @@ authRouter.get('/callback', async (req, res) => {
       }
     }
 
+    // Check if character has Station_Manager corp role (needed for structure ESI).
+    let hasStationManager = false;
+    if (userCorpId) {
+      try {
+        const rolesRes = await fetch(
+          `https://esi.evetech.net/v2/characters/${characterId}/roles/`,
+          { headers: { Authorization: `Bearer ${tokens.access_token}` } },
+        );
+        if (rolesRes.ok) {
+          const rolesData = await rolesRes.json() as { roles?: string[] };
+          hasStationManager = (rolesData.roles ?? []).includes('Station_Manager');
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+
     const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     // Role policy:
@@ -154,8 +206,8 @@ authRouter.get('/callback', async (req, res) => {
     const defaultRole = (!config.corpMode || isAdminChar) ? 'admin' : 'readonly';
 
     const { rows } = await db.query<{ id: number; role: string; blocked: boolean }>(
-      `INSERT INTO users (character_id, character_name, access_token, refresh_token, token_expires_at, role, corp_id, alliance_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $8, $10)
+      `INSERT INTO users (character_id, character_name, access_token, refresh_token, token_expires_at, role, corp_id, alliance_id, has_station_manager)
+       VALUES ($1, $2, $3, $4, $5, $6, $8, $10, $11)
        ON CONFLICT (character_id) DO UPDATE SET
          character_name   = EXCLUDED.character_name,
          access_token     = EXCLUDED.access_token,
@@ -163,6 +215,7 @@ authRouter.get('/callback', async (req, res) => {
          token_expires_at = EXCLUDED.token_expires_at,
          corp_id          = COALESCE($8::int,  users.corp_id),
          alliance_id      = COALESCE($10::int, users.alliance_id),
+         has_station_manager = EXCLUDED.has_station_manager,
          role             = CASE
            -- ADMIN_CHAR_ID is always pinned to admin regardless of mode
            WHEN $7::int IS NOT NULL AND users.character_id = $7::int THEN 'admin'
@@ -173,7 +226,7 @@ authRouter.get('/callback', async (req, res) => {
          updated_at       = NOW()
        RETURNING id, role, blocked`,
       [characterId, jwtPayload.name, encryptToken(tokens.access_token), encryptToken(tokens.refresh_token), expiresAt,
-       defaultRole, config.adminCharId, userCorpId, !config.corpMode, userAllianceId],
+       defaultRole, config.adminCharId, userCorpId, !config.corpMode, userAllianceId, hasStationManager],
     );
 
     const userId = rows[0].id;
@@ -286,6 +339,11 @@ authRouter.get('/me', async (req, res) => {
     req.session.role  = role;
   }
 
+  const structFlags = await db.query<{ has_station_manager: boolean; has_structures_scope: boolean }>(
+    `SELECT has_station_manager, has_structures_scope FROM users WHERE id = $1`,
+    [req.session.userId],
+  );
+
   res.json({
     user: {
       id:            req.session.userId,
@@ -307,6 +365,8 @@ authRouter.get('/me', async (req, res) => {
       uiSettings:    prefs.uiSettings ?? {},
       panelOrder:    prefs.panelOrder,
       canViewReports: config.reportsCharId !== null && req.session.characterId === config.reportsCharId,
+      hasStationManager:  structFlags.rows[0]?.has_station_manager ?? false,
+      hasStructuresScope: structFlags.rows[0]?.has_structures_scope ?? false,
     },
   });
 });

--- a/server/src/routes/corpStructures.ts
+++ b/server/src/routes/corpStructures.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express';
+import { db } from '../db.js';
+import { config } from '../config.js';
+
+const router = Router();
+
+function requireCorpMember(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) {
+  if (!req.session.userId || !req.session.userCorpId) {
+    res.status(401).json({ error: 'Not authenticated or not in a corp' });
+    return;
+  }
+  next();
+}
+
+router.use(requireCorpMember);
+
+router.get('/', async (req, res) => {
+  const corpId = req.session.userCorpId!;
+  const useShared = config.corpMapShared && config.corpIds.length > 1;
+
+  const { rows } = await db.query(
+    `SELECT cs.structure_id, cs.corporation_id, cs.system_id, cs.type_id,
+            cs.name, cs.state, cs.fuel_expires, cs.services,
+            cs.reinforce_hour, cs.state_timer_start, cs.state_timer_end,
+            cs.unanchors_at, cs.last_polled,
+            it.name AS type_name,
+            ss.name AS system_name
+     FROM corp_structures cs
+     LEFT JOIN item_types it ON it.eve_type_id = cs.type_id
+     LEFT JOIN solar_systems ss ON ss.eve_system_id = cs.system_id
+     WHERE cs.removed_at IS NULL
+       AND ${useShared ? 'cs.corporation_id = ANY($1)' : 'cs.corporation_id = $1'}
+     ORDER BY cs.fuel_expires ASC NULLS LAST`,
+    [useShared ? config.corpIds : corpId],
+  );
+
+  res.json(rows);
+});
+
+router.get('/by-system/:eveSystemId', async (req, res) => {
+  const corpId = req.session.userCorpId!;
+  const eveSystemId = parseInt(req.params.eveSystemId, 10);
+  if (!Number.isInteger(eveSystemId)) {
+    res.status(400).json({ error: 'Invalid system ID' });
+    return;
+  }
+
+  const useShared = config.corpMapShared && config.corpIds.length > 1;
+
+  const { rows } = await db.query(
+    `SELECT cs.structure_id, cs.corporation_id, cs.system_id, cs.type_id,
+            cs.name, cs.state, cs.fuel_expires, cs.services,
+            cs.reinforce_hour, cs.state_timer_start, cs.state_timer_end,
+            cs.unanchors_at, cs.last_polled,
+            it.name AS type_name
+     FROM corp_structures cs
+     LEFT JOIN item_types it ON it.eve_type_id = cs.type_id
+     WHERE cs.removed_at IS NULL
+       AND cs.system_id = $1
+       AND ${useShared ? 'cs.corporation_id = ANY($2)' : 'cs.corporation_id = $2'}`,
+    [eveSystemId, useShared ? config.corpIds : corpId],
+  );
+
+  res.json(rows);
+});
+
+export default router;

--- a/server/src/services/corpStructures.ts
+++ b/server/src/services/corpStructures.ts
@@ -1,0 +1,227 @@
+import { db } from '../db.js';
+import { config } from '../config.js';
+import { getValidToken } from '../utils/eveToken.js';
+import { createLogger } from '../utils/logger.js';
+import { notifyDiscord, fuelAlertEmbed } from './discord.js';
+
+const log = createLogger('corp-structures');
+const POLL_MS = 61 * 60 * 1000;
+
+const lastWorkingUser = new Map<number, number>();
+
+export async function initCorpStructures(): Promise<void> {
+  if (!config.corpMode) return;
+
+  try { await pollAllCorps(); }
+  catch (err) { log.error('boot poll failed:', err); }
+
+  setInterval(() => {
+    pollAllCorps().catch((err) => log.error('poll failed:', err));
+  }, POLL_MS);
+}
+
+async function pollAllCorps(): Promise<void> {
+  for (const corpId of config.corpIds) {
+    try {
+      await pollCorp(corpId);
+    } catch (err) {
+      log.error(`corp ${corpId} poll failed:`, err);
+    }
+  }
+}
+
+async function pollCorp(corpId: number): Promise<void> {
+  const token = await findWorkingToken(corpId);
+  if (!token) {
+    log.info(`corp ${corpId}: no working Station_Manager token — skipping`);
+    return;
+  }
+
+  const structures = await fetchAllPages(corpId, token);
+  if (structures === null) return;
+
+  await upsertStructures(structures);
+  await markRemoved(corpId, structures.map((s) => s.structure_id));
+  await checkFuelAlerts(corpId);
+
+  log.info(`corp ${corpId}: polled ${structures.length} structure(s)`);
+}
+
+interface ESIStructure {
+  structure_id: number;
+  corporation_id: number;
+  system_id: number;
+  type_id: number;
+  name?: string;
+  state: string;
+  fuel_expires?: string;
+  services?: { name: string; state: string }[];
+  reinforce_hour?: number;
+  state_timer_start?: string;
+  state_timer_end?: string;
+  unanchors_at?: string;
+}
+
+async function findWorkingToken(corpId: number): Promise<string | null> {
+  const cached = lastWorkingUser.get(corpId);
+  if (cached) {
+    const token = await tryUserToken(cached, corpId);
+    if (token) return token;
+    lastWorkingUser.delete(corpId);
+  }
+
+  const { rows } = await db.query<{ id: number }>(
+    `SELECT id FROM users WHERE corp_id = $1 AND has_structures_scope = TRUE AND role != 'blocked'`,
+    [corpId],
+  );
+
+  for (const row of rows) {
+    const token = await tryUserToken(row.id, corpId);
+    if (token) {
+      lastWorkingUser.set(corpId, row.id);
+      return token;
+    }
+  }
+
+  return null;
+}
+
+async function tryUserToken(userId: number, corpId: number): Promise<string | null> {
+  try {
+    const token = await getValidToken(userId);
+    const res = await fetch(
+      `https://esi.evetech.net/v4/corporations/${corpId}/structures/?datasource=tranquility&page=1`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (res.ok) return token;
+    if (res.status === 403) {
+      await db.query(`UPDATE users SET has_station_manager = FALSE WHERE id = $1`, [userId]);
+      log.info(`user ${userId}: lost Station_Manager — marked`);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAllPages(corpId: number, token: string): Promise<ESIStructure[] | null> {
+  const firstRes = await fetch(
+    `https://esi.evetech.net/v4/corporations/${corpId}/structures/?datasource=tranquility&page=1`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!firstRes.ok) {
+    log.warn(`corp ${corpId}: ESI returned ${firstRes.status}`);
+    return null;
+  }
+
+  const structures: ESIStructure[] = await firstRes.json() as ESIStructure[];
+  const totalPages = parseInt(firstRes.headers.get('x-pages') ?? '1', 10);
+
+  if (totalPages > 1) {
+    const pagePromises = [];
+    for (let page = 2; page <= totalPages; page++) {
+      pagePromises.push(
+        fetch(
+          `https://esi.evetech.net/v4/corporations/${corpId}/structures/?datasource=tranquility&page=${page}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        ).then((r) => r.ok ? r.json() as Promise<ESIStructure[]> : []),
+      );
+    }
+    const pages = await Promise.all(pagePromises);
+    for (const page of pages) structures.push(...page);
+  }
+
+  return structures;
+}
+
+async function upsertStructures(structures: ESIStructure[]): Promise<void> {
+  for (const s of structures) {
+    await db.query(
+      `INSERT INTO corp_structures
+         (structure_id, corporation_id, system_id, type_id, name, state,
+          fuel_expires, services, reinforce_hour,
+          state_timer_start, state_timer_end, unanchors_at, last_polled, removed_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,NOW(),NULL)
+       ON CONFLICT (structure_id) DO UPDATE SET
+         corporation_id    = EXCLUDED.corporation_id,
+         system_id         = EXCLUDED.system_id,
+         type_id           = EXCLUDED.type_id,
+         name              = EXCLUDED.name,
+         state             = EXCLUDED.state,
+         fuel_expires      = EXCLUDED.fuel_expires,
+         services          = EXCLUDED.services,
+         reinforce_hour    = EXCLUDED.reinforce_hour,
+         state_timer_start = EXCLUDED.state_timer_start,
+         state_timer_end   = EXCLUDED.state_timer_end,
+         unanchors_at      = EXCLUDED.unanchors_at,
+         last_polled       = NOW(),
+         removed_at        = NULL`,
+      [s.structure_id, s.corporation_id, s.system_id, s.type_id,
+       s.name ?? '', s.state,
+       s.fuel_expires ?? null, JSON.stringify(s.services ?? []),
+       s.reinforce_hour ?? null,
+       s.state_timer_start ?? null, s.state_timer_end ?? null,
+       s.unanchors_at ?? null],
+    );
+  }
+}
+
+async function markRemoved(corpId: number, activeIds: number[]): Promise<void> {
+  if (activeIds.length === 0) {
+    await db.query(
+      `UPDATE corp_structures SET removed_at = NOW() WHERE corporation_id = $1 AND removed_at IS NULL`,
+      [corpId],
+    );
+    return;
+  }
+  await db.query(
+    `UPDATE corp_structures SET removed_at = NOW()
+     WHERE corporation_id = $1 AND removed_at IS NULL
+       AND structure_id != ALL($2)`,
+    [corpId, activeIds],
+  );
+}
+
+async function checkFuelAlerts(corpId: number): Promise<void> {
+  const { rows } = await db.query<{
+    structure_id: number; name: string; system_id: number;
+    fuel_expires: string; type_id: number;
+  }>(
+    `SELECT cs.structure_id, cs.name, cs.system_id, cs.fuel_expires, cs.type_id
+     FROM corp_structures cs
+     WHERE cs.corporation_id = $1
+       AND cs.fuel_expires IS NOT NULL
+       AND cs.fuel_expires <= NOW() + make_interval(hours => $2)
+       AND cs.removed_at IS NULL
+       AND (cs.fuel_alert_sent_at IS NULL
+            OR cs.fuel_alert_sent_at < cs.fuel_expires - make_interval(hours => $2))`,
+    [corpId, config.fuelAlertHours],
+  );
+
+  for (const row of rows) {
+    const hoursLeft = Math.max(0, Math.round(
+      (new Date(row.fuel_expires).getTime() - Date.now()) / (1000 * 60 * 60),
+    ));
+
+    const systemName = await resolveSystemName(row.system_id);
+
+    notifyDiscord(corpId, fuelAlertEmbed({
+      structureName: row.name,
+      systemName,
+      hoursLeft,
+    }));
+
+    await db.query(
+      `UPDATE corp_structures SET fuel_alert_sent_at = NOW() WHERE structure_id = $1`,
+      [row.structure_id],
+    );
+  }
+}
+
+async function resolveSystemName(eveSystemId: number): Promise<string> {
+  const { rows } = await db.query<{ name: string }>(
+    `SELECT name FROM solar_systems WHERE eve_system_id = $1`,
+    [eveSystemId],
+  );
+  return rows[0]?.name ?? `System ${eveSystemId}`;
+}

--- a/server/src/services/discord.ts
+++ b/server/src/services/discord.ts
@@ -110,3 +110,16 @@ export function connectionEmbed(p: {
     timestamp:   new Date().toISOString(),
   };
 }
+
+const RED = 0xff4444;
+
+export function fuelAlertEmbed(p: {
+  structureName: string; systemName: string; hoursLeft: number;
+}): DiscordEmbed {
+  return {
+    title:       '⛽ Low Fuel',
+    description: `**${p.structureName}** in **${p.systemName}** has ~${p.hoursLeft}h of fuel remaining.`,
+    color:       p.hoursLeft <= 24 ? RED : AMBER,
+    timestamp:   new Date().toISOString(),
+  };
+}

--- a/server/src/session.d.ts
+++ b/server/src/session.d.ts
@@ -8,6 +8,7 @@ declare module 'express-session' {
     role: 'admin' | 'full' | 'edit' | 'readonly';
     userCorpId?: number | null;
     oauthState: string;
+    scopeGrant?: boolean;
     // Cached UI preferences — kept in sync by PATCH /auth/preferences so
     // /auth/me doesn't have to hit the DB on every page load.
     prefs: {

--- a/web/src/components/ui/FuelAlertChip.tsx
+++ b/web/src/components/ui/FuelAlertChip.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../api/client';
+import { useAuth } from '../../context/AuthContext';
+import { GasPumpIcon } from '@phosphor-icons/react';
+
+interface CorpStructure {
+  structure_id: number;
+  name: string;
+  system_name: string;
+  fuel_expires: string | null;
+}
+
+export function FuelAlertChip() {
+  const { user } = useAuth();
+  const [nearest, setNearest] = useState<{ name: string; systemName: string; hoursLeft: number } | null>(null);
+
+  useEffect(() => {
+    if (!user?.corpMode) return;
+
+    function poll() {
+      api<CorpStructure[]>('/api/corp-structures')
+        .then((structures) => {
+          let min: typeof nearest = null;
+          for (const s of structures) {
+            if (!s.fuel_expires) continue;
+            const hoursLeft = (new Date(s.fuel_expires).getTime() - Date.now()) / (1000 * 60 * 60);
+            if (hoursLeft > 0 && (!min || hoursLeft < min.hoursLeft)) {
+              min = { name: s.name, systemName: s.system_name, hoursLeft };
+            }
+          }
+          setNearest(min);
+        })
+        .catch(() => setNearest(null));
+    }
+
+    poll();
+    const interval = setInterval(poll, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [user?.corpMode]);
+
+  if (!nearest) return null;
+
+  const days = Math.floor(nearest.hoursLeft / 24);
+  const hours = Math.round(nearest.hoursLeft % 24);
+  const label = days > 0 ? `${days}d ${hours}h` : `${hours}h`;
+
+  const urgency =
+    nearest.hoursLeft <= 24 ? 'fuel-chip--critical' :
+    nearest.hoursLeft <= 72 ? 'fuel-chip--warning' :
+    'fuel-chip--caution';
+
+  return (
+    <span
+      className={`toolbar__chip fuel-chip ${urgency}`}
+      data-tooltip={`${nearest.name} in ${nearest.systemName} — ${label} fuel left`}
+    >
+      <GasPumpIcon size={14} weight="fill" />
+      <span className="fuel-chip__label">Fuel: {label}</span>
+    </span>
+  );
+}

--- a/web/src/components/ui/StructuresPane.tsx
+++ b/web/src/components/ui/StructuresPane.tsx
@@ -12,6 +12,38 @@ import { setDestination, addWaypoint } from '../../api/waypoint';
 import { toast } from './Toaster';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useStandings } from '../../hooks/useStandings';
+import { useAuth } from '../../context/AuthContext';
+
+interface ESICorpStructure {
+  structure_id: number;
+  corporation_id: number;
+  system_id: number;
+  type_id: number;
+  name: string;
+  state: string;
+  fuel_expires: string | null;
+  services: { name: string; state: string }[];
+  reinforce_hour: number | null;
+  state_timer_start: string | null;
+  state_timer_end: string | null;
+  unanchors_at: string | null;
+  last_polled: string;
+  type_name: string | null;
+}
+
+function fuelStatus(fuelExpires: string | null): { label: string; className: string } | null {
+  if (!fuelExpires) return null;
+  const hoursLeft = (new Date(fuelExpires).getTime() - Date.now()) / (1000 * 60 * 60);
+  if (hoursLeft <= 0) return { label: 'EMPTY', className: 'fuel--empty' };
+  if (hoursLeft < 24) return { label: `${Math.round(hoursLeft)}h`, className: 'fuel--critical' };
+  if (hoursLeft < 72) {
+    const d = Math.floor(hoursLeft / 24);
+    const h = Math.round(hoursLeft % 24);
+    return { label: `${d}d ${h}h`, className: 'fuel--warning' };
+  }
+  if (hoursLeft < 168) return { label: `${Math.round(hoursLeft / 24)}d`, className: 'fuel--caution' };
+  return { label: `${Math.round(hoursLeft / 24)}d`, className: 'fuel--ok' };
+}
 
 const STRUCTURE_TYPE_LABELS: Record<StructureType, string> = {
   unknown:   'Unknown',
@@ -69,7 +101,9 @@ export function StructuresPane({ systemId }: { systemId: string }) {
   const activeMapId = useMapStore((s) => s.activeMapId);
   const canEdit     = useCanEditContent();
   const standings   = useStandings();
+  const { user }    = useAuth();
   const [structures, setStructures] = useState<Structure[]>([]);
+  const [esiStructures, setEsiStructures] = useState<ESICorpStructure[]>([]);
   const [pendingAction, setPendingAction] = useState<{ message: string; fn: () => void } | null>(null);
   const [ctx, setCtx] = useState<{ x: number; y: number; structure: Structure } | null>(null);
 
@@ -109,6 +143,18 @@ export function StructuresPane({ systemId }: { systemId: string }) {
       .then(setStructures)
       .catch(() => {});
   }, [structRev, activeMapId, systemId, isShareMode]);
+
+  const eveSystemId = useMapStore((s) => {
+    const sys = s.map.systems.find((sys) => sys.id === systemId);
+    return sys?.eveSystemId ?? null;
+  });
+
+  useEffect(() => {
+    if (!eveSystemId || isShareMode || !user?.corpMode) return;
+    api<ESICorpStructure[]>(`/api/corp-structures/by-system/${eveSystemId}`)
+      .then(setEsiStructures)
+      .catch(() => setEsiStructures([]));
+  }, [eveSystemId, isShareMode, user?.corpMode]);
 
   useEffect(() => {
     const close = () => setCtx(null);
@@ -201,7 +247,15 @@ export function StructuresPane({ systemId }: { systemId: string }) {
         />
       )}
       <div className="sig-pane">
-        {!isShareMode && structures.length === 0 && (
+        {user?.corpMode && user.hasStationManager && !user.hasStructuresScope && (
+          <div className="structures-pane__grant-banner">
+            <span>Enable structure tracking for your corp</span>
+            <a href="/auth/grant-structures" className="structures-pane__grant-link">
+              Authorize with EVE Online
+            </a>
+          </div>
+        )}
+        {!isShareMode && structures.length === 0 && esiStructures.length === 0 && (
           <p className="sig-pane__hint">You can copy and paste structures directly from your Overview in EVE. In space, right-click anywhere in your Overview window and choose "Copy Selected Rows" (or select the lines and Ctrl+C). Paste here with Ctrl+V — the structure ID, name, and type are imported automatically.</p>
         )}
         {canEdit && !isShareMode && (
@@ -215,7 +269,7 @@ export function StructuresPane({ systemId }: { systemId: string }) {
           </div>
         )}
 
-        {structures.length === 0 ? (
+        {structures.length === 0 && esiStructures.length === 0 ? (
           <div className="sig-pane__empty">No structures recorded</div>
         ) : (
           <table className="sig-table">
@@ -335,6 +389,35 @@ export function StructuresPane({ systemId }: { systemId: string }) {
                 </tr>
                 );
               })}
+              {esiStructures
+                .filter((esi) => !structures.some((s) => s.eveId === esi.structure_id))
+                .map((esi) => {
+                  const fuel = fuelStatus(esi.fuel_expires);
+                  return (
+                    <tr key={`esi-${esi.structure_id}`} className="structures-pane__row--esi">
+                      <td>{esi.name}</td>
+                      <td>{esi.type_name ?? `Type ${esi.type_id}`}</td>
+                      <td>
+                        <span className={`structures-pane__state structures-pane__state--${esi.state}`}>
+                          {esi.state.replace(/_/g, ' ')}
+                        </span>
+                      </td>
+                      <td>
+                        {fuel && <span className={`structures-pane__fuel ${fuel.className}`}>{fuel.label}</span>}
+                      </td>
+                      <td>
+                        {(esi.services ?? []).map((svc) => (
+                          <span key={svc.name} className={`structures-pane__service structures-pane__service--${svc.state}`}>
+                            {svc.name}
+                          </span>
+                        ))}
+                      </td>
+                      {!isShareMode && (
+                        <td><span className="structures-pane__esi-tag">ESI</span></td>
+                      )}
+                    </tr>
+                  );
+                })}
             </tbody>
           </table>
         )}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -10,6 +10,7 @@ import { UserStatsModal } from './UserStatsModal';
 import { ConfirmModal } from './ConfirmModal';
 import { CreateMapModal } from './CreateMapModal';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
+import { FuelAlertChip } from './FuelAlertChip';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
@@ -329,6 +330,7 @@ export function Toolbar() {
       </div>
 
       <ProximityChip />
+      <FuelAlertChip />
 
       <div className="toolbar__spacer" />
 

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -18,6 +18,8 @@ export interface AuthUser {
   uiSettings: Record<string, unknown>;
   panelOrder: string[];
   canViewReports: boolean;
+  hasStationManager: boolean;
+  hasStructuresScope: boolean;
 }
 
 interface AuthContextValue {


### PR DESCRIPTION
## Summary

Adds live corp structure data from ESI into the existing structures card on the system panel. Structures owned by the corp auto-populate with fuel timers, state, services, and reinforcement info.

- **Optional ESI scope** — `esi-corporations.read_structures.v1` is granted separately via `/auth/grant-structures`, only prompted to users with the Station_Manager corp role
- **Server-side poller** — fetches structures hourly per corp, stores in `corp_structures` table, survives restarts
- **Fuel alerts** — toolbar chip shows lowest fuel timer across all corp structures; Discord webhook fires when fuel drops below configurable threshold (`FUEL_ALERT_HOURS`, default 72h)
- **System panel enrichment** — ESI structures appear alongside manually-pasted ones, with fuel countdown, state badge, and services list
- **No new pages/routes** — stays map-centric, no standalone dashboard