### PR TITLE
Add Join Discord buttons to the landing page

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5283,6 +5283,26 @@ select.sig-toolbar-btn option {
 }
 .landing__switch-link:hover { color: #4d9de0; border-color: #4d9de0; }
 
+/* "Join the Discord" button under the EVE SSO login - Discord blurple. */
+.landing__discord-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 10px 18px;
+  background: #5865f2;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: calc(14px * var(--font-scale, 1));
+  border-radius: 8px;
+  text-decoration: none;
+  transition: background 0.15s, transform 0.15s;
+}
+.landing__discord-btn:hover {
+  background: #4752c4;
+  transform: translateY(-1px);
+}
+
 .landing__section {
   width: 100%;
   padding: 48px 0;

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -577,6 +577,24 @@ export function LandingPage() {
           </a>
         </section>
 
+        {/* ── Discord CTA ──────────────────────────────────── */}
+        <section className="landing__section landing__compare">
+          <h2 className="landing__section-title">Got questions, ideas, or bugs?</h2>
+          <p className="landing__section-body">
+            Drop into the Nexum Discord — feedback, feature requests, scanning
+            chat and o7s all welcome.
+          </p>
+          <a
+            href="https://discord.gg/vXzFRCYpQ"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="landing__discord-btn"
+          >
+            <DiscordLogoIcon size={20} weight="fill" />
+            <span>Join the Nexum Discord</span>
+          </a>
+        </section>
+
         {/* ── About Nexum ───────────────────────────────────── */}
         <section className="landing__section" id="about-nexum">
           <h2 className="landing__section-title">About Nexum</h2>

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -4,7 +4,7 @@ import {
   GraphIcon, MapTrifoldIcon, GaugeIcon, MagnifyingGlassIcon, SelectionIcon, ImageIcon, HourglassIcon,
   UsersIcon, StackIcon, ArrowsMergeIcon, ArrowsClockwiseIcon, LockIcon, ShieldCheckIcon,
   CardsIcon, WaveformIcon, BuildingsIcon, SparkleIcon, ChartLineIcon, FlagBannerIcon, SwordIcon, HandshakeIcon,
-  PathIcon, StarIcon, SnowflakeIcon, LightningIcon, WarningIcon, NavigationArrowIcon, MapPinIcon, BroadcastIcon, BellRingingIcon,
+  PathIcon, StarIcon, SnowflakeIcon, LightningIcon, WarningIcon, NavigationArrowIcon, MapPinIcon, BroadcastIcon, BellRingingIcon, DiscordLogoIcon,
   CommandIcon, HouseIcon, SkullIcon, ChartBarIcon, PulseIcon, EyeIcon, SidebarIcon,
   SquaresFourIcon, UserGearIcon, TableIcon, ChartDonutIcon, ClockIcon, ClipboardTextIcon, TagIcon, IdentificationCardIcon,
 } from '@phosphor-icons/react';
@@ -515,6 +515,15 @@ export function LandingPage() {
               </p>
             </>
           )}
+          <a
+            href="https://discord.gg/vXzFRCYpQ"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="landing__discord-btn"
+          >
+            <DiscordLogoIcon size={20} weight="fill" />
+            <span>Join the Nexum Discord</span>
+          </a>
         </div>
         {FEATURE_SECTIONS.map((section) => (
           <section key={section.title} className="landing__section landing__section--features">


### PR DESCRIPTION
Adds two 'Join the Nexum Discord' buttons to the landing page so visitors get an obvious next step whether they hit the page to log in or just scrolled the whole thing reading about features.

- **Under the EVE SSO login** (CTA block): sits below the EVE login note for new visitors and below the 'Continue as <name>' flow for returning ones - shown to both.
- **Below the comparison section**: framed as 'Got questions, ideas, or bugs?' so it reads as a feedback / chat invitation, not a duplicate of the top one. Centered inside a `landing__compare` section between the compare CTA and About Nexum.

Both use the new `landing__discord-btn` class (Discord blurple, Phosphor `DiscordLogoIcon`), open https://discord.gg/vXzFRCYpQ in a new tab with `rel='noopener noreferrer'`. Type-check and build clean.