### PR TITLE
i18n scaffolding: react-i18next foundation + language switcher

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,9 +24,12 @@
     "@xyflow/react": "^12.10.2",
     "chart.js": "^4.5.1",
     "html-to-image": "^1.11.13",
+    "i18next": "^26.3.0",
+    "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.2.5",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.5",
+    "react-i18next": "^17.0.8",
     "rehype-sanitize": "^6.0.0",
     "uuid": "^14.0.0",
     "zustand": "^5.0.13"

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'react-i18next';
+import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../../i18n';
+
+// Native language names — these read the same in every locale, so they're not
+// translated (English is always "English", German always "Deutsch").
+const LANGUAGE_NAMES: Record<SupportedLanguage, string> = {
+  en: 'English',
+  de: 'Deutsch',
+};
+
+export function LanguageSwitcher() {
+  const { t, i18n } = useTranslation();
+  const current = (i18n.resolvedLanguage ?? 'en') as SupportedLanguage;
+
+  return (
+    <select
+      className="toolbar__lang-select"
+      value={current}
+      onChange={(e) => { void i18n.changeLanguage(e.target.value); }}
+      data-tooltip={t('language.label')}
+      aria-label={t('language.label')}
+    >
+      {SUPPORTED_LANGUAGES.map((lng) => (
+        <option key={lng} value={lng}>{LANGUAGE_NAMES[lng]}</option>
+      ))}
+    </select>
+  );
+}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -9,6 +9,7 @@ import { useCanCreateMaps } from '../../hooks/useCanCreateMaps';
 import { UserStatsModal } from './UserStatsModal';
 import { ConfirmModal } from './ConfirmModal';
 import { CreateMapModal } from './CreateMapModal';
+import { LanguageSwitcher } from './LanguageSwitcher';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
@@ -362,6 +363,8 @@ export function Toolbar() {
       >
         <SlidersHorizontalIcon size={18} weight="regular" />
       </button>
+
+      <LanguageSwitcher />
 
       <div className="toolbar__server-status">
         <div className="toolbar__server-row">

--- a/web/src/i18n/README.md
+++ b/web/src/i18n/README.md
@@ -1,0 +1,68 @@
+# Internationalisation (i18n)
+
+Scaffolding for translating Nexum's UI. Built on
+[`react-i18next`](https://react.i18next.com/). This is the foundation only — most
+UI strings are still hardcoded and get migrated to `t()` incrementally.
+
+## What gets translated
+
+**App chrome only** — buttons, labels, tooltips, hints, messages.
+
+**NOT translated:** EVE game data — system names, ship/type names, and wormhole
+codes/classes (`C1`–`C6`, `HS`, `LS`, `NS`, `K162`, `Thera`, …). These are
+canonical English from the SDE/ESI and stay as-is everywhere.
+
+## Layout
+
+```
+i18n/
+  index.ts              init (detector + localStorage persistence, fallback en)
+  i18next.d.ts          type-safe t() keys, checked against the en resource
+  locales/<lng>/common.json   one JSON per language
+```
+
+`en` is the source of truth; every other locale mirrors its key shape.
+
+## Using it in a component
+
+```tsx
+import { useTranslation } from 'react-i18next';
+
+function Save() {
+  const { t } = useTranslation();
+  return <button>{t('actions.save')}</button>;
+}
+```
+
+Keys are type-checked — a typo or missing key is a compile error.
+
+### Interpolation & plurals
+
+```tsx
+t('units.jumps', { count: n })   // "1 jump" / "3 jumps"
+```
+
+Define plural forms with the `_one` / `_other` suffixes (see `units.jumps` in
+`common.json`); i18next picks the right one per language's plural rules.
+
+## Adding a string
+
+1. Add the key to `locales/en/common.json` (and the same key to every other
+   locale).
+2. Replace the hardcoded text with `t('your.key')`.
+
+## Adding a language
+
+1. Create `locales/<code>/common.json` mirroring `en`.
+2. Add `<code>` to `SUPPORTED_LANGUAGES` and `resources` in `index.ts`.
+3. Add its native name to `LANGUAGE_NAMES` in
+   `../components/ui/LanguageSwitcher.tsx`.
+
+## Migration plan
+
+1. ~~Foundation: library, init, language switcher~~ ✅ (this scaffolding)
+2. Consolidate the scattered relative-time / mass / pluralisation formatters into
+   i18n-aware helpers (the trickiest part — do before mass extraction).
+3. Extract strings component-by-component into `common.json` (split into feature
+   namespaces as it grows).
+4. Add a real second language end-to-end to flush out text-overflow / format bugs.

--- a/web/src/i18n/i18next.d.ts
+++ b/web/src/i18n/i18next.d.ts
@@ -1,0 +1,14 @@
+import 'i18next';
+import type enCommon from './locales/en/common.json';
+
+// Makes t() keys type-checked and autocompleted against the English resource —
+// a typo or missing key becomes a compile error. English is the source of truth;
+// other locales mirror its shape.
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'common';
+    resources: {
+      common: typeof enCommon;
+    };
+  }
+}

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -1,0 +1,42 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import enCommon from './locales/en/common.json';
+import deCommon from './locales/de/common.json';
+
+// Languages we ship translations for. Add a code here AND a matching
+// locales/<code>/common.json file to add a language. Native language names
+// live in the LanguageSwitcher (they read the same in every locale).
+export const SUPPORTED_LANGUAGES = ['en', 'de'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+// One namespace ('common') for now. Split into feature namespaces
+// (sidebar, toolbar, admin, …) as the string count grows.
+export const resources = {
+  en: { common: enCommon },
+  de: { common: deCommon },
+} as const;
+
+// NOTE: EVE game data (system names, ship types, wormhole codes like C1/HS/K162)
+// is canonical English and is NOT translated — only app chrome goes through i18n.
+void i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'en',
+    supportedLngs: SUPPORTED_LANGUAGES,
+    defaultNS: 'common',
+    ns: ['common'],
+    detection: {
+      // Prefer a previously chosen language, else the browser's; persist the choice.
+      order: ['localStorage', 'navigator'],
+      lookupLocalStorage: 'nexum.lang',
+      caches: ['localStorage'],
+    },
+    interpolation: { escapeValue: false }, // React already escapes output
+    returnNull: false,
+  });
+
+export default i18n;

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1,0 +1,16 @@
+{
+  "language": {
+    "label": "Sprache"
+  },
+  "actions": {
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "delete": "Löschen",
+    "copy": "Kopieren",
+    "close": "Schließen"
+  },
+  "units": {
+    "jumps_one": "{{count}} Sprung",
+    "jumps_other": "{{count}} Sprünge"
+  }
+}

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1,0 +1,16 @@
+{
+  "language": {
+    "label": "Language"
+  },
+  "actions": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "copy": "Copy",
+    "close": "Close"
+  },
+  "units": {
+    "jumps_one": "{{count}} jump",
+    "jumps_other": "{{count}} jumps"
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,5 @@
 import './debug'
+import './i18n' // initialise i18next before any component renders
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "resolveJsonModule": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -116,6 +116,11 @@
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
 
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.29.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/template@^7.28.6":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
@@ -1370,6 +1375,13 @@ hermes-parser@^0.25.1:
   dependencies:
     hermes-estree "0.25.1"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 html-to-image@^1.11.13:
   version "1.11.13"
   resolved "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz"
@@ -1384,6 +1396,18 @@ html-void-elements@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+
+i18next-browser-languagedetector@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz#f17a918d376a97aa12a5b63fd8ea559a6231935b"
+  integrity sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.0.tgz#057c1165589b3f312714ea2a0c3f368c2c7cd84f"
+  integrity sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -2187,6 +2211,15 @@ react-dom@^19.2.5:
   dependencies:
     scheduler "^0.27.0"
 
+react-i18next@^17.0.8:
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-17.0.8.tgz#a3880ddbfd956846f4600004313b048c1c705aee"
+  integrity sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==
+  dependencies:
+    "@babel/runtime" "^7.29.2"
+    html-parse-stringify "^3.0.1"
+    use-sync-external-store "^1.6.0"
+
 react-markdown@~10.1.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz"
@@ -2596,7 +2629,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-sync-external-store@^1.2.2:
+use-sync-external-store@^1.2.2, use-sync-external-store@^1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
@@ -2642,6 +2675,11 @@ vite@^8.0.10:
     tinyglobby "^0.2.16"
   optionalDependencies:
     fsevents "~2.3.3"
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 web-namespaces@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
First stage of the localization effort. Targets the long-lived `localization` integration branch (not `main`) — `localization` only merges to `release` once we have a fully translated second language.

## What's in this stage (foundation only)
- Adds `i18next` / `react-i18next` / browser language-detector.
- `web/src/i18n/`: init (localStorage persistence under `nexum.lang` + browser detection, `en` fallback), `en` + `de` locale JSON, and type-safe `t()` keys checked against the English resource.
- `LanguageSwitcher` component mounted in the Toolbar; choice persists.
- Seeds common actions + a plural example (`units.jumps` → "1 jump" / "3 jumps").
- Enables `resolveJsonModule`; README documents the pattern and what stays untranslated (EVE canonical data: system/ship names, WH codes/classes).

## Not included yet
- Mass string extraction. Existing UI strings are still hardcoded.
- Next stage: consolidate the scattered relative-time / mass / pluralization formatters into i18n-aware helpers (the real unlock) before extraction.

## Verification
- `yarn build` (`tsc -b` + Vite) passes.

Merges cleanly into `localization` (only touches new i18n files + 3 small wiring edits).