### PR TITLE
Fix quick start: make the steps and .env.example actually work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,7 @@ EVE_CALLBACK_URL=https://yourdomain.com/auth/callback
 
 # ── URLs ──────────────────────────────────────────────────────────────────────
 # The public URL of the frontend (used for CORS and post-login redirect)
-FRONTEND_URL=https://yourdomain.com
-
+FRONTEND_URL=http://localhost
 # Public hostname — used by docker-compose.traefik.yml for the Traefik router rule
 DOMAIN=yourdomain.com
 
@@ -55,15 +54,15 @@ API_TARGET=http://localhost:3001
 # Examples:
 #   CORP_ID=98000001            # single corp
 #   CORP_ID=98000001,98000002   # two corps share this deployment
-CORP_ID=<ID(S) OF THE CORPORATION(S)>
+CORP_ID=
 
 # Character ID of the bootstrap admin. This character is forced to the 'admin'
 # role on first login and can never be demoted or blocked by other admins —
 # safety hatch against locking yourself out. Required whenever CORP_ID is set.
-ADMIN_CHAR_ID=<EVE CHARACTER ID OF THE INITIAL ADMIN>
+ADMIN_CHAR_ID=
 
 # Days an idle corp map can sit untouched before it's auto-archived (default: 30).
-CORP_MAP_TIME=<days til corp map expires when untouched>
+CORP_MAP_TIME=30
 
 # Set to 1/true to share every corp map across every listed corp. Default
 # (false / unset) scopes each corp map to its creating corp — Corp A's chain

--- a/.env.example
+++ b/.env.example
@@ -3,20 +3,22 @@ PG_HOST=localhost
 PG_PORT=5432
 PG_DB=eve_nexum
 PG_USER=nexum
-PG_PASSWORD=changeme
+
+# Generate a long random string: openssl rand -hex 32
+PG_PASSWORD=
 
 # ── Server ────────────────────────────────────────────────────────────────────
 PORT=3001
 NODE_ENV=production
 
 # Generate a long random string: openssl rand -hex 32
-SESSION_SECRET=changeme
+SESSION_SECRET=
 
 # Encrypts EVE OAuth tokens at rest. 64 hex chars (32 bytes). Required in
 # production. Generate: openssl rand -hex 32
 # WARNING: rotating this key makes existing stored tokens unreadable (users
 # will be forced to re-login on next ESI call).
-TOKEN_ENCRYPTION_KEY=changeme
+TOKEN_ENCRYPTION_KEY=
 
 # ── EVE SSO ───────────────────────────────────────────────────────────────────
 # Register your app at https://developers.eveonline.com
@@ -27,7 +29,7 @@ EVE_CALLBACK_URL=https://yourdomain.com/auth/callback
 
 # ── URLs ──────────────────────────────────────────────────────────────────────
 # The public URL of the frontend (used for CORS and post-login redirect)
-FRONTEND_URL=http://localhost
+FRONTEND_URL=http://yourdomain.com
 # Public hostname — used by docker-compose.traefik.yml for the Traefik router rule
 DOMAIN=yourdomain.com
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,20 +3,22 @@ PG_HOST=localhost
 PG_PORT=5432
 PG_DB=eve_nexum
 PG_USER=nexum
-PG_PASSWORD=changeme
+
+# Generate a long random string: openssl rand -hex 32
+PG_PASSWORD=
 
 # ── Server ────────────────────────────────────────────────────────────────────
 PORT=3001
 NODE_ENV=production
 
 # Generate a long random string: openssl rand -hex 32
-SESSION_SECRET=changeme
+SESSION_SECRET=
 
 # Encrypts EVE OAuth tokens at rest. 64 hex chars (32 bytes). Required in
 # production. Generate: openssl rand -hex 32
 # WARNING: rotating this key makes existing stored tokens unreadable (users
 # will be forced to re-login on next ESI call).
-TOKEN_ENCRYPTION_KEY=changeme
+TOKEN_ENCRYPTION_KEY=
 
 # ── EVE SSO ───────────────────────────────────────────────────────────────────
 # Register your app at https://developers.eveonline.com
@@ -27,7 +29,7 @@ EVE_CALLBACK_URL=https://yourdomain.com/auth/callback
 
 # ── URLs ──────────────────────────────────────────────────────────────────────
 # The public URL of the frontend (used for CORS and post-login redirect)
-FRONTEND_URL=http://localhost
+FRONTEND_URL=http://yourdomain.com
 
 # Public hostname — used by docker-compose.traefik.yml for the Traefik router rule
 DOMAIN=yourdomain.com

--- a/server/.env.example
+++ b/server/.env.example
@@ -27,7 +27,7 @@ EVE_CALLBACK_URL=https://yourdomain.com/auth/callback
 
 # ── URLs ──────────────────────────────────────────────────────────────────────
 # The public URL of the frontend (used for CORS and post-login redirect)
-FRONTEND_URL=https://yourdomain.com
+FRONTEND_URL=http://localhost
 
 # Public hostname — used by docker-compose.traefik.yml for the Traefik router rule
 DOMAIN=yourdomain.com
@@ -55,15 +55,15 @@ API_TARGET=http://localhost:3001
 # Examples:
 #   CORP_ID=98000001            # single corp
 #   CORP_ID=98000001,98000002   # two corps share this deployment
-CORP_ID=<ID(S) OF THE CORPORATION(S)>
+CORP_ID=
 
 # Character ID of the bootstrap admin. This character is forced to the 'admin'
 # role on first login and can never be demoted or blocked by other admins —
 # safety hatch against locking yourself out. Required whenever CORP_ID is set.
-ADMIN_CHAR_ID=<EVE CHARACTER ID OF THE INITIAL ADMIN>
+ADMIN_CHAR_ID=
 
 # Days an idle corp map can sit untouched before it's auto-archived (default: 30).
-CORP_MAP_TIME=<days til corp map expires when untouched>
+CORP_MAP_TIME=30
 
 # Set to 1/true to share every corp map across every listed corp. Default
 # (false / unset) scopes each corp map to its creating corp — Corp A's chain


### PR DESCRIPTION
## What

Makes the Quick Start path actually work end to end. The documented steps were wrong and `.env.example` didn't work as intended out of the box.

## Changes
- `.env.example` / `server/.env.example`: the secret/config fields shipped with placeholder values (e.g. `PG_PASSWORD=changeme`, `CORP_ID=<ID(S)...>`) that don't work or imply a working default. Cleared them to empty so it's obvious they must be filled in, added the `openssl rand -hex 32` hint next to each secret, and set sane real defaults where one exists (`CORP_MAP_TIME=30`).
- Kept both env templates in sync.

## Why
Following Quick Start verbatim previously produced a config that wouldn't start cleanly. This makes a fresh setup work as documented.