### PR TITLE
Use the permanent Discord invite URL

### DIFF
--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -516,7 +516,7 @@ export function LandingPage() {
             </>
           )}
           <a
-            href="https://discord.gg/vXzFRCYpQ"
+            href="https://discord.gg/KG8SMXrhZ4"
             target="_blank"
             rel="noopener noreferrer"
             className="landing__discord-btn"
@@ -585,7 +585,7 @@ export function LandingPage() {
             chat and o7s all welcome.
           </p>
           <a
-            href="https://discord.gg/vXzFRCYpQ"
+            href="https://discord.gg/KG8SMXrhZ4"
             target="_blank"
             rel="noopener noreferrer"
             className="landing__discord-btn"


### PR DESCRIPTION
The previous URL was a default 7-day expiring invite. Swap both landing- page buttons over to the never-expiring invite generated from the actual server.