### PR TITLE
Release: Discord notification controls and richer K162 alerts

### DIFF
--- a/.github/workflows/release-discord.yml
+++ b/.github/workflows/release-discord.yml
@@ -1,0 +1,101 @@
+name: Patch notes to Discord
+
+# When `release` is merged into `main` (a push to main), post the patch notes
+# to the Discord #patch-notes channel.
+#
+# Notes = titles of the PRs that merged into the `release` branch and arrived in
+# this push (base = release). Filtering on base = release naturally excludes the
+# release->main promotion PR itself, and any direct pushes to main.
+#
+# Requires repo secret DISCORD_WEBHOOK_URL = the patch-notes channel webhook.
+# (This is a GitHub Actions secret, independent of the app's runtime
+# DISCORD_WEBHOOK_URL env var — make sure it's the public patch-notes webhook.)
+#
+# VERSIONING (later): once tags/versions exist, replace the git-log note
+# generation below with the tag-based `gh api .../releases/generate-notes`
+# (which also honours .github/release.yml categorisation), and trigger on the
+# published release/tag instead of push.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  patch-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # full history so we can diff the pushed range
+
+      - name: Build and post patch notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WEBHOOK:  ${{ secrets.DISCORD_WEBHOOK_URL }}
+          BEFORE:   ${{ github.event.before }}
+          AFTER:    ${{ github.event.after }}
+          COMPARE:  ${{ github.event.compare }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::error::DISCORD_WEBHOOK_URL secret is not set"; exit 1
+          fi
+
+          # Range of commits introduced by this push. Guard the zero-SHA case
+          # (first push / force-push) by falling back to the latest commit.
+          ZERO="0000000000000000000000000000000000000000"
+          if [ "$BEFORE" = "$ZERO" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            RANGE="${AFTER}~1..${AFTER}"
+          else
+            RANGE="${BEFORE}..${AFTER}"
+          fi
+
+          # PR numbers referenced by merge commits in this push.
+          mapfile -t PRS < <(git log --merges --pretty=format:'%s' "$RANGE" \
+                               | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true)
+
+          # Keep only PRs whose base was `release` (the actual features); this
+          # drops the release->main promotion PR (base = main). PR titles come
+          # from the API and are JSON-encoded via jq below — never shell-eval'd.
+          NOTES=""
+          for pr in "${PRS[@]:-}"; do
+            [ -z "$pr" ] && continue
+            base=$(gh pr view "$pr" --json baseRefName -q .baseRefName 2>/dev/null || echo "")
+            if [ "$base" = "release" ]; then
+              title=$(gh pr view "$pr" --json title -q .title 2>/dev/null || echo "PR #$pr")
+              NOTES="${NOTES}- ${title} (#${pr})"$'\n'
+            fi
+          done
+
+          # Fallback: no qualifying PRs (e.g. a direct push) — use commit subjects.
+          if [ -z "$NOTES" ]; then
+            NOTES="$(git log --no-merges --pretty=format:'- %s' "$RANGE" | head -n 30 || true)"
+          fi
+          if [ -z "$NOTES" ]; then
+            echo "Nothing to announce for $RANGE"; exit 0
+          fi
+
+          # Discord embed descriptions cap at ~4096 chars.
+          if [ "${#NOTES}" -gt 3800 ]; then
+            NOTES="${NOTES:0:3800}"$'\n'"… and more — ${COMPARE}"
+          fi
+
+          DATE="$(date -u +%Y-%m-%d)"
+          payload=$(jq -n \
+            --arg title "◈ Nexum update — ${DATE}" \
+            --arg desc  "$NOTES" \
+            --arg url   "${COMPARE}" \
+            '{ embeds: [ {
+                 title: $title,
+                 url: $url,
+                 description: $desc,
+                 color: 6003711,
+                 footer: { text: "Nexum • eve-nexum.com" }
+            } ] }')
+
+          curl -fsSL -X POST -H "Content-Type: application/json" -d "$payload" "$WEBHOOK"
+          echo "Posted patch notes for $RANGE"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - **Storm tracking** — active null-sec storms (Electric / Gamma / Exotic / Plasma) from the community-maintained [EveScout Rescue stormtrack](https://evescoutrescue.com/home/stormtrack.php) feed surface as a colour-coded ⚡ icon on matching system nodes, with a tooltip showing last report and reporter. Refreshed every 30 minutes. (ESI doesn't expose stellar phenomena yet; this scrapes the public community feed and will swap to ESI when CCP ships one.)
 - **Proximity alerts** — incursions, pirate insurgencies, **and hostile-sov-holder systems** (any sov-holding system where you've set the corp or alliance to a negative standing) appear as a toolbar chip showing the closest threat in jumps. Configurable threshold with browser notification + audio ping when you cross into the zone.
 - **Inbound K162 alert** — when a signature's wormhole type is set to K162 anywhere on the map, a toast + browser notification + distinct audio ping fire immediately. K162 means "the other side opened this hole", so it's a strong intel signal that something just connected into your chain.
-- **Discord notifications** — push corp chain intel to a Discord channel so alerts land even when nobody's watching the tab. Fires server-side on an inbound K162 and on a new wormhole connection, scoped to corp maps and configured per corp via a webhook URL (`DISCORD_WEBHOOK_URL`). Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel. See [Discord notifications](#discord-notifications).
+- **Discord notifications** — push corp chain intel to a Discord channel so alerts land even when nobody's watching the tab. Fires server-side on an inbound K162 and on a new wormhole connection, scoped to corp maps and configured per corp via a webhook URL (`DISCORD_WEBHOOK_URL`). Admins can narrow which regions and maps notify from the **Discord** tab in the admin panel. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel. See [Discord notifications](#discord-notifications).
 - **Chain exit summary** — sidebar widget that counts every K-space exit currently on the map by security class (HS / LS / NS) as coloured chips, and pinpoints the nearest gate route to Jita ("Nearest Jita: 7j via Amarr") so loot runs and logistics planning don't need a manual route check.
 - **Route planner** — server-side BFS over stargates + your live chain, so a route through a wormhole hop is a single click.
 - **Location tracking** — opt-in live character location dot in the toolbar plus per-map "you are here" indicator.
@@ -117,7 +117,7 @@ Edit `.env` and fill in the required values:
 | `CORP_MAP_TIME` | Optional | Days an idle corp map can sit untouched before it's auto-archived. Default `30`. |
 | `MAX_USER_MAPS` | Optional | Max number of personal maps per user. Default `5`. |
 | `MAX_CORP_MAPS` | Optional | Max number of corp maps per corp. Default `5`. |
-| `DISCORD_WEBHOOK_URL` | Optional | Discord webhook(s) for corp-intel notifications (inbound K162, new connections). One URL fires for **every** corp map; for multi-corp deployments use `corpId=URL` pairs (comma-separated) to route each corp to its own channel — e.g. `98000001=https://discord.com/api/webhooks/…,98000002=https://discord.com/api/webhooks/…`. Personal maps never notify. Leave unset to disable. See [Discord notifications](#discord-notifications). |
+| `DISCORD_WEBHOOK_URL` | Optional | Discord webhook(s) for corp-intel notifications (inbound K162, new connections). One URL fires for **every** corp map; for multi-corp deployments use `corpId=URL` pairs (comma-separated) to route each corp to its own channel — e.g. `98000001=https://discord.com/api/webhooks/…,98000002=https://discord.com/api/webhooks/…`. Personal maps never notify. Leave unset to disable. Which regions/maps actually notify is then filtered per corp in the admin **Discord** tab. See [Discord notifications](#discord-notifications). |
 
 **EVE developer app scopes**
 
@@ -472,13 +472,21 @@ DISCORD_WEBHOOK_URL=98000001=https://discord.com/api/webhooks/1/a,98000002=https
 
 The webhook URL is a secret: it lives only in the server env, is never sent to the browser, and is masked in logs. Changing it takes effect on the next server restart. Leave it unset to disable notifications entirely.
 
+**Filtering (admin).** By default every corp map and region notifies. The **Discord** tab in the admin panel lets an admin narrow this per corp, without touching the webhook:
+
+- **Regions** — notify for all regions (default), or only a chosen allowlist. The wormhole's system region is checked at send time; for a new connection, either endpoint's region qualifies.
+- **Excluded maps** — every map notifies by default; tick maps to exclude them.
+
+These settings only ever *subtract* from the default, and new maps are always included automatically, so nothing silently goes dark.
+
 ### Admin operations
 
-Admins reach the dashboard from the **Admin** button in the toolbar, which lands them at `#/admin/users`. The page has four tabs:
+Admins reach the dashboard from the **Admin** button in the toolbar, which lands them at `#/admin/users`. The page has five tabs:
 
 - **Users** — role select, block / unblock, recheck corp via ESI.
 - **Maps** — every corp map across every listed corp. Force-lock, force-unlock, force-delete. Solo maps are deliberately excluded — they belong to individual users.
 - **Reports** — placeholder for future ops reports.
+- **Discord** — per-corp notification filters: a region allowlist and per-map exclusions (see [Discord notifications](#discord-notifications)).
 - **Audit log** — last 200 admin actions, newest first.
 
 Each tab is also reachable at its own hash route (`#/admin/maps`, `#/admin/audit`, …). All mutating actions write to the `admin_audit` table with the actor, target, old value, and new value.

--- a/discord_filters_feature.md
+++ b/discord_filters_feature.md
@@ -1,0 +1,164 @@
+# Discord Notification Filters (Admin) - Design
+
+## 1. Goal
+
+Let a corp control which Discord wormhole notifications it actually receives,
+from an admin-panel "Discord" tab, instead of getting a ping for every wormhole
+on every corp map. Two independent filters, both applied at send time:
+
+- **Region filter** (per corp): notify for all regions (default), or only a
+  chosen allowlist of regions.
+- **Map exclusions** (per map): every map notifies by default (auto opt-in);
+  admins pick maps to *exclude*.
+
+Builds directly on the existing Discord webhook feature
+([discord_webhooks_feature.md]) and its `dispatchK162` / `dispatchNewConnection`
+helpers in `server/src/routes/maps.ts`.
+
+## 2. Decisions (locked)
+
+- Webhook URL stays in **env** (`DISCORD_WEBHOOK_URL`); this feature does NOT
+  move it into the DB or UI.
+- Filter on **both** EVE region and per-map (both filters apply, AND'd).
+- Maps are **auto opt-in**; the per-map control is framed as "exclude" because
+  the default is on.
+- The region check is **generic** - it runs for *any* wormhole notification
+  (K162 today, anything later), resolved from the event's system region at send
+  time. Not K162-specific.
+
+## 3. Data model (migration in `server/src/migrate.ts`)
+
+Follows the existing `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` / `CREATE TABLE
+IF NOT EXISTS` idempotent pattern.
+
+```sql
+-- Per-map opt-out. DEFAULT TRUE means every existing and future map notifies
+-- unless explicitly excluded (fail-open - no map silently goes dark).
+ALTER TABLE maps ADD COLUMN IF NOT EXISTS discord_notify BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Per-corp region filter. No row => defaults (all_regions = true) => notify all.
+CREATE TABLE IF NOT EXISTS corp_discord_settings (
+  corp_id      INTEGER     PRIMARY KEY,
+  all_regions  BOOLEAN     NOT NULL DEFAULT TRUE,
+  regions      TEXT[]      NOT NULL DEFAULT '{}',   -- region NAMES (match map_systems.region_name)
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+Region **names** (not ids) are stored, because `map_systems` carries
+`region_name` (text) - so the filter is a direct `region_name = ANY(regions)`
+compare with no extra join. The admin UI gets `{id, name}` from
+`GET /api/regions` and sends the chosen names.
+
+## 4. The filter
+
+A single shared gate, run before every `notifyDiscord(...)` call:
+
+```
+notify  ==  mapNotEnabled? no
+            AND ( all_regions OR any(eventRegion) IN regions )
+```
+
+- **map gate:** `maps.discord_notify` is true.
+- **region gate:** corp `all_regions` true, OR at least one of the event's
+  system regions is in the allowlist.
+- **K162 / single-system events:** region set = `[system.region_name]`.
+- **New connection (two endpoints):** region set =
+  `[source.region_name, target.region_name]` - passes if *either* side is in an
+  allowed region (the wormhole "appears in" a watched region from one side).
+- **Unknown region** (`region_name` null, e.g. some manual/J-space systems):
+  matches nothing, so when an allowlist is active such events are suppressed;
+  with `all_regions` (default) they still notify. Documented behaviour.
+
+### Where it lives
+Fold the lookup into the queries the dispatch helpers already run (they join
+`maps` + `map_systems`), adding `m.discord_notify`, the system `region_name`(s),
+and a `LEFT JOIN corp_discord_settings cds ON cds.corp_id = <corp>`. Then a tiny
+pure helper decides:
+
+```ts
+function regionAllowed(allRegions: boolean, allow: string[], names: (string|null)[]): boolean {
+  if (allRegions) return true;
+  return names.some((n) => n != null && allow.includes(n));
+}
+// notify = mapEnabled && regionAllowed(...)
+```
+
+No new query round-trips; one extra join + column on the existing dispatch
+reads. (corp settings are tiny and rarely change - an optional in-memory TTL
+cache keyed by corpId can come later if needed.)
+
+## 5. Server API (`server/src/routes/admin.ts`)
+
+All under the existing admin gating. Reads on `adminReadRouter`
+(`requireAdminRead`), writes on `adminRouter` (`requireAdmin`). Scope to the
+admin's own corp via `req.session.userCorpId` (multi-corp safe).
+
+- `GET /api/admin/discord` -> `{ allRegions, regions: string[], maps: [{ id, name, excluded }] }`
+  - settings for the caller's corp (defaults if no row), plus that corp's maps
+    with their `excluded` (= `NOT discord_notify`) state.
+- `PUT /api/admin/discord` -> body `{ allRegions, regions }` -> upsert
+  `corp_discord_settings` (`ON CONFLICT (corp_id) DO UPDATE`). Validate `regions`
+  against known region names.
+- `PATCH /api/admin/maps/:mapId/discord` -> body `{ excluded: boolean }` ->
+  set `maps.discord_notify = NOT excluded` (verify the map belongs to the
+  caller's corp).
+- Region list for the picker reuses the existing `GET /api/regions`.
+
+Optionally record changes in the **audit log** (the app already has one) -
+"discord region filter changed", "map excluded/included" - for parity with other
+admin actions.
+
+## 6. Admin UI - new "Discord" tab (`web/src/components/ui/AdminPage.tsx`)
+
+- Add `'discord'` to the `Tab` type and `ALL_TABS`
+  (`{ key: 'discord', label: 'Discord', path: '/admin/discord' }`), gated to
+  `isAdmin` (like Maps/Audit), rendered as `<DiscordTab />`; add to `pathToTab`.
+- **DiscordTab** sections:
+  1. **Region filter** - a toggle: "Notify for all regions" vs "Only selected
+     regions". When "selected": a searchable multi-select (same data/UX as the
+     create-map region picker) showing chosen regions as removable chips. Save
+     -> `PUT /api/admin/discord`.
+  2. **Excluded maps** - the corp's maps listed with an "Exclude from Discord"
+     checkbox each (unchecked = notifying, the default). Toggling ->
+     `PATCH /api/admin/maps/:id/discord`. Copy makes clear maps notify by
+     default and this list is the exceptions.
+
+## 7. Defaults & migration safety
+
+- `discord_notify DEFAULT TRUE` + no `corp_discord_settings` row (=> `all_regions`
+  true) means **out of the box every map and region still notifies exactly as
+  today**. The filters only ever subtract once an admin configures them, and new
+  maps are always included automatically.
+
+## 8. Edge cases
+
+- **No settings row:** treat as `all_regions = true`, `regions = []`.
+- **Map deleted:** `discord_notify` goes with it (cascade). Excluding then
+  deleting is a no-op.
+- **Multi-corp:** everything is keyed by corp; an admin only sees/edits their
+  corp's settings and maps.
+- **Unknown/J-space region:** see section 4 - suppressed under an active
+  allowlist, notified under `all_regions`.
+- **Personal maps:** unchanged - they never notify (no `corp_id`); this feature
+  only concerns corp maps.
+
+## 9. Phased rollout
+
+1. Migration (`maps.discord_notify`, `corp_discord_settings`).
+2. Filter wiring in `dispatchK162` / `dispatchNewConnection` (+ the
+   `regionAllowed` helper) - reads the new column/table; defaults keep current
+   behaviour.
+3. Admin API (`GET`/`PUT /api/admin/discord`, `PATCH .../maps/:id/discord`).
+4. Admin "Discord" tab UI (region filter + excluded maps).
+5. (Optional) audit-log the changes; in-memory cache for corp settings.
+
+## 10. Notes / risks
+
+- Region filtering is most meaningful for k-space / region-map usage; for pure
+  J-space home chains region names are opaque, where the per-map exclude is the
+  more useful lever. Both are provided, so each corp uses whichever fits.
+- Single-instance assumption is irrelevant here (DB-backed config), unlike the
+  in-memory webhook queue.
+- Keep the webhook a deploy-level secret (env); this tab never shows or stores
+  it.

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -120,6 +120,21 @@ export async function migrate() {
     -- ignore it (owner / share recipients can always merge into them).
     ALTER TABLE maps ADD COLUMN IF NOT EXISTS allow_as_merge_destination BOOLEAN NOT NULL DEFAULT FALSE;
 
+    -- Per-map opt-out for Discord notifications. DEFAULT TRUE means every map —
+    -- existing and future — notifies unless an admin explicitly excludes it
+    -- (fail-open, so a new map never silently goes dark).
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS discord_notify BOOLEAN NOT NULL DEFAULT TRUE;
+
+    -- Per-corp Discord notification settings (region filter). No row => the
+    -- defaults below => notify for every region. The regions column holds
+    -- region NAMES, matched directly against map_systems.region_name.
+    CREATE TABLE IF NOT EXISTS corp_discord_settings (
+      corp_id     INTEGER     PRIMARY KEY,
+      all_regions BOOLEAN     NOT NULL DEFAULT TRUE,
+      regions     TEXT[]      NOT NULL DEFAULT '{}',
+      updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
     CREATE TABLE IF NOT EXISTS map_systems (
       id            UUID        PRIMARY KEY,
       map_id        UUID        NOT NULL REFERENCES maps(id) ON DELETE CASCADE,

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -449,6 +449,86 @@ adminRouter.delete('/maps/:id', async (req, res) => {
   res.json({ ok: true });
 });
 
+// ── Discord notification settings ─────────────────────────────────────────────
+// Per-corp region filter + per-map exclusions for the Discord webhook
+// notifications. Scoped to the admin's own corp (req.session.userCorpId). See
+// discord_filters_feature.md.
+
+// GET /api/admin/discord — current settings + this corp's maps with their
+// excluded state (excluded = NOT discord_notify).
+adminRouter.get('/discord', async (req, res) => {
+  const corpId = req.session.userCorpId ?? null;
+  if (corpId == null) {
+    res.json({ corpId: null, allRegions: true, regions: [], maps: [] });
+    return;
+  }
+  const [settings, maps] = await Promise.all([
+    db.query<{ allRegions: boolean; regions: string[] }>(
+      `SELECT all_regions AS "allRegions", regions FROM corp_discord_settings WHERE corp_id = $1`,
+      [corpId],
+    ),
+    db.query<{ id: string; name: string; excluded: boolean }>(
+      `SELECT id, name, NOT discord_notify AS excluded FROM maps WHERE corp_id = $1 ORDER BY name`,
+      [corpId],
+    ),
+  ]);
+  const row = settings.rows[0];
+  res.json({
+    corpId,
+    allRegions: row?.allRegions ?? true,
+    regions:    row?.regions ?? [],
+    maps:       maps.rows,
+  });
+});
+
+// PUT /api/admin/discord — set the region filter for the admin's corp.
+adminRouter.put('/discord', async (req, res) => {
+  const corpId = req.session.userCorpId ?? null;
+  if (corpId == null) { res.status(400).json({ error: 'No corp context' }); return; }
+
+  const body = req.body as { allRegions?: unknown; regions?: unknown };
+  const allRegions = body.allRegions !== false; // default true
+  let regions = Array.isArray(body.regions)
+    ? body.regions.filter((r): r is string => typeof r === 'string')
+    : [];
+
+  // Validate region names against the known region list (drop anything bogus).
+  if (regions.length) {
+    const { rows } = await db.query<{ name: string }>(
+      `SELECT name FROM map_regions WHERE name = ANY($1::text[])`, [regions],
+    );
+    const valid = new Set(rows.map((r) => r.name));
+    regions = [...new Set(regions.filter((r) => valid.has(r)))];
+  }
+
+  await db.query(
+    `INSERT INTO corp_discord_settings (corp_id, all_regions, regions, updated_at)
+     VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (corp_id) DO UPDATE
+       SET all_regions = EXCLUDED.all_regions, regions = EXCLUDED.regions, updated_at = NOW()`,
+    [corpId, allRegions, regions],
+  );
+  res.json({ ok: true, allRegions, regions });
+});
+
+// PATCH /api/admin/maps/:id/discord — exclude / re-include one of the corp's
+// maps from Discord notifications. Maps notify by default, so this manages the
+// exceptions. Scoped to the admin's corp.
+adminRouter.patch('/maps/:id/discord', async (req, res) => {
+  const mapId  = req.params.id;
+  const corpId = req.session.userCorpId ?? null;
+  if (!mapId)            { res.status(400).json({ error: 'invalid map id' }); return; }
+  if (corpId == null)    { res.status(400).json({ error: 'No corp context' }); return; }
+  const excluded = (req.body as { excluded?: unknown }).excluded === true;
+
+  const { rowCount } = await db.query(
+    `UPDATE maps SET discord_notify = $1, updated_at = NOW() WHERE id = $2 AND corp_id = $3`,
+    [!excluded, mapId, corpId],
+  );
+  if (!rowCount) { res.status(404).json({ error: 'Map not found' }); return; }
+  res.json({ ok: true, excluded });
+});
+
 // Maps a window query-param value to a Postgres interval string. NULL means
 // "no time bound" — used for the 'all' window. Keys are the only values the
 // frontend is allowed to send.

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -204,6 +204,15 @@ async function requireMapWrite(res: Response, mapId: string, req: Request): Prom
 // (a webhook failure must not affect the user's action). Hooked into the
 // interactive handlers — never the bulk seed/merge paths — so a region seed
 // can't flood the channel. See discord_webhooks_feature.md.
+//
+// Per-corp region + per-map filtering (see discord_filters_feature.md) is
+// applied at send time: a notification goes out only if the map isn't excluded
+// AND the corp accepts the event's region. `regionAllowed` is the region half —
+// pass on `all_regions`, or if any of the event's system regions is allowlisted.
+function regionAllowed(allRegions: boolean, allow: string[], names: (string | null)[]): boolean {
+  if (allRegions) return true;
+  return names.some((n) => n != null && allow.includes(n));
+}
 
 // K162 notifications are deferred briefly so a follow-up edit — most usefully
 // the wormhole's "leads to" — can be picked up and included. The send is keyed
@@ -248,19 +257,34 @@ function flushK162(sigId: string): void {
 // K162, including the leads-to if one was set in the meantime.
 async function fireK162(corpId: number | null, sigId: string, actor: string | null): Promise<void> {
   try {
-    const { rows } = await db.query<{ whType: string | null; leadsTo: string | null; system: string; systemClass: string; mapName: string }>(
+    const { rows } = await db.query<{
+      whType: string | null; leadsTo: string | null; system: string; systemClass: string;
+      region: string | null; mapName: string; mapEnabled: boolean; allRegions: boolean; regions: string[];
+    }>(
       `SELECT sg.wh_type AS "whType", sg.wh_leads_to AS "leadsTo",
-              s.name AS "system", s.system_class AS "systemClass", m.name AS "mapName"
+              s.name AS "system", s.system_class AS "systemClass", s.region_name AS "region",
+              m.name AS "mapName", m.discord_notify AS "mapEnabled",
+              COALESCE(cds.all_regions, TRUE)        AS "allRegions",
+              COALESCE(cds.regions, '{}'::text[])    AS "regions"
          FROM map_signatures sg
          JOIN map_systems s ON s.id = sg.system_id
          JOIN maps m ON m.id = s.map_id
+         LEFT JOIN corp_discord_settings cds ON cds.corp_id = $2
         WHERE sg.id = $1`,
-      [sigId],
+      [sigId, corpId],
     );
     const r = rows[0];
     if (!r) { discordLog.info(`K162 (sig ${sigId}) removed before send — skipping`); return; }
     if ((r.whType ?? '').toUpperCase() !== 'K162') {
       discordLog.info(`K162 (sig ${sigId}) changed to "${r.whType ?? ''}" before send — skipping`);
+      return;
+    }
+    if (!r.mapEnabled) {
+      discordLog.info(`K162 (sig ${sigId}) suppressed — map "${r.mapName}" is excluded from Discord`);
+      return;
+    }
+    if (!regionAllowed(r.allRegions, r.regions, [r.region])) {
+      discordLog.info(`K162 (sig ${sigId}) suppressed — region "${r.region ?? 'unknown'}" not in the corp filter`);
       return;
     }
     notifyDiscord(corpId, k162Embed({ system: r.system, systemClass: r.systemClass, leadsTo: r.leadsTo, mapName: r.mapName, actor }));
@@ -278,16 +302,31 @@ function dispatchNewConnection(
     return;
   }
   discordLog.info(`new connection on corp map (corpId=${meta.corpId}) — building notification`);
-  db.query<{ a: string; b: string; mapName: string }>(
-    `SELECT a.name AS a, b.name AS b, m.name AS "mapName"
+  db.query<{
+    a: string; b: string; regionA: string | null; regionB: string | null;
+    mapName: string; mapEnabled: boolean; allRegions: boolean; regions: string[];
+  }>(
+    `SELECT a.name AS a, b.name AS b, a.region_name AS "regionA", b.region_name AS "regionB",
+            m.name AS "mapName", m.discord_notify AS "mapEnabled",
+            COALESCE(cds.all_regions, TRUE)     AS "allRegions",
+            COALESCE(cds.regions, '{}'::text[]) AS "regions"
        FROM maps m
        JOIN map_systems a ON a.id = $2
        JOIN map_systems b ON b.id = $3
+       LEFT JOIN corp_discord_settings cds ON cds.corp_id = $4
       WHERE m.id = $1`,
-    [mapId, sourceId, targetId],
+    [mapId, sourceId, targetId, meta.corpId],
   ).then(({ rows }) => {
     const r = rows[0];
     if (!r) { discordLog.warn(`connection dispatch: endpoints not found`); return; }
+    if (!r.mapEnabled) {
+      discordLog.info(`new connection suppressed — map "${r.mapName}" is excluded from Discord`);
+      return;
+    }
+    if (!regionAllowed(r.allRegions, r.regions, [r.regionA, r.regionB])) {
+      discordLog.info(`new connection suppressed — neither region (${r.regionA ?? '?'} / ${r.regionB ?? '?'}) in the corp filter`);
+      return;
+    }
     notifyDiscord(meta.corpId, connectionEmbed({ a: r.a, b: r.b, whType, size, mapName: r.mapName, actor }));
   }).catch((e) => discordLog.warn(`connection dispatch query failed: ${(e as Error).message}`));
 }

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -13,6 +13,7 @@ import { reportPresence, removePresence, presenceSnapshot } from '../services/pr
 import { notifyDiscord, webhookFor, k162Embed, connectionEmbed } from '../services/discord.js';
 
 const log = createLogger('maps');
+const discordLog = createLogger('discord');
 
 // EVE system name → numeric ID lookup against the SDE-seeded solar_systems
 // table. Used to backfill eve_system_id at write time when the client posts
@@ -204,24 +205,79 @@ async function requireMapWrite(res: Response, mapId: string, req: Request): Prom
 // interactive handlers — never the bulk seed/merge paths — so a region seed
 // can't flood the channel. See discord_webhooks_feature.md.
 
-function dispatchK162(meta: MapMeta, systemId: string, actor: string | null): void {
-  if (!webhookFor(meta.corpId)) return; // off, or personal map (corpId === null)
-  db.query<{ name: string; systemClass: string; mapName: string }>(
-    `SELECT s.name, s.system_class AS "systemClass", m.name AS "mapName"
-       FROM map_systems s JOIN maps m ON m.id = s.map_id
-      WHERE s.id = $1`,
-    [systemId],
-  ).then(({ rows }) => {
+// K162 notifications are deferred briefly so a follow-up edit — most usefully
+// the wormhole's "leads to" — can be picked up and included. The send is keyed
+// by signature id; at fire time we re-read the signature and send whatever it
+// is *then* (skipping it if it's no longer a K162). A fixed cap means we never
+// wait longer than this, and a second detection for an already-pending sig is
+// ignored so the original deadline stands.
+const K162_DEFER_MS = 10_000;
+interface PendingK162 { timer: ReturnType<typeof setTimeout>; corpId: number | null; actor: string | null; }
+const pendingK162 = new Map<string, PendingK162>();
+
+function dispatchK162(meta: MapMeta, sigId: string, systemId: string, actor: string | null): void {
+  if (!webhookFor(meta.corpId)) {
+    discordLog.info(`K162 detected (system ${systemId}) but not sending — no webhook for corpId=${meta.corpId ?? 'null (personal map; webhooks are corp-maps only)'}`);
+    return;
+  }
+  if (pendingK162.has(sigId)) {
+    discordLog.info(`K162 (sig ${sigId}) already pending — keeping the existing ${K162_DEFER_MS / 1000}s window`);
+    return;
+  }
+  discordLog.info(`K162 on corp map (corpId=${meta.corpId}, sig ${sigId}) — deferring ${K162_DEFER_MS / 1000}s to catch a leads-to`);
+  const timer = setTimeout(() => {
+    pendingK162.delete(sigId);
+    void fireK162(meta.corpId, sigId, actor);
+  }, K162_DEFER_MS);
+  pendingK162.set(sigId, { timer, corpId: meta.corpId, actor });
+}
+
+// Send a pending K162 immediately — e.g. once its leads-to has been filled in —
+// instead of waiting out the rest of the defer window. No-op if nothing is
+// pending for this signature. Fires with the original detection's context.
+function flushK162(sigId: string): void {
+  const p = pendingK162.get(sigId);
+  if (!p) return;
+  clearTimeout(p.timer);
+  pendingK162.delete(sigId);
+  discordLog.info(`K162 (sig ${sigId}) leads-to set — sending now instead of waiting`);
+  void fireK162(p.corpId, sigId, p.actor);
+}
+
+// Re-read the signature now (after the defer window) and send if it's still a
+// K162, including the leads-to if one was set in the meantime.
+async function fireK162(corpId: number | null, sigId: string, actor: string | null): Promise<void> {
+  try {
+    const { rows } = await db.query<{ whType: string | null; leadsTo: string | null; system: string; systemClass: string; mapName: string }>(
+      `SELECT sg.wh_type AS "whType", sg.wh_leads_to AS "leadsTo",
+              s.name AS "system", s.system_class AS "systemClass", m.name AS "mapName"
+         FROM map_signatures sg
+         JOIN map_systems s ON s.id = sg.system_id
+         JOIN maps m ON m.id = s.map_id
+        WHERE sg.id = $1`,
+      [sigId],
+    );
     const r = rows[0];
-    if (r) notifyDiscord(meta.corpId, k162Embed({ system: r.name, systemClass: r.systemClass, mapName: r.mapName, actor }));
-  }).catch(() => { /* best-effort */ });
+    if (!r) { discordLog.info(`K162 (sig ${sigId}) removed before send — skipping`); return; }
+    if ((r.whType ?? '').toUpperCase() !== 'K162') {
+      discordLog.info(`K162 (sig ${sigId}) changed to "${r.whType ?? ''}" before send — skipping`);
+      return;
+    }
+    notifyDiscord(corpId, k162Embed({ system: r.system, systemClass: r.systemClass, leadsTo: r.leadsTo, mapName: r.mapName, actor }));
+  } catch (e) {
+    discordLog.warn(`K162 deferred dispatch failed: ${(e as Error).message}`);
+  }
 }
 
 function dispatchNewConnection(
   meta: MapMeta, mapId: string, sourceId: string, targetId: string,
   whType: string | null, size: string | null, actor: string | null,
 ): void {
-  if (!webhookFor(meta.corpId)) return;
+  if (!webhookFor(meta.corpId)) {
+    discordLog.info(`new connection but not sending — no webhook for corpId=${meta.corpId ?? 'null (personal map; webhooks are corp-maps only)'}`);
+    return;
+  }
+  discordLog.info(`new connection on corp map (corpId=${meta.corpId}) — building notification`);
   db.query<{ a: string; b: string; mapName: string }>(
     `SELECT a.name AS a, b.name AS b, m.name AS "mapName"
        FROM maps m
@@ -231,8 +287,9 @@ function dispatchNewConnection(
     [mapId, sourceId, targetId],
   ).then(({ rows }) => {
     const r = rows[0];
-    if (r) notifyDiscord(meta.corpId, connectionEmbed({ a: r.a, b: r.b, whType, size, mapName: r.mapName, actor }));
-  }).catch(() => { /* best-effort */ });
+    if (!r) { discordLog.warn(`connection dispatch: endpoints not found`); return; }
+    notifyDiscord(meta.corpId, connectionEmbed({ a: r.a, b: r.b, whType, size, mapName: r.mapName, actor }));
+  }).catch((e) => discordLog.warn(`connection dispatch query failed: ${(e as Error).message}`));
 }
 
 // Confirms a system UUID actually belongs to the supplied map; prevents
@@ -1612,7 +1669,8 @@ mapsRouter.post('/:mapId/systems/:systemId/signatures', async (req, res) => {
   db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
   recordGhostSiteIfMatch(systemId, name);
   publishToMap(mapId, { type: 'sig.changed', actor: req.get('x-client-id') ?? null, systemId });
-  if ((whType ?? '').toUpperCase() === 'K162') dispatchK162(access, systemId, req.session.characterName ?? null);
+  if (whType) discordLog.info(`sig POST on system ${systemId}: whType="${whType}"`);
+  if ((whType ?? '').toUpperCase() === 'K162') dispatchK162(access, rows[0].id, systemId, req.session.characterName ?? null);
   res.status(201).json(rows[0]);
 });
 
@@ -1634,6 +1692,9 @@ mapsRouter.patch('/:mapId/systems/:systemId/signatures/:sigId', async (req, res)
       `SELECT wh_type FROM map_signatures WHERE id = $1 AND system_id = $2`, [sigId, systemId]);
     prevWasK162 = (prev[0]?.wh_type ?? '').toUpperCase() === 'K162';
   }
+  if (typeof updates.whType === 'string') {
+    discordLog.info(`sig PATCH on system ${systemId}: whType="${updates.whType}" (settingK162=${settingK162}, prevWasK162=${prevWasK162})`);
+  }
 
   const sets: string[] = ['updated_at = NOW()'];
   const vals: unknown[] = [];
@@ -1649,7 +1710,10 @@ mapsRouter.patch('/:mapId/systems/:systemId/signatures/:sigId', async (req, res)
   db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
   if (typeof updates.name === 'string') recordGhostSiteIfMatch(systemId, updates.name);
   publishToMap(mapId, { type: 'sig.changed', actor: req.get('x-client-id') ?? null, systemId });
-  if (settingK162 && !prevWasK162) dispatchK162(access, systemId, req.session.characterName ?? null);
+  if (settingK162 && !prevWasK162) dispatchK162(access, sigId, systemId, req.session.characterName ?? null);
+  // If the leads-to was just filled in, send any pending K162 now rather than
+  // waiting out the rest of the window — the intel we were waiting for is here.
+  if (typeof updates.whLeadsTo === 'string' && updates.whLeadsTo.trim()) flushK162(sigId);
   res.json({ ok: true });
 });
 

--- a/server/src/services/discord.ts
+++ b/server/src/services/discord.ts
@@ -6,6 +6,16 @@ import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('discord');
 
+// Log the configuration once at startup so a misconfigured DISCORD_WEBHOOK_URL
+// is obvious in the logs. URLs are secrets, so we log presence, not values.
+{
+  const corps = Object.keys(config.discord.byCorp);
+  const enabled = !!config.discord.defaultUrl || corps.length > 0;
+  log.info(enabled
+    ? `enabled — default webhook: ${config.discord.defaultUrl ? 'set' : 'none'}; per-corp overrides: [${corps.join(', ') || 'none'}]`
+    : 'disabled — DISCORD_WEBHOOK_URL is not set (no notifications will be sent)');
+}
+
 // Resolve the webhook for a map's corp: per-corp override, else the default,
 // else null (feature off, or a personal map with corpId === null).
 export function webhookFor(corpId: number | null): string | null {
@@ -32,12 +42,16 @@ let draining = false;
 // Enqueue a notification. No-op when no webhook is configured for the corp.
 export function notifyDiscord(corpId: number | null, embed: DiscordEmbed): void {
   const url = webhookFor(corpId);
-  if (!url) return;
+  if (!url) {
+    log.info(`skip "${embed.title}" — no webhook resolved for corpId=${corpId ?? 'null (personal map)'}`);
+    return;
+  }
   if (queue.length >= MAX_QUEUE) {
-    log.warn(`queue full (${MAX_QUEUE}) — dropping a notification`);
+    log.warn(`queue full (${MAX_QUEUE}) — dropping "${embed.title}"`);
     return;
   }
   queue.push({ url, embed });
+  log.info(`queued "${embed.title}" for corpId=${corpId} (queue depth: ${queue.length})`);
   void drain();
 }
 
@@ -69,7 +83,12 @@ async function deliver(item: QueueItem, attempt = 0): Promise<void> {
       await sleep(waitMs);
       return deliver(item, attempt + 1);
     }
-    if (!r.ok) log.warn(`webhook POST failed: ${r.status}`);
+    if (!r.ok) {
+      const body = await r.text().catch(() => '');
+      log.warn(`webhook POST failed: ${r.status} ${body.slice(0, 200)}`);
+      return;
+    }
+    log.info(`delivered "${item.embed.title}" (${r.status})`);
   } catch (err) {
     // Timeout / network / Discord down — drop it. Intel is ephemeral; never
     // let a webhook failure bubble into the request path.
@@ -84,12 +103,15 @@ const AMBER = 0xf0a030;
 const BLUE  = 0x5b9bff;
 
 export function k162Embed(p: {
-  system: string; systemClass: string; mapName: string; actor: string | null;
+  system: string; systemClass: string; leadsTo?: string | null; mapName: string; actor: string | null;
 }): DiscordEmbed {
+  const fields: NonNullable<DiscordEmbed['fields']> = [];
+  if (p.leadsTo) fields.push({ name: 'Leads to', value: p.leadsTo, inline: true });
   return {
     title:       '⚠️ Inbound K162',
     description: `New **K162** in **${p.system}** (${p.systemClass}) — something just connected into **${p.mapName}**.`,
     color:       AMBER,
+    fields:      fields.length ? fields : undefined,
     footer:      p.actor ? { text: `set by ${p.actor}` } : undefined,
     timestamp:   new Date().toISOString(),
   };

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6137,6 +6137,102 @@ select.sig-toolbar-btn option {
   padding: 24px 0;
 }
 
+/* ---- Admin Discord tab ---- */
+.discord-admin__hint {
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #8090a8;
+  max-width: 640px;
+  line-height: 1.5;
+  margin: 6px 0 18px;
+}
+.discord-admin__section {
+  margin: 0 0 28px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #1a2535;
+}
+.discord-admin__heading {
+  font-size: calc(15px * var(--font-scale, 1));
+  color: #c8d8f0;
+  margin: 0 0 10px;
+}
+.discord-admin__radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: calc(14px * var(--font-scale, 1));
+  color: #c8d2e6;
+  margin: 6px 0;
+  cursor: pointer;
+}
+.discord-admin__regions {
+  margin: 10px 0 4px;
+  padding-left: 24px;
+  max-width: 520px;
+  position: relative;
+}
+.discord-admin__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.discord-admin__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px 3px 10px;
+  background: rgba(91, 155, 255, 0.12);
+  color: #aecbff;
+  border-radius: 12px;
+  font-size: calc(13px * var(--font-scale, 1));
+}
+.discord-admin__chip button {
+  background: none;
+  border: none;
+  color: #aecbff;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.discord-admin__chip button:hover { color: #fff; }
+.discord-admin__search {
+  width: 100%;
+  box-sizing: border-box;
+}
+.discord-admin__results {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 4px;
+  background: #0e1626;
+  border: 1px solid #1e2740;
+  border-radius: 6px;
+  max-width: 520px;
+}
+.discord-admin__results li button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: #c8d2e6;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(13px * var(--font-scale, 1));
+}
+.discord-admin__results li button:hover { background: rgba(91, 155, 255, 0.12); }
+.discord-admin__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+}
+.discord-admin__saved {
+  color: #3ddc84;
+  font-size: calc(13px * var(--font-scale, 1));
+}
+
 .admin-page__error {
   font-size: calc(13px * var(--font-scale, 1));
   color: #e05a5a;

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -17,12 +17,13 @@ ChartJS.register(ArcElement, CategoryScale, LinearScale, PointElement, LineEleme
 type Role = 'admin' | 'full' | 'edit' | 'readonly';
 const ROLES: Role[] = ['admin', 'full', 'edit', 'readonly'];
 
-type Tab = 'users' | 'maps' | 'reports' | 'audit';
+type Tab = 'users' | 'maps' | 'reports' | 'audit' | 'discord';
 
 const ALL_TABS: { key: Tab; label: string; path: string }[] = [
   { key: 'users',   label: 'Users',     path: '/admin/users'   },
   { key: 'maps',    label: 'Maps',      path: '/admin/maps'    },
   { key: 'reports', label: 'Reports',   path: '/admin/reports' },
+  { key: 'discord', label: 'Discord',   path: '/admin/discord' },
   { key: 'audit',   label: 'Audit log', path: '/admin/audit'   },
 ];
 
@@ -63,6 +64,7 @@ export function AdminPage() {
         {tab === 'users'   && (isAdmin || canSeeReports) && <UsersTab />}
         {tab === 'maps'    && isAdmin       && <MapsTab />}
         {tab === 'reports' && (isAdmin || canSeeReports) && <ReportsTab />}
+        {tab === 'discord' && isAdmin       && <DiscordTab />}
         {tab === 'audit'   && isAdmin       && <AuditTab />}
       </main>
     </div>
@@ -73,6 +75,7 @@ function pathToTab(path: string, isAdmin: boolean, canSeeReports: boolean): Tab 
   const fallback: Tab = isAdmin || canSeeReports ? 'users' : 'reports';
   if (path.startsWith('/admin/maps'))    return isAdmin       ? 'maps'    : fallback;
   if (path.startsWith('/admin/reports')) return (isAdmin || canSeeReports) ? 'reports' : fallback;
+  if (path.startsWith('/admin/discord')) return isAdmin       ? 'discord' : fallback;
   if (path.startsWith('/admin/audit'))   return isAdmin       ? 'audit'   : fallback;
   return fallback;
 }
@@ -163,15 +166,19 @@ function UsersTab() {
   );
 
   const load = useCallback(async () => {
-    setError(null);
     try {
       const r = await api<{ users: AdminUser[] }>('/api/admin/users');
       setUsers(r.users);
+      setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load users');
     }
   }, []);
 
+  // load() is async and only setStates after its await (never synchronously),
+  // so this fetch-on-mount of a reusable loader is safe; the rule is a false
+  // positive here.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(); }, [load]);
 
   async function changeRole(u: AdminUser, role: Role) {
@@ -347,15 +354,19 @@ function MapsTab() {
   const [deleteTarget, setDeleteTarget] = useState<AdminMap | null>(null);
 
   const load = useCallback(async () => {
-    setError(null);
     try {
       const r = await api<{ maps: AdminMap[] }>('/api/admin/maps');
       setMaps(r.maps);
+      setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load maps');
     }
   }, []);
 
+  // load() is async and only setStates after its await (never synchronously),
+  // so this fetch-on-mount of a reusable loader is safe; the rule is a false
+  // positive here.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(); }, [load]);
 
   async function setLock(m: AdminMap, locked: boolean) {
@@ -633,16 +644,26 @@ function UsersReport() {
   const [filter, setFilter] = useState<UserFilterKey>('all');
   const [window, setWindow] = useState<WindowKey>('all');
 
-  useEffect(() => {
+  // Reset to the loading state during render when the query changes, so the
+  // fetch effect below performs no synchronous setState.
+  const reqKey = `${filter}|${window}`;
+  const [prevKey, setPrevKey] = useState(reqKey);
+  if (prevKey !== reqKey) {
+    setPrevKey(reqKey);
     setRows(null);
     setError(null);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
     const params = new URLSearchParams();
     if (filter !== 'all') params.set('filter', filter);
     if (window !== 'all') params.set('window', window);
     const qs = params.toString();
     api<{ users: UserReportRow[] }>(`/api/admin/reports/users${qs ? `?${qs}` : ''}`)
-      .then((r) => setRows(r.users))
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load users report'));
+      .then((r) => { if (!cancelled) setRows(r.users); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load users report'); });
+    return () => { cancelled = true; };
   }, [filter, window]);
 
   const sortedRows = useMemo(() => {
@@ -890,13 +911,22 @@ function SystemsReport() {
   const [whSort, setWhSort] = useState<{ key: WhSortKey; dir: SortDir }>({ key: 'count', dir: 'desc' });
   const [window, setWindow] = useState<WindowKey>('month');
 
-  useEffect(() => {
+  // Reset to the loading state during render when the window changes, so the
+  // fetch effect below performs no synchronous setState.
+  const [prevWindow, setPrevWindow] = useState(window);
+  if (prevWindow !== window) {
+    setPrevWindow(window);
     setData(null);
     setError(null);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
     const qs = window === 'all' ? '' : `?window=${window}`;
     api<SystemsReportData>(`/api/admin/reports/systems${qs}`)
-      .then(setData)
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load systems report'));
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load systems report'); });
+    return () => { cancelled = true; };
   }, [window]);
 
   const sortedWh = useMemo(() => {
@@ -1276,4 +1306,174 @@ function formatEuropeanDate(date: Date): string {
 function csvEscape(value: string): string {
   if (/[",\r\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
   return value;
+}
+
+// ── Discord tab ───────────────────────────────────────────────────────────────
+interface DiscordSettings {
+  corpId:     number | null;
+  allRegions: boolean;
+  regions:    string[];
+  maps:       { id: string; name: string; excluded: boolean }[];
+}
+interface RegionOption { id: number; name: string }
+
+function DiscordTab() {
+  const [data, setData]           = useState<DiscordSettings | null>(null);
+  const [regionOpts, setRegionOpts] = useState<RegionOption[]>([]);
+  const [error, setError]         = useState<string | null>(null);
+  const [saving, setSaving]       = useState(false);
+  const [saved, setSaved]         = useState(false);
+
+  // Editable copy of the region filter.
+  const [allRegions, setAllRegions] = useState(true);
+  const [regions, setRegions]       = useState<string[]>([]);
+  const [query, setQuery]           = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const [s, r] = await Promise.all([
+        api<DiscordSettings>('/api/admin/discord'),
+        api<{ regions: RegionOption[] }>('/api/regions'),
+      ]);
+      setData(s);
+      setAllRegions(s.allRegions);
+      setRegions(s.regions);
+      setRegionOpts(r.regions);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load Discord settings');
+    }
+  }, []);
+  // load() is async and only setStates after its await (never synchronously),
+  // so this fetch-on-mount of a reusable loader is safe; the rule is a false
+  // positive here.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { load(); }, [load]);
+
+  async function saveRegions() {
+    setSaving(true); setSaved(false);
+    try {
+      await api('/api/admin/discord', { method: 'PUT', body: JSON.stringify({ allRegions, regions }) });
+      setData((d) => (d ? { ...d, allRegions, regions } : d));
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleMap(id: string, excluded: boolean) {
+    setData((d) => (d ? { ...d, maps: d.maps.map((m) => (m.id === id ? { ...m, excluded } : m)) } : d));
+    try {
+      await api(`/api/admin/maps/${id}/discord`, { method: 'PATCH', body: JSON.stringify({ excluded }) });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Update failed');
+      load(); // reload to revert the optimistic toggle
+    }
+  }
+
+  const addRegion    = (name: string) => { if (!regions.includes(name)) setRegions([...regions, name]); setQuery(''); };
+  const removeRegion = (name: string) => setRegions(regions.filter((r) => r !== name));
+
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? regionOpts.filter((o) => o.name.toLowerCase().includes(q) && !regions.includes(o.name)).slice(0, 8)
+    : [];
+
+  if (!data && error) return (<><h2 className="admin-page__section-title">Discord</h2><div className="admin-page__error">{error}</div></>);
+  if (!data)          return (<><h2 className="admin-page__section-title">Discord</h2><div className="admin-page__loading">Loading…</div></>);
+  if (data.corpId == null) {
+    return (<><h2 className="admin-page__section-title">Discord</h2>
+      <div className="admin-page__empty">No corp context — Discord notifications apply to corp maps only.</div></>);
+  }
+
+  const dirty = allRegions !== data.allRegions || regions.slice().sort().join('|') !== data.regions.slice().sort().join('|');
+
+  return (
+    <>
+      <h2 className="admin-page__section-title">Discord notifications</h2>
+      {error && <div className="admin-page__error">{error}</div>}
+      <p className="discord-admin__hint">
+        Controls which wormhole notifications this corp&apos;s maps post to Discord. The webhook itself is set
+        server-side (DISCORD_WEBHOOK_URL). By default every map and region notifies — these settings only subtract.
+      </p>
+
+      <section className="discord-admin__section">
+        <h3 className="discord-admin__heading">Regions</h3>
+        <label className="discord-admin__radio">
+          <input type="radio" name="discord-regions" checked={allRegions} onChange={() => setAllRegions(true)} />
+          Notify for all regions
+        </label>
+        <label className="discord-admin__radio">
+          <input type="radio" name="discord-regions" checked={!allRegions} onChange={() => setAllRegions(false)} />
+          Only selected regions
+        </label>
+
+        {!allRegions && (
+          <div className="discord-admin__regions">
+            <div className="discord-admin__chips">
+              {regions.length === 0
+                ? <span className="admin-page__empty">No regions selected — nothing will notify until you add some.</span>
+                : regions.map((r) => (
+                    <span key={r} className="discord-admin__chip">
+                      {r}
+                      <button type="button" onClick={() => removeRegion(r)} aria-label={`Remove ${r}`}>×</button>
+                    </span>
+                  ))}
+            </div>
+            <input
+              type="text"
+              className="discord-admin__search"
+              placeholder="Type to search regions…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            {matches.length > 0 && (
+              <ul className="discord-admin__results">
+                {matches.map((o) => (
+                  <li key={o.id}><button type="button" onClick={() => addRegion(o.name)}>{o.name}</button></li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <div className="discord-admin__actions">
+          <button className="btn btn--primary" disabled={!dirty || saving} onClick={saveRegions}>
+            {saving ? 'Saving…' : 'Save regions'}
+          </button>
+          {saved && <span className="discord-admin__saved">Saved</span>}
+        </div>
+      </section>
+
+      <section className="discord-admin__section">
+        <h3 className="discord-admin__heading">Excluded maps</h3>
+        <p className="discord-admin__hint">All maps notify by default. Tick a map to exclude it from Discord.</p>
+        {data.maps.length === 0
+          ? <div className="admin-page__empty">No corp maps yet.</div>
+          : (
+            <table className="admin-modal__table">
+              <thead><tr><th>Map</th><th>Exclude</th></tr></thead>
+              <tbody>
+                {data.maps.map((m) => (
+                  <tr key={m.id}>
+                    <td>{m.name}</td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        className="sig-checkbox"
+                        checked={m.excluded}
+                        onChange={(e) => toggleMap(m.id, e.target.checked)}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+      </section>
+    </>
+  );
 }

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -181,7 +181,7 @@ const FEATURE_SECTIONS: FeatureSection[] = [
       {
         icon: BellRingingIcon,
         title: 'Discord notifications',
-        desc: 'Push corp chain intel to a Discord channel so alerts land even when nobody\'s watching the tab. Fires server-side on an inbound K162 or a new wormhole connection, scoped to corp maps and configured per corp via a webhook URL. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel.',
+        desc: 'Push corp chain intel to a Discord channel so alerts land even when nobody\'s watching the tab. Fires server-side on an inbound K162 or a new wormhole connection, scoped to corp maps. Admins filter which regions and maps notify from the admin panel. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel.',
       },
       {
         icon: NavigationArrowIcon,

--- a/web/src/components/ui/NotesEditor.tsx
+++ b/web/src/components/ui/NotesEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import MDEditor, { getCommands } from '@uiw/react-md-editor';
 import rehypeSanitize from 'rehype-sanitize';
 
@@ -29,6 +29,11 @@ const NOTES_HEIGHT_KEY = 'nexum.notesEditorHeight';
 const DEFAULT_NOTES_HEIGHT = 80;
 const MIN_NOTES_HEIGHT = 80;
 
+// Notes save (the parent onChange) is debounced so we don't write to the
+// server on every keystroke; pending edits are flushed immediately on blur
+// and on unmount so nothing is lost.
+const SAVE_DEBOUNCE_MS = 600;
+
 function readNotesHeight(): number {
   try {
     const v = parseInt(localStorage.getItem(NOTES_HEIGHT_KEY) ?? '', 10);
@@ -42,6 +47,45 @@ export function NotesEditor({ value, onChange, compact = false, readOnly = false
   // Initial height for the full pane, read once from localStorage at mount.
   const [initialHeight] = useState(readNotesHeight);
 
+  // Local draft so typing stays instant while the parent save is debounced.
+  const [draft, setDraft] = useState(value);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pending   = useRef<string | null>(null);
+  // Keep the latest onChange in a ref so the debounced flush never goes stale.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
+
+  const flush = useCallback(() => {
+    if (saveTimer.current) { clearTimeout(saveTimer.current); saveTimer.current = null; }
+    if (pending.current !== null) {
+      onChangeRef.current(pending.current);
+      pending.current = null;
+    }
+  }, []);
+
+  // Adopt external updates (e.g. a remote edit) when the value prop actually
+  // changes — but never while the user is actively editing, which would clobber
+  // their typing. Done during render (React's recommended "adjust state on prop
+  // change" pattern) rather than in an effect, so there's no extra render pass
+  // and no risk of reverting an in-flight edit on blur.
+  const [seenValue, setSeenValue] = useState(value);
+  if (value !== seenValue) {
+    setSeenValue(value);
+    if (!focused) setDraft(value);
+  }
+
+  // Flush any pending save when the editor unmounts.
+  useEffect(() => () => flush(), [flush]);
+
+  const handleEditorChange = (v: string | undefined) => {
+    if (readOnly) return;
+    const next = v ?? '';
+    setDraft(next);
+    pending.current = next;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(flush, SAVE_DEBOUNCE_MS);
+  };
+
   const enterEdit = () => {
     if (readOnly || focused) return;
     setFocused(true);
@@ -51,7 +95,7 @@ export function NotesEditor({ value, onChange, compact = false, readOnly = false
   };
 
   if (compact && !focused) {
-    if (!value) {
+    if (!draft) {
       if (readOnly) return <div className="notes-editor notes-editor--empty" />;
       return (
         <div className="notes-editor notes-editor--empty" onClick={enterEdit}>
@@ -60,8 +104,8 @@ export function NotesEditor({ value, onChange, compact = false, readOnly = false
       );
     }
     return (
-      <div className="notes-editor notes-editor--preview" onClick={enterEdit} title={value}>
-        {value}
+      <div className="notes-editor notes-editor--preview" onClick={enterEdit} title={draft}>
+        {draft}
       </div>
     );
   }
@@ -73,12 +117,12 @@ export function NotesEditor({ value, onChange, compact = false, readOnly = false
       data-color-mode="dark"
       onClick={enterEdit}
       onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) setFocused(false);
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) { flush(); setFocused(false); }
       }}
     >
       <MDEditor
-        value={value}
-        onChange={(v) => { if (!readOnly) onChange(v ?? ''); }}
+        value={draft}
+        onChange={handleEditorChange}
         // Compact notes (signature / structure rows) read as a plain text
         // field: no markdown toolbar and a bare textarea (no live preview
         // split). The full Notes pane keeps the toolbar + live preview.


### PR DESCRIPTION
## What's new

### Take control of your Discord pings
Corp admins can now decide exactly what Nexum posts to Discord. A new **Discord** tab in the admin panel lets you:

- Be notified for **all regions**, or only the **specific regions** you care about.
- **Exclude individual maps** from notifications entirely.

Everything stays on by default, so nothing changes unless you tune it - the controls only ever quiet things down. And new maps are always included automatically, so you'll never miss a chain you just set up.

### Smarter inbound-K162 alerts
When someone marks an inbound K162, Nexum now waits a few seconds to catch the "leads to" you set right afterwards - so the Discord ping tells you **where the new hole goes**, not just that one appeared. Fill in the destination and it sends straight away; otherwise it sends shortly after on its own. Correct a mis-tagged hole within that window and the false alarm is quietly dropped.

### Smoother notes
The notes editor now saves when you pause rather than on every keystroke, so typing is snappier and there's far less back-and-forth with the server.

---

**Behind the scenes:** added diagnostics for the Discord notifications, and the plumbing to post these patch notes to Discord automatically on future releases.