### PR TITLE
Ignore the local backup-db.sh ops script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ server/data/*.zip
 .claude/
 
 changes.md
+
+# Local ops scripts kept outside the public OSS distribution.
+scripts/backup-db.sh


### PR DESCRIPTION
Keeps `scripts/backup-db.sh` out of the public repo - it lives on the VPS (and any maintainer's working tree) but isn't part of the OSS distribution. The previous PR adding the script (#42) has been closed and its branch deleted.

One-line .gitignore addition; nothing else changes.