### PR TITLE
Admin Discord notification filters (regions + map exclusions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - **Storm tracking** — active null-sec storms (Electric / Gamma / Exotic / Plasma) from the community-maintained [EveScout Rescue stormtrack](https://evescoutrescue.com/home/stormtrack.php) feed surface as a colour-coded ⚡ icon on matching system nodes, with a tooltip showing last report and reporter. Refreshed every 30 minutes. (ESI doesn't expose stellar phenomena yet; this scrapes the public community feed and will swap to ESI when CCP ships one.)
 - **Proximity alerts** — incursions, pirate insurgencies, **and hostile-sov-holder systems** (any sov-holding system where you've set the corp or alliance to a negative standing) appear as a toolbar chip showing the closest threat in jumps. Configurable threshold with browser notification + audio ping when you cross into the zone.
 - **Inbound K162 alert** — when a signature's wormhole type is set to K162 anywhere on the map, a toast + browser notification + distinct audio ping fire immediately. K162 means "the other side opened this hole", so it's a strong intel signal that something just connected into your chain.
-- **Discord notifications** — push corp chain intel to a Discord channel so alerts land even when nobody's watching the tab. Fires server-side on an inbound K162 and on a new wormhole connection, scoped to corp maps and configured per corp via a webhook URL (`DISCORD_WEBHOOK_URL`). Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel. See [Discord notifications](#discord-notifications).
+- **Discord notifications** — push corp chain intel to a Discord channel so alerts land even when nobody's watching the tab. Fires server-side on an inbound K162 and on a new wormhole connection, scoped to corp maps and configured per corp via a webhook URL (`DISCORD_WEBHOOK_URL`). Admins can narrow which regions and maps notify from the **Discord** tab in the admin panel. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel. See [Discord notifications](#discord-notifications).
 - **Chain exit summary** — sidebar widget that counts every K-space exit currently on the map by security class (HS / LS / NS) as coloured chips, and pinpoints the nearest gate route to Jita ("Nearest Jita: 7j via Amarr") so loot runs and logistics planning don't need a manual route check.
 - **Route planner** — server-side BFS over stargates + your live chain, so a route through a wormhole hop is a single click.
 - **Location tracking** — opt-in live character location dot in the toolbar plus per-map "you are here" indicator.
@@ -117,7 +117,7 @@ Edit `.env` and fill in the required values:
 | `CORP_MAP_TIME` | Optional | Days an idle corp map can sit untouched before it's auto-archived. Default `30`. |
 | `MAX_USER_MAPS` | Optional | Max number of personal maps per user. Default `5`. |
 | `MAX_CORP_MAPS` | Optional | Max number of corp maps per corp. Default `5`. |
-| `DISCORD_WEBHOOK_URL` | Optional | Discord webhook(s) for corp-intel notifications (inbound K162, new connections). One URL fires for **every** corp map; for multi-corp deployments use `corpId=URL` pairs (comma-separated) to route each corp to its own channel — e.g. `98000001=https://discord.com/api/webhooks/…,98000002=https://discord.com/api/webhooks/…`. Personal maps never notify. Leave unset to disable. See [Discord notifications](#discord-notifications). |
+| `DISCORD_WEBHOOK_URL` | Optional | Discord webhook(s) for corp-intel notifications (inbound K162, new connections). One URL fires for **every** corp map; for multi-corp deployments use `corpId=URL` pairs (comma-separated) to route each corp to its own channel — e.g. `98000001=https://discord.com/api/webhooks/…,98000002=https://discord.com/api/webhooks/…`. Personal maps never notify. Leave unset to disable. Which regions/maps actually notify is then filtered per corp in the admin **Discord** tab. See [Discord notifications](#discord-notifications). |
 
 **EVE developer app scopes**
 
@@ -472,13 +472,21 @@ DISCORD_WEBHOOK_URL=98000001=https://discord.com/api/webhooks/1/a,98000002=https
 
 The webhook URL is a secret: it lives only in the server env, is never sent to the browser, and is masked in logs. Changing it takes effect on the next server restart. Leave it unset to disable notifications entirely.
 
+**Filtering (admin).** By default every corp map and region notifies. The **Discord** tab in the admin panel lets an admin narrow this per corp, without touching the webhook:
+
+- **Regions** — notify for all regions (default), or only a chosen allowlist. The wormhole's system region is checked at send time; for a new connection, either endpoint's region qualifies.
+- **Excluded maps** — every map notifies by default; tick maps to exclude them.
+
+These settings only ever *subtract* from the default, and new maps are always included automatically, so nothing silently goes dark.
+
 ### Admin operations
 
-Admins reach the dashboard from the **Admin** button in the toolbar, which lands them at `#/admin/users`. The page has four tabs:
+Admins reach the dashboard from the **Admin** button in the toolbar, which lands them at `#/admin/users`. The page has five tabs:
 
 - **Users** — role select, block / unblock, recheck corp via ESI.
 - **Maps** — every corp map across every listed corp. Force-lock, force-unlock, force-delete. Solo maps are deliberately excluded — they belong to individual users.
 - **Reports** — placeholder for future ops reports.
+- **Discord** — per-corp notification filters: a region allowlist and per-map exclusions (see [Discord notifications](#discord-notifications)).
 - **Audit log** — last 200 admin actions, newest first.
 
 Each tab is also reachable at its own hash route (`#/admin/maps`, `#/admin/audit`, …). All mutating actions write to the `admin_audit` table with the actor, target, old value, and new value.

--- a/discord_filters_feature.md
+++ b/discord_filters_feature.md
@@ -1,0 +1,164 @@
+# Discord Notification Filters (Admin) - Design
+
+## 1. Goal
+
+Let a corp control which Discord wormhole notifications it actually receives,
+from an admin-panel "Discord" tab, instead of getting a ping for every wormhole
+on every corp map. Two independent filters, both applied at send time:
+
+- **Region filter** (per corp): notify for all regions (default), or only a
+  chosen allowlist of regions.
+- **Map exclusions** (per map): every map notifies by default (auto opt-in);
+  admins pick maps to *exclude*.
+
+Builds directly on the existing Discord webhook feature
+([discord_webhooks_feature.md]) and its `dispatchK162` / `dispatchNewConnection`
+helpers in `server/src/routes/maps.ts`.
+
+## 2. Decisions (locked)
+
+- Webhook URL stays in **env** (`DISCORD_WEBHOOK_URL`); this feature does NOT
+  move it into the DB or UI.
+- Filter on **both** EVE region and per-map (both filters apply, AND'd).
+- Maps are **auto opt-in**; the per-map control is framed as "exclude" because
+  the default is on.
+- The region check is **generic** - it runs for *any* wormhole notification
+  (K162 today, anything later), resolved from the event's system region at send
+  time. Not K162-specific.
+
+## 3. Data model (migration in `server/src/migrate.ts`)
+
+Follows the existing `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` / `CREATE TABLE
+IF NOT EXISTS` idempotent pattern.
+
+```sql
+-- Per-map opt-out. DEFAULT TRUE means every existing and future map notifies
+-- unless explicitly excluded (fail-open - no map silently goes dark).
+ALTER TABLE maps ADD COLUMN IF NOT EXISTS discord_notify BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Per-corp region filter. No row => defaults (all_regions = true) => notify all.
+CREATE TABLE IF NOT EXISTS corp_discord_settings (
+  corp_id      INTEGER     PRIMARY KEY,
+  all_regions  BOOLEAN     NOT NULL DEFAULT TRUE,
+  regions      TEXT[]      NOT NULL DEFAULT '{}',   -- region NAMES (match map_systems.region_name)
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+Region **names** (not ids) are stored, because `map_systems` carries
+`region_name` (text) - so the filter is a direct `region_name = ANY(regions)`
+compare with no extra join. The admin UI gets `{id, name}` from
+`GET /api/regions` and sends the chosen names.
+
+## 4. The filter
+
+A single shared gate, run before every `notifyDiscord(...)` call:
+
+```
+notify  ==  mapNotEnabled? no
+            AND ( all_regions OR any(eventRegion) IN regions )
+```
+
+- **map gate:** `maps.discord_notify` is true.
+- **region gate:** corp `all_regions` true, OR at least one of the event's
+  system regions is in the allowlist.
+- **K162 / single-system events:** region set = `[system.region_name]`.
+- **New connection (two endpoints):** region set =
+  `[source.region_name, target.region_name]` - passes if *either* side is in an
+  allowed region (the wormhole "appears in" a watched region from one side).
+- **Unknown region** (`region_name` null, e.g. some manual/J-space systems):
+  matches nothing, so when an allowlist is active such events are suppressed;
+  with `all_regions` (default) they still notify. Documented behaviour.
+
+### Where it lives
+Fold the lookup into the queries the dispatch helpers already run (they join
+`maps` + `map_systems`), adding `m.discord_notify`, the system `region_name`(s),
+and a `LEFT JOIN corp_discord_settings cds ON cds.corp_id = <corp>`. Then a tiny
+pure helper decides:
+
+```ts
+function regionAllowed(allRegions: boolean, allow: string[], names: (string|null)[]): boolean {
+  if (allRegions) return true;
+  return names.some((n) => n != null && allow.includes(n));
+}
+// notify = mapEnabled && regionAllowed(...)
+```
+
+No new query round-trips; one extra join + column on the existing dispatch
+reads. (corp settings are tiny and rarely change - an optional in-memory TTL
+cache keyed by corpId can come later if needed.)
+
+## 5. Server API (`server/src/routes/admin.ts`)
+
+All under the existing admin gating. Reads on `adminReadRouter`
+(`requireAdminRead`), writes on `adminRouter` (`requireAdmin`). Scope to the
+admin's own corp via `req.session.userCorpId` (multi-corp safe).
+
+- `GET /api/admin/discord` -> `{ allRegions, regions: string[], maps: [{ id, name, excluded }] }`
+  - settings for the caller's corp (defaults if no row), plus that corp's maps
+    with their `excluded` (= `NOT discord_notify`) state.
+- `PUT /api/admin/discord` -> body `{ allRegions, regions }` -> upsert
+  `corp_discord_settings` (`ON CONFLICT (corp_id) DO UPDATE`). Validate `regions`
+  against known region names.
+- `PATCH /api/admin/maps/:mapId/discord` -> body `{ excluded: boolean }` ->
+  set `maps.discord_notify = NOT excluded` (verify the map belongs to the
+  caller's corp).
+- Region list for the picker reuses the existing `GET /api/regions`.
+
+Optionally record changes in the **audit log** (the app already has one) -
+"discord region filter changed", "map excluded/included" - for parity with other
+admin actions.
+
+## 6. Admin UI - new "Discord" tab (`web/src/components/ui/AdminPage.tsx`)
+
+- Add `'discord'` to the `Tab` type and `ALL_TABS`
+  (`{ key: 'discord', label: 'Discord', path: '/admin/discord' }`), gated to
+  `isAdmin` (like Maps/Audit), rendered as `<DiscordTab />`; add to `pathToTab`.
+- **DiscordTab** sections:
+  1. **Region filter** - a toggle: "Notify for all regions" vs "Only selected
+     regions". When "selected": a searchable multi-select (same data/UX as the
+     create-map region picker) showing chosen regions as removable chips. Save
+     -> `PUT /api/admin/discord`.
+  2. **Excluded maps** - the corp's maps listed with an "Exclude from Discord"
+     checkbox each (unchecked = notifying, the default). Toggling ->
+     `PATCH /api/admin/maps/:id/discord`. Copy makes clear maps notify by
+     default and this list is the exceptions.
+
+## 7. Defaults & migration safety
+
+- `discord_notify DEFAULT TRUE` + no `corp_discord_settings` row (=> `all_regions`
+  true) means **out of the box every map and region still notifies exactly as
+  today**. The filters only ever subtract once an admin configures them, and new
+  maps are always included automatically.
+
+## 8. Edge cases
+
+- **No settings row:** treat as `all_regions = true`, `regions = []`.
+- **Map deleted:** `discord_notify` goes with it (cascade). Excluding then
+  deleting is a no-op.
+- **Multi-corp:** everything is keyed by corp; an admin only sees/edits their
+  corp's settings and maps.
+- **Unknown/J-space region:** see section 4 - suppressed under an active
+  allowlist, notified under `all_regions`.
+- **Personal maps:** unchanged - they never notify (no `corp_id`); this feature
+  only concerns corp maps.
+
+## 9. Phased rollout
+
+1. Migration (`maps.discord_notify`, `corp_discord_settings`).
+2. Filter wiring in `dispatchK162` / `dispatchNewConnection` (+ the
+   `regionAllowed` helper) - reads the new column/table; defaults keep current
+   behaviour.
+3. Admin API (`GET`/`PUT /api/admin/discord`, `PATCH .../maps/:id/discord`).
+4. Admin "Discord" tab UI (region filter + excluded maps).
+5. (Optional) audit-log the changes; in-memory cache for corp settings.
+
+## 10. Notes / risks
+
+- Region filtering is most meaningful for k-space / region-map usage; for pure
+  J-space home chains region names are opaque, where the per-map exclude is the
+  more useful lever. Both are provided, so each corp uses whichever fits.
+- Single-instance assumption is irrelevant here (DB-backed config), unlike the
+  in-memory webhook queue.
+- Keep the webhook a deploy-level secret (env); this tab never shows or stores
+  it.

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -120,6 +120,21 @@ export async function migrate() {
     -- ignore it (owner / share recipients can always merge into them).
     ALTER TABLE maps ADD COLUMN IF NOT EXISTS allow_as_merge_destination BOOLEAN NOT NULL DEFAULT FALSE;
 
+    -- Per-map opt-out for Discord notifications. DEFAULT TRUE means every map —
+    -- existing and future — notifies unless an admin explicitly excludes it
+    -- (fail-open, so a new map never silently goes dark).
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS discord_notify BOOLEAN NOT NULL DEFAULT TRUE;
+
+    -- Per-corp Discord notification settings (region filter). No row => the
+    -- defaults below => notify for every region. The regions column holds
+    -- region NAMES, matched directly against map_systems.region_name.
+    CREATE TABLE IF NOT EXISTS corp_discord_settings (
+      corp_id     INTEGER     PRIMARY KEY,
+      all_regions BOOLEAN     NOT NULL DEFAULT TRUE,
+      regions     TEXT[]      NOT NULL DEFAULT '{}',
+      updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
     CREATE TABLE IF NOT EXISTS map_systems (
       id            UUID        PRIMARY KEY,
       map_id        UUID        NOT NULL REFERENCES maps(id) ON DELETE CASCADE,

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -449,6 +449,86 @@ adminRouter.delete('/maps/:id', async (req, res) => {
   res.json({ ok: true });
 });
 
+// ── Discord notification settings ─────────────────────────────────────────────
+// Per-corp region filter + per-map exclusions for the Discord webhook
+// notifications. Scoped to the admin's own corp (req.session.userCorpId). See
+// discord_filters_feature.md.
+
+// GET /api/admin/discord — current settings + this corp's maps with their
+// excluded state (excluded = NOT discord_notify).
+adminRouter.get('/discord', async (req, res) => {
+  const corpId = req.session.userCorpId ?? null;
+  if (corpId == null) {
+    res.json({ corpId: null, allRegions: true, regions: [], maps: [] });
+    return;
+  }
+  const [settings, maps] = await Promise.all([
+    db.query<{ allRegions: boolean; regions: string[] }>(
+      `SELECT all_regions AS "allRegions", regions FROM corp_discord_settings WHERE corp_id = $1`,
+      [corpId],
+    ),
+    db.query<{ id: string; name: string; excluded: boolean }>(
+      `SELECT id, name, NOT discord_notify AS excluded FROM maps WHERE corp_id = $1 ORDER BY name`,
+      [corpId],
+    ),
+  ]);
+  const row = settings.rows[0];
+  res.json({
+    corpId,
+    allRegions: row?.allRegions ?? true,
+    regions:    row?.regions ?? [],
+    maps:       maps.rows,
+  });
+});
+
+// PUT /api/admin/discord — set the region filter for the admin's corp.
+adminRouter.put('/discord', async (req, res) => {
+  const corpId = req.session.userCorpId ?? null;
+  if (corpId == null) { res.status(400).json({ error: 'No corp context' }); return; }
+
+  const body = req.body as { allRegions?: unknown; regions?: unknown };
+  const allRegions = body.allRegions !== false; // default true
+  let regions = Array.isArray(body.regions)
+    ? body.regions.filter((r): r is string => typeof r === 'string')
+    : [];
+
+  // Validate region names against the known region list (drop anything bogus).
+  if (regions.length) {
+    const { rows } = await db.query<{ name: string }>(
+      `SELECT name FROM map_regions WHERE name = ANY($1::text[])`, [regions],
+    );
+    const valid = new Set(rows.map((r) => r.name));
+    regions = [...new Set(regions.filter((r) => valid.has(r)))];
+  }
+
+  await db.query(
+    `INSERT INTO corp_discord_settings (corp_id, all_regions, regions, updated_at)
+     VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (corp_id) DO UPDATE
+       SET all_regions = EXCLUDED.all_regions, regions = EXCLUDED.regions, updated_at = NOW()`,
+    [corpId, allRegions, regions],
+  );
+  res.json({ ok: true, allRegions, regions });
+});
+
+// PATCH /api/admin/maps/:id/discord — exclude / re-include one of the corp's
+// maps from Discord notifications. Maps notify by default, so this manages the
+// exceptions. Scoped to the admin's corp.
+adminRouter.patch('/maps/:id/discord', async (req, res) => {
+  const mapId  = req.params.id;
+  const corpId = req.session.userCorpId ?? null;
+  if (!mapId)            { res.status(400).json({ error: 'invalid map id' }); return; }
+  if (corpId == null)    { res.status(400).json({ error: 'No corp context' }); return; }
+  const excluded = (req.body as { excluded?: unknown }).excluded === true;
+
+  const { rowCount } = await db.query(
+    `UPDATE maps SET discord_notify = $1, updated_at = NOW() WHERE id = $2 AND corp_id = $3`,
+    [!excluded, mapId, corpId],
+  );
+  if (!rowCount) { res.status(404).json({ error: 'Map not found' }); return; }
+  res.json({ ok: true, excluded });
+});
+
 // Maps a window query-param value to a Postgres interval string. NULL means
 // "no time bound" — used for the 'all' window. Keys are the only values the
 // frontend is allowed to send.

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -204,6 +204,15 @@ async function requireMapWrite(res: Response, mapId: string, req: Request): Prom
 // (a webhook failure must not affect the user's action). Hooked into the
 // interactive handlers — never the bulk seed/merge paths — so a region seed
 // can't flood the channel. See discord_webhooks_feature.md.
+//
+// Per-corp region + per-map filtering (see discord_filters_feature.md) is
+// applied at send time: a notification goes out only if the map isn't excluded
+// AND the corp accepts the event's region. `regionAllowed` is the region half —
+// pass on `all_regions`, or if any of the event's system regions is allowlisted.
+function regionAllowed(allRegions: boolean, allow: string[], names: (string | null)[]): boolean {
+  if (allRegions) return true;
+  return names.some((n) => n != null && allow.includes(n));
+}
 
 // K162 notifications are deferred briefly so a follow-up edit — most usefully
 // the wormhole's "leads to" — can be picked up and included. The send is keyed
@@ -248,19 +257,34 @@ function flushK162(sigId: string): void {
 // K162, including the leads-to if one was set in the meantime.
 async function fireK162(corpId: number | null, sigId: string, actor: string | null): Promise<void> {
   try {
-    const { rows } = await db.query<{ whType: string | null; leadsTo: string | null; system: string; systemClass: string; mapName: string }>(
+    const { rows } = await db.query<{
+      whType: string | null; leadsTo: string | null; system: string; systemClass: string;
+      region: string | null; mapName: string; mapEnabled: boolean; allRegions: boolean; regions: string[];
+    }>(
       `SELECT sg.wh_type AS "whType", sg.wh_leads_to AS "leadsTo",
-              s.name AS "system", s.system_class AS "systemClass", m.name AS "mapName"
+              s.name AS "system", s.system_class AS "systemClass", s.region_name AS "region",
+              m.name AS "mapName", m.discord_notify AS "mapEnabled",
+              COALESCE(cds.all_regions, TRUE)        AS "allRegions",
+              COALESCE(cds.regions, '{}'::text[])    AS "regions"
          FROM map_signatures sg
          JOIN map_systems s ON s.id = sg.system_id
          JOIN maps m ON m.id = s.map_id
+         LEFT JOIN corp_discord_settings cds ON cds.corp_id = $2
         WHERE sg.id = $1`,
-      [sigId],
+      [sigId, corpId],
     );
     const r = rows[0];
     if (!r) { discordLog.info(`K162 (sig ${sigId}) removed before send — skipping`); return; }
     if ((r.whType ?? '').toUpperCase() !== 'K162') {
       discordLog.info(`K162 (sig ${sigId}) changed to "${r.whType ?? ''}" before send — skipping`);
+      return;
+    }
+    if (!r.mapEnabled) {
+      discordLog.info(`K162 (sig ${sigId}) suppressed — map "${r.mapName}" is excluded from Discord`);
+      return;
+    }
+    if (!regionAllowed(r.allRegions, r.regions, [r.region])) {
+      discordLog.info(`K162 (sig ${sigId}) suppressed — region "${r.region ?? 'unknown'}" not in the corp filter`);
       return;
     }
     notifyDiscord(corpId, k162Embed({ system: r.system, systemClass: r.systemClass, leadsTo: r.leadsTo, mapName: r.mapName, actor }));
@@ -278,16 +302,31 @@ function dispatchNewConnection(
     return;
   }
   discordLog.info(`new connection on corp map (corpId=${meta.corpId}) — building notification`);
-  db.query<{ a: string; b: string; mapName: string }>(
-    `SELECT a.name AS a, b.name AS b, m.name AS "mapName"
+  db.query<{
+    a: string; b: string; regionA: string | null; regionB: string | null;
+    mapName: string; mapEnabled: boolean; allRegions: boolean; regions: string[];
+  }>(
+    `SELECT a.name AS a, b.name AS b, a.region_name AS "regionA", b.region_name AS "regionB",
+            m.name AS "mapName", m.discord_notify AS "mapEnabled",
+            COALESCE(cds.all_regions, TRUE)     AS "allRegions",
+            COALESCE(cds.regions, '{}'::text[]) AS "regions"
        FROM maps m
        JOIN map_systems a ON a.id = $2
        JOIN map_systems b ON b.id = $3
+       LEFT JOIN corp_discord_settings cds ON cds.corp_id = $4
       WHERE m.id = $1`,
-    [mapId, sourceId, targetId],
+    [mapId, sourceId, targetId, meta.corpId],
   ).then(({ rows }) => {
     const r = rows[0];
     if (!r) { discordLog.warn(`connection dispatch: endpoints not found`); return; }
+    if (!r.mapEnabled) {
+      discordLog.info(`new connection suppressed — map "${r.mapName}" is excluded from Discord`);
+      return;
+    }
+    if (!regionAllowed(r.allRegions, r.regions, [r.regionA, r.regionB])) {
+      discordLog.info(`new connection suppressed — neither region (${r.regionA ?? '?'} / ${r.regionB ?? '?'}) in the corp filter`);
+      return;
+    }
     notifyDiscord(meta.corpId, connectionEmbed({ a: r.a, b: r.b, whType, size, mapName: r.mapName, actor }));
   }).catch((e) => discordLog.warn(`connection dispatch query failed: ${(e as Error).message}`));
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6137,6 +6137,102 @@ select.sig-toolbar-btn option {
   padding: 24px 0;
 }
 
+/* ---- Admin Discord tab ---- */
+.discord-admin__hint {
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #8090a8;
+  max-width: 640px;
+  line-height: 1.5;
+  margin: 6px 0 18px;
+}
+.discord-admin__section {
+  margin: 0 0 28px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #1a2535;
+}
+.discord-admin__heading {
+  font-size: calc(15px * var(--font-scale, 1));
+  color: #c8d8f0;
+  margin: 0 0 10px;
+}
+.discord-admin__radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: calc(14px * var(--font-scale, 1));
+  color: #c8d2e6;
+  margin: 6px 0;
+  cursor: pointer;
+}
+.discord-admin__regions {
+  margin: 10px 0 4px;
+  padding-left: 24px;
+  max-width: 520px;
+  position: relative;
+}
+.discord-admin__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.discord-admin__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px 3px 10px;
+  background: rgba(91, 155, 255, 0.12);
+  color: #aecbff;
+  border-radius: 12px;
+  font-size: calc(13px * var(--font-scale, 1));
+}
+.discord-admin__chip button {
+  background: none;
+  border: none;
+  color: #aecbff;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.discord-admin__chip button:hover { color: #fff; }
+.discord-admin__search {
+  width: 100%;
+  box-sizing: border-box;
+}
+.discord-admin__results {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 4px;
+  background: #0e1626;
+  border: 1px solid #1e2740;
+  border-radius: 6px;
+  max-width: 520px;
+}
+.discord-admin__results li button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: #c8d2e6;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(13px * var(--font-scale, 1));
+}
+.discord-admin__results li button:hover { background: rgba(91, 155, 255, 0.12); }
+.discord-admin__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+}
+.discord-admin__saved {
+  color: #3ddc84;
+  font-size: calc(13px * var(--font-scale, 1));
+}
+
 .admin-page__error {
   font-size: calc(13px * var(--font-scale, 1));
   color: #e05a5a;

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -17,12 +17,13 @@ ChartJS.register(ArcElement, CategoryScale, LinearScale, PointElement, LineEleme
 type Role = 'admin' | 'full' | 'edit' | 'readonly';
 const ROLES: Role[] = ['admin', 'full', 'edit', 'readonly'];
 
-type Tab = 'users' | 'maps' | 'reports' | 'audit';
+type Tab = 'users' | 'maps' | 'reports' | 'audit' | 'discord';
 
 const ALL_TABS: { key: Tab; label: string; path: string }[] = [
   { key: 'users',   label: 'Users',     path: '/admin/users'   },
   { key: 'maps',    label: 'Maps',      path: '/admin/maps'    },
   { key: 'reports', label: 'Reports',   path: '/admin/reports' },
+  { key: 'discord', label: 'Discord',   path: '/admin/discord' },
   { key: 'audit',   label: 'Audit log', path: '/admin/audit'   },
 ];
 
@@ -63,6 +64,7 @@ export function AdminPage() {
         {tab === 'users'   && (isAdmin || canSeeReports) && <UsersTab />}
         {tab === 'maps'    && isAdmin       && <MapsTab />}
         {tab === 'reports' && (isAdmin || canSeeReports) && <ReportsTab />}
+        {tab === 'discord' && isAdmin       && <DiscordTab />}
         {tab === 'audit'   && isAdmin       && <AuditTab />}
       </main>
     </div>
@@ -73,6 +75,7 @@ function pathToTab(path: string, isAdmin: boolean, canSeeReports: boolean): Tab 
   const fallback: Tab = isAdmin || canSeeReports ? 'users' : 'reports';
   if (path.startsWith('/admin/maps'))    return isAdmin       ? 'maps'    : fallback;
   if (path.startsWith('/admin/reports')) return (isAdmin || canSeeReports) ? 'reports' : fallback;
+  if (path.startsWith('/admin/discord')) return isAdmin       ? 'discord' : fallback;
   if (path.startsWith('/admin/audit'))   return isAdmin       ? 'audit'   : fallback;
   return fallback;
 }
@@ -163,15 +166,19 @@ function UsersTab() {
   );
 
   const load = useCallback(async () => {
-    setError(null);
     try {
       const r = await api<{ users: AdminUser[] }>('/api/admin/users');
       setUsers(r.users);
+      setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load users');
     }
   }, []);
 
+  // load() is async and only setStates after its await (never synchronously),
+  // so this fetch-on-mount of a reusable loader is safe; the rule is a false
+  // positive here.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(); }, [load]);
 
   async function changeRole(u: AdminUser, role: Role) {
@@ -347,15 +354,19 @@ function MapsTab() {
   const [deleteTarget, setDeleteTarget] = useState<AdminMap | null>(null);
 
   const load = useCallback(async () => {
-    setError(null);
     try {
       const r = await api<{ maps: AdminMap[] }>('/api/admin/maps');
       setMaps(r.maps);
+      setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load maps');
     }
   }, []);
 
+  // load() is async and only setStates after its await (never synchronously),
+  // so this fetch-on-mount of a reusable loader is safe; the rule is a false
+  // positive here.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(); }, [load]);
 
   async function setLock(m: AdminMap, locked: boolean) {
@@ -633,16 +644,26 @@ function UsersReport() {
   const [filter, setFilter] = useState<UserFilterKey>('all');
   const [window, setWindow] = useState<WindowKey>('all');
 
-  useEffect(() => {
+  // Reset to the loading state during render when the query changes, so the
+  // fetch effect below performs no synchronous setState.
+  const reqKey = `${filter}|${window}`;
+  const [prevKey, setPrevKey] = useState(reqKey);
+  if (prevKey !== reqKey) {
+    setPrevKey(reqKey);
     setRows(null);
     setError(null);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
     const params = new URLSearchParams();
     if (filter !== 'all') params.set('filter', filter);
     if (window !== 'all') params.set('window', window);
     const qs = params.toString();
     api<{ users: UserReportRow[] }>(`/api/admin/reports/users${qs ? `?${qs}` : ''}`)
-      .then((r) => setRows(r.users))
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load users report'));
+      .then((r) => { if (!cancelled) setRows(r.users); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load users report'); });
+    return () => { cancelled = true; };
   }, [filter, window]);
 
   const sortedRows = useMemo(() => {
@@ -890,13 +911,22 @@ function SystemsReport() {
   const [whSort, setWhSort] = useState<{ key: WhSortKey; dir: SortDir }>({ key: 'count', dir: 'desc' });
   const [window, setWindow] = useState<WindowKey>('month');
 
-  useEffect(() => {
+  // Reset to the loading state during render when the window changes, so the
+  // fetch effect below performs no synchronous setState.
+  const [prevWindow, setPrevWindow] = useState(window);
+  if (prevWindow !== window) {
+    setPrevWindow(window);
     setData(null);
     setError(null);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
     const qs = window === 'all' ? '' : `?window=${window}`;
     api<SystemsReportData>(`/api/admin/reports/systems${qs}`)
-      .then(setData)
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load systems report'));
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load systems report'); });
+    return () => { cancelled = true; };
   }, [window]);
 
   const sortedWh = useMemo(() => {
@@ -1276,4 +1306,174 @@ function formatEuropeanDate(date: Date): string {
 function csvEscape(value: string): string {
   if (/[",\r\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
   return value;
+}
+
+// ── Discord tab ───────────────────────────────────────────────────────────────
+interface DiscordSettings {
+  corpId:     number | null;
+  allRegions: boolean;
+  regions:    string[];
+  maps:       { id: string; name: string; excluded: boolean }[];
+}
+interface RegionOption { id: number; name: string }
+
+function DiscordTab() {
+  const [data, setData]           = useState<DiscordSettings | null>(null);
+  const [regionOpts, setRegionOpts] = useState<RegionOption[]>([]);
+  const [error, setError]         = useState<string | null>(null);
+  const [saving, setSaving]       = useState(false);
+  const [saved, setSaved]         = useState(false);
+
+  // Editable copy of the region filter.
+  const [allRegions, setAllRegions] = useState(true);
+  const [regions, setRegions]       = useState<string[]>([]);
+  const [query, setQuery]           = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const [s, r] = await Promise.all([
+        api<DiscordSettings>('/api/admin/discord'),
+        api<{ regions: RegionOption[] }>('/api/regions'),
+      ]);
+      setData(s);
+      setAllRegions(s.allRegions);
+      setRegions(s.regions);
+      setRegionOpts(r.regions);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load Discord settings');
+    }
+  }, []);
+  // load() is async and only setStates after its await (never synchronously),
+  // so this fetch-on-mount of a reusable loader is safe; the rule is a false
+  // positive here.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { load(); }, [load]);
+
+  async function saveRegions() {
+    setSaving(true); setSaved(false);
+    try {
+      await api('/api/admin/discord', { method: 'PUT', body: JSON.stringify({ allRegions, regions }) });
+      setData((d) => (d ? { ...d, allRegions, regions } : d));
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleMap(id: string, excluded: boolean) {
+    setData((d) => (d ? { ...d, maps: d.maps.map((m) => (m.id === id ? { ...m, excluded } : m)) } : d));
+    try {
+      await api(`/api/admin/maps/${id}/discord`, { method: 'PATCH', body: JSON.stringify({ excluded }) });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Update failed');
+      load(); // reload to revert the optimistic toggle
+    }
+  }
+
+  const addRegion    = (name: string) => { if (!regions.includes(name)) setRegions([...regions, name]); setQuery(''); };
+  const removeRegion = (name: string) => setRegions(regions.filter((r) => r !== name));
+
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? regionOpts.filter((o) => o.name.toLowerCase().includes(q) && !regions.includes(o.name)).slice(0, 8)
+    : [];
+
+  if (!data && error) return (<><h2 className="admin-page__section-title">Discord</h2><div className="admin-page__error">{error}</div></>);
+  if (!data)          return (<><h2 className="admin-page__section-title">Discord</h2><div className="admin-page__loading">Loading…</div></>);
+  if (data.corpId == null) {
+    return (<><h2 className="admin-page__section-title">Discord</h2>
+      <div className="admin-page__empty">No corp context — Discord notifications apply to corp maps only.</div></>);
+  }
+
+  const dirty = allRegions !== data.allRegions || regions.slice().sort().join('|') !== data.regions.slice().sort().join('|');
+
+  return (
+    <>
+      <h2 className="admin-page__section-title">Discord notifications</h2>
+      {error && <div className="admin-page__error">{error}</div>}
+      <p className="discord-admin__hint">
+        Controls which wormhole notifications this corp&apos;s maps post to Discord. The webhook itself is set
+        server-side (DISCORD_WEBHOOK_URL). By default every map and region notifies — these settings only subtract.
+      </p>
+
+      <section className="discord-admin__section">
+        <h3 className="discord-admin__heading">Regions</h3>
+        <label className="discord-admin__radio">
+          <input type="radio" name="discord-regions" checked={allRegions} onChange={() => setAllRegions(true)} />
+          Notify for all regions
+        </label>
+        <label className="discord-admin__radio">
+          <input type="radio" name="discord-regions" checked={!allRegions} onChange={() => setAllRegions(false)} />
+          Only selected regions
+        </label>
+
+        {!allRegions && (
+          <div className="discord-admin__regions">
+            <div className="discord-admin__chips">
+              {regions.length === 0
+                ? <span className="admin-page__empty">No regions selected — nothing will notify until you add some.</span>
+                : regions.map((r) => (
+                    <span key={r} className="discord-admin__chip">
+                      {r}
+                      <button type="button" onClick={() => removeRegion(r)} aria-label={`Remove ${r}`}>×</button>
+                    </span>
+                  ))}
+            </div>
+            <input
+              type="text"
+              className="discord-admin__search"
+              placeholder="Type to search regions…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            {matches.length > 0 && (
+              <ul className="discord-admin__results">
+                {matches.map((o) => (
+                  <li key={o.id}><button type="button" onClick={() => addRegion(o.name)}>{o.name}</button></li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <div className="discord-admin__actions">
+          <button className="btn btn--primary" disabled={!dirty || saving} onClick={saveRegions}>
+            {saving ? 'Saving…' : 'Save regions'}
+          </button>
+          {saved && <span className="discord-admin__saved">Saved</span>}
+        </div>
+      </section>
+
+      <section className="discord-admin__section">
+        <h3 className="discord-admin__heading">Excluded maps</h3>
+        <p className="discord-admin__hint">All maps notify by default. Tick a map to exclude it from Discord.</p>
+        {data.maps.length === 0
+          ? <div className="admin-page__empty">No corp maps yet.</div>
+          : (
+            <table className="admin-modal__table">
+              <thead><tr><th>Map</th><th>Exclude</th></tr></thead>
+              <tbody>
+                {data.maps.map((m) => (
+                  <tr key={m.id}>
+                    <td>{m.name}</td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        className="sig-checkbox"
+                        checked={m.excluded}
+                        onChange={(e) => toggleMap(m.id, e.target.checked)}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+      </section>
+    </>
+  );
 }

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -181,7 +181,7 @@ const FEATURE_SECTIONS: FeatureSection[] = [
       {
         icon: BellRingingIcon,
         title: 'Discord notifications',
-        desc: 'Push corp chain intel to a Discord channel so alerts land even when nobody\'s watching the tab. Fires server-side on an inbound K162 or a new wormhole connection, scoped to corp maps and configured per corp via a webhook URL. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel.',
+        desc: 'Push corp chain intel to a Discord channel so alerts land even when nobody\'s watching the tab. Fires server-side on an inbound K162 or a new wormhole connection, scoped to corp maps. Admins filter which regions and maps notify from the admin panel. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel.',
       },
       {
         icon: NavigationArrowIcon,


### PR DESCRIPTION
A new admin **Discord** tab lets a corp control which wormhole notifications its maps post to Discord, instead of pinging for every region on every map.

- **Migration**: `maps.discord_notify` (DEFAULT TRUE — auto opt-in) and a per-corp `corp_discord_settings` table (all-regions flag + region-name allowlist).
- **Filter**: a shared `regionAllowed()` gate; `dispatchK162` / `dispatchNewConnection` pull the map flag + region(s) + corp settings in their existing query and suppress (with a log line) when a map is excluded or the region isn't allowed. New connections pass if either endpoint's region is allowed.
- **Admin API** (admin-gated, scoped to the caller's corp): `GET`/`PUT /api/admin/discord`, `PATCH /api/admin/maps/:id/discord`; region picker reuses `GET /api/regions`.
- **Admin UI**: region filter (all vs selected, searchable multi-select) + excluded-maps list. README + landing updated.

Defaults preserve today's notify-everything behaviour; filters only subtract once configured, and new maps are always included.

> Stacked on `feature/discord` (PR #30) — base will auto-retarget to `release` once that merges. Also makes `AdminPage.tsx` lint-clean.