### PR TITLE
i18n stage 2: consolidate formatters into i18n-aware helpers

### DIFF
--- a/web/src/components/ui/A0Pane.tsx
+++ b/web/src/components/ui/A0Pane.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MapPinSimpleIcon, PathIcon } from '@phosphor-icons/react';
+import { jumps } from '../../i18n/format';
 import { useA0Systems } from '../../hooks/useA0Systems';
 import { useCharacterLocation } from '../../hooks/useCharacterLocation';
 import { useRoute } from '../../hooks/useRoute';
@@ -9,6 +11,7 @@ import { useMapStore } from '../../store/mapStore';
 const TOP_N = 10;
 
 export function A0Pane() {
+  const { t } = useTranslation();
   const all      = useA0Systems();
   const routeMode = useMapStore((s) => s.routeMode);
   const location = useCharacterLocation();
@@ -71,7 +74,7 @@ export function A0Pane() {
             <div className="scout-row__region">{s.regionName}</div>
 
             <div className="scout-row__actions">
-              <span className="scout-row__jumps">{s.jumps} jumps</span>
+              <span className="scout-row__jumps">{jumps(t, s.jumps)}</span>
               <button
                 type="button"
                 className="sys-btn scout-row__btn scout-row__btn--icon"

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { api } from '../../api/client';
 import { useAuth } from '../../context/AuthContext';
 import { useHashRoute } from '../../hooks/useHashRoute';
+import { timeAgo, europeanDate, DASH } from '../../i18n/format';
 import { ConfirmModal } from './ConfirmModal';
 import {
   Chart as ChartJS,
@@ -145,6 +148,7 @@ function compareUsers(a: AdminUser, b: AdminUser, sort: UserSort): number {
 }
 
 function UsersTab() {
+  const { t } = useTranslation();
   const { user: self } = useAuth();
   const canEdit = self?.role === 'admin';
   const [users, setUsers]     = useState<AdminUser[] | null>(null);
@@ -285,7 +289,7 @@ function UsersTab() {
                       ? <span className="admin-modal__pill admin-modal__pill--blocked">blocked</span>
                       : <span className="admin-modal__pill admin-modal__pill--ok">active</span>}
                   </td>
-                  <td className="admin-modal__when">{formatRelative(u.lastLogin)}</td>
+                  <td className="admin-modal__when">{formatRelative(t, u.lastLogin)}</td>
                   {canEdit && (
                     <td className="admin-modal__actions">
                       {u.blocked ? (
@@ -348,6 +352,7 @@ interface AdminMap {
 }
 
 function MapsTab() {
+  const { t } = useTranslation();
   const [maps, setMaps]   = useState<AdminMap[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -440,7 +445,7 @@ function MapsTab() {
                       ? <span className="admin-modal__pill admin-modal__pill--blocked">locked</span>
                       : <span className="admin-modal__pill admin-modal__pill--ok">open</span>}
                   </td>
-                  <td className="admin-modal__when">{formatRelative(m.lastActiveAt)}</td>
+                  <td className="admin-modal__when">{formatRelative(t, m.lastActiveAt)}</td>
                   <td className="admin-modal__actions">
                     {m.locked ? (
                       <button
@@ -638,6 +643,7 @@ function compareValues(a: string | number | null, b: string | number | null, dir
 }
 
 function UsersReport() {
+  const { t } = useTranslation();
   const [rows, setRows]   = useState<UserReportRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [sort, setSort]   = useState<{ key: UserReportSortKey; dir: SortDir }>({ key: 'name', dir: 'asc' });
@@ -826,12 +832,12 @@ function UsersReport() {
                     ? <span className="admin-modal__mono">{u.allianceId}</span>
                     : '—'}
               </td>
-              <td className="admin-modal__when">{u.lastLogin ? formatRelative(u.lastLogin) : '—'}</td>
+              <td className="admin-modal__when">{u.lastLogin ? formatRelative(t, u.lastLogin) : '—'}</td>
               <td className="admin-modal__num">{u.systemsAdded   > 0 ? u.systemsAdded   : '—'}</td>
               <td className="admin-modal__num">{u.systemsDeleted > 0 ? u.systemsDeleted : '—'}</td>
-              <td className="admin-modal__when">{u.lastCorpStructAt ? formatRelative(u.lastCorpStructAt) : '—'}</td>
+              <td className="admin-modal__when">{u.lastCorpStructAt ? formatRelative(t, u.lastCorpStructAt) : '—'}</td>
               <td className="admin-modal__num">{u.totalCorpStructures > 0 ? u.totalCorpStructures : '—'}</td>
-              <td className="admin-modal__when">{u.lastCorpSigAt ? formatRelative(u.lastCorpSigAt) : '—'}</td>
+              <td className="admin-modal__when">{u.lastCorpSigAt ? formatRelative(t, u.lastCorpSigAt) : '—'}</td>
               <td className="admin-modal__num">{total > 0 ? total : '—'}</td>
               {SIG_TYPE_ORDER.map((t) => {
                 const n = u.sigTypeCounts[t.key] ?? 0;
@@ -1203,6 +1209,7 @@ interface AuditEntry {
 }
 
 function AuditTab() {
+  const { t } = useTranslation();
   const [entries, setEntries] = useState<AuditEntry[] | null>(null);
   const [error, setError]     = useState<string | null>(null);
 
@@ -1262,7 +1269,7 @@ function AuditTab() {
           <tbody>
             {entries.map((e) => (
               <tr key={e.id}>
-                <td className="admin-modal__when">{formatRelative(e.createdAt)}</td>
+                <td className="admin-modal__when">{formatRelative(t, e.createdAt)}</td>
                 <td>{e.actorCharacterName ?? '—'}</td>
                 <td><span className="admin-modal__action">{e.action}</span></td>
                 <td>{e.targetCharacterName ?? '—'}</td>
@@ -1280,25 +1287,14 @@ function AuditTab() {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function formatRelative(iso: string): string {
+function formatRelative(t: TFunction, iso: string): string {
   const date = new Date(iso);
   const then = date.getTime();
-  if (Number.isNaN(then)) return '—';
-  const secs = Math.floor((Date.now() - then) / 1000);
-  if (secs < 60)              return `${secs}s ago`;
-  if (secs < 3600)            return `${Math.floor(secs / 60)}m ago`;
-  if (secs < 86400)           return `${Math.floor(secs / 3600)}h ago`;
-  if (secs < 86400 * 30)      return `${Math.floor(secs / 86400)}d ago`;
+  if (Number.isNaN(then)) return DASH;
   // Anything older than ~a month is more useful as an absolute European
   // date (DD-MM-YYYY) than "65d ago".
-  return formatEuropeanDate(date);
-}
-
-function formatEuropeanDate(date: Date): string {
-  const dd   = String(date.getDate()).padStart(2, '0');
-  const mm   = String(date.getMonth() + 1).padStart(2, '0');
-  const yyyy = date.getFullYear();
-  return `${dd}-${mm}-${yyyy}`;
+  if (Date.now() - then >= 86400 * 30 * 1000) return europeanDate(date);
+  return timeAgo(t, date);
 }
 
 // RFC 4180 CSV escaping: wrap in double quotes if the field contains a

--- a/web/src/components/ui/KillboardPane.tsx
+++ b/web/src/components/ui/KillboardPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useKillboard } from '../../hooks/useKillboard';
 import { useStandings } from '../../hooks/useStandings';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { abbreviateValue } from '../../i18n/format';
 import type { ZkbKill } from '../../hooks/useKillboard';
 
 const NPC_TOGGLE_KEY = 'nexum.killboardIncludeNpc';
@@ -16,13 +17,6 @@ const ZKB     = 'https://zkillboard.com';
 // At or above this many attackers a kill is treated as a "gank" (overwhelming
 // force) rather than a small gang. Tune to taste.
 const GANK_THRESHOLD = 10;
-
-function formatIsk(v: number): string {
-  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
-  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
-  if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
-  return String(Math.round(v));
-}
 
 function timeAgo(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime();
@@ -216,7 +210,7 @@ function KillRow({ kill, standings }: { kill: ZkbKill; standings: ReturnType<typ
         )}
 
         <div className="zkb-kill__meta">
-          <span className="zkb-kill__value">{formatIsk(kill.zkb.totalValue)} ISK</span>
+          <span className="zkb-kill__value">{abbreviateValue(kill.zkb.totalValue)} ISK</span>
           <span className="zkb-kill__time">{timeAgo(kill.killmail_time)}</span>
         </div>
       </div>

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import {
   useNotificationPermission,
   notifyPermissionChanged,
 } from "../../hooks/useNotificationPermission";
+import { expiresIn } from "../../i18n/format";
 import { useMapStore } from "../../store/mapStore";
 import { useAuth } from "../../context/AuthContext";
 import { api } from "../../api/client";
@@ -132,6 +134,7 @@ const SHARE_EXPIRY_OPTIONS: Array<{ hours: number; label: string }> = [
 const SHARE_EXPIRY_DEFAULT = 24;
 
 function ShareSection() {
+  const { t } = useTranslation();
   const map = useMapStore((s) => s.map);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -252,12 +255,7 @@ function ShareSection() {
   }
 
   function formatRemaining(): string {
-    const ms = expiresAt - now;
-    if (ms <= 0) return "expired";
-    const h = Math.floor(ms / 3_600_000);
-    const m = Math.floor((ms % 3_600_000) / 60_000);
-    if (h > 0) return `expires in ${h}h ${m}m`;
-    return `expires in ${m}m`;
+    return expiresIn(t, expiresAt - now);
   }
 
   // Update toggle state locally and, if a link is live, push a PATCH so

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { api } from '../../api/client';
 import { useMapStore } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
@@ -14,6 +15,7 @@ import { toast } from './Toaster';
 import { reevaluateConnectionsForSystem } from '../../utils/whAutoDetect';
 import { alertInboundK162 } from '../../utils/k162Alert';
 import { WORMHOLE_TYPES } from '../../data/wormholes';
+import { duration, DASH } from '../../i18n/format';
 
 // Aging bands for wormhole signatures, anchored to the WH type's known
 // lifetime. K162 and unknown codes return '' (no tint) since we don't
@@ -108,19 +110,6 @@ const DEFAULT_WIDTHS: Record<ColKey, number> = {
   updated: 80,
 };
 
-function elapsed(isoString: string | undefined, now: number): string {
-  if (!isoString) return '—';
-  const diff = Math.floor((now - new Date(isoString).getTime()) / 1000);
-  if (diff < 0) return '0s';
-  if (diff < 60) return `${diff}s`;
-  const m = Math.floor(diff / 60);
-  const s = diff % 60;
-  if (m < 60) return `${m}m ${s < 10 ? '0' : ''}${s}s`;
-  const h = Math.floor(m / 60);
-  const rm = m % 60;
-  return `${h}h ${rm < 10 ? '0' : ''}${rm}m`;
-}
-
 // Single module-level 1 s tick shared across every ElapsedCell instance.
 // Previously each SignaturePane drove a state update every second, which
 // re-rendered every row including its embedded MDEditor — extremely expensive.
@@ -137,6 +126,7 @@ function startTickIfNeeded() {
 }
 
 function ElapsedCell({ iso, className }: { iso: string | undefined; className?: string }) {
+  const { t } = useTranslation();
   const [, setTick] = useState(0);
   useEffect(() => {
     const fn = () => setTick((n) => n + 1);
@@ -150,7 +140,10 @@ function ElapsedCell({ iso, className }: { iso: string | undefined; className?: 
       }
     };
   }, []);
-  return <td className={className}>{elapsed(iso, tickNow)}</td>;
+  const text = iso
+    ? duration(t, Math.floor((tickNow - new Date(iso).getTime()) / 1000))
+    : DASH;
+  return <td className={className}>{text}</td>;
 }
 
 export function SignaturePane({ systemId }: { systemId: string }) {

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,4 +1,7 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { timeAgo, jumps } from '../../i18n/format';
 import { useMapStore } from '../../store/mapStore';
 import { useAuth } from '../../context/AuthContext';
 import { useOnlineStatus } from '../../hooks/useOnlineStatus';
@@ -106,18 +109,11 @@ function useEveServerStatus(): EveStatus | null {
   return status;
 }
 
-function formatCheckedAt(date: Date): string {
-  const secs = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (secs < 5)  return 'just now';
-  if (secs < 60) return `${secs}s ago`;
-  return `${Math.floor(secs / 60)}m ago`;
-}
-
 // Build the tooltip for the online-status dot. When ESI reports online we
 // surface the TQ session-start timestamp + how long ago it was, so an
 // orphan session ("online for 6 hours but I crashed at lunchtime") is
 // instantly recognisable from the tooltip alone.
-function onlineTooltip(online: boolean | null, lastLoginIso: string | null): string {
+function onlineTooltip(t: TFunction, online: boolean | null, lastLoginIso: string | null): string {
   if (online === false) return 'Offline';
   if (online === null)  return 'Status unknown';
   if (!lastLoginIso)    return 'Online in EVE';
@@ -126,26 +122,19 @@ function onlineTooltip(online: boolean | null, lastLoginIso: string | null): str
   // DD-MM-YYYY HH:MM UTC matches the rest of the app's date display.
   const pad = (n: number) => String(n).padStart(2, '0');
   const stamp = `${pad(ts.getUTCDate())}-${pad(ts.getUTCMonth() + 1)}-${ts.getUTCFullYear()} ${pad(ts.getUTCHours())}:${pad(ts.getUTCMinutes())} UTC`;
-  // Rough age — minutes for the first hour, then hours, then days. Plenty
-  // good enough for "is this session weirdly old?" at a glance.
-  const ageMin = Math.floor((Date.now() - ts.getTime()) / 60_000);
-  let age: string;
-  if (ageMin < 1)        age = 'just now';
-  else if (ageMin < 60)  age = `${ageMin}m ago`;
-  else if (ageMin < 24 * 60) age = `${Math.floor(ageMin / 60)}h ago`;
-  else                   age = `${Math.floor(ageMin / (24 * 60))}d ago`;
-  return `Online in EVE since ${stamp} (${age})`;
+  return `Online in EVE since ${stamp} (${timeAgo(t, ts)})`;
 }
 
 // Self-contained "checked Xs ago" label — owns its own 5 s tick so the rest of
 // the Toolbar doesn't re-render every five seconds along with it.
 function CheckedAtLabel({ checkedAt }: { checkedAt: Date }) {
+  const { t } = useTranslation();
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick((n) => n + 1), 5_000);
     return () => clearInterval(id);
   }, []);
-  return <span className="toolbar__checked-at">checked {formatCheckedAt(checkedAt)}</span>;
+  return <span className="toolbar__checked-at">checked {timeAgo(t, checkedAt)}</span>;
 }
 
 // Persistent indicator for the nearest live threat (incursion / insurgency).
@@ -153,6 +142,7 @@ function CheckedAtLabel({ checkedAt }: { checkedAt: Date }) {
 // on threshold crossings — Toolbar is rendered once for every logged-in user).
 function ProximityChip() {
   const { nearest, threshold } = useProximityAlerts();
+  const { t } = useTranslation();
   // The user's configurable threshold gates both display and the alert state —
   // if the chip is shown, the threat is in-zone by definition. Filters out the
   // permanent "20 jumps — …" noise on most maps.
@@ -169,13 +159,14 @@ function ProximityChip() {
     >
       <span className="toolbar__proximity-icon"><Icon size={14} weight="bold" /></span>
       <span className="toolbar__proximity-text">
-        {nearest.jumps === 0 ? 'IN' : `${nearest.jumps} jumps`} - {label}
+        {nearest.jumps === 0 ? 'IN' : jumps(t, nearest.jumps)} - {label}
       </span>
     </span>
   );
 }
 
 export function Toolbar() {
+  const { t } = useTranslation();
   const mapName         = useMapStore((s) => s.map.name);
   const mapLocked       = useMapStore((s) => !!s.map.locked);
   const systemCount     = useMapStore((s) => s.map.systems.length);
@@ -417,7 +408,7 @@ export function Toolbar() {
         <div className="toolbar__user">
           <span
             className={`toolbar__online-dot${online === true ? ' toolbar__online-dot--on' : online === false ? ' toolbar__online-dot--off' : ''}`}
-            title={onlineTooltip(online, lastLogin)}
+            title={onlineTooltip(t, online, lastLogin)}
           />
           <img
             className="toolbar__avatar"

--- a/web/src/components/ui/UserStatsModal.tsx
+++ b/web/src/components/ui/UserStatsModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { XIcon } from '@phosphor-icons/react';
 import { useStats, type StatPeriod, type SigBreakdown } from '../../hooks/useStats';
 
@@ -8,6 +9,7 @@ const SPARK_PAD  = { top: 6, right: 6, bottom: 18, left: 28 };
 const SPARK_COLOR = '#6ea0ff';
 
 function SigSparkline({ values }: { values: number[] }) {
+  const { t } = useTranslation();
   const n      = values.length;
   const iw     = SPARK_VB_W - SPARK_PAD.left - SPARK_PAD.right;
   const ih     = SPARK_VB_H - SPARK_PAD.top  - SPARK_PAD.bottom;
@@ -26,8 +28,8 @@ function SigSparkline({ values }: { values: number[] }) {
   const yTicks = [...new Set([0, Math.round(maxVal / 2), maxVal])];
   // X ticks: 30d ago (left) and today (right)
   const xLabels: { x: number; label: string }[] = n > 0 ? [
-    { x: xOf(0),     label: `${n - 1}d ago` },
-    { x: xOf(n - 1), label: 'today' },
+    { x: xOf(0),     label: t('time.daysAgo', { value: n - 1 }) },
+    { x: xOf(n - 1), label: t('time.today') },
   ] : [];
 
   return (
@@ -92,7 +94,7 @@ function SigSparkline({ values }: { values: number[] }) {
       </svg>
       {hover && (
         <div className="stats-modal__spark-tooltip">
-          <strong>{hover.value.toLocaleString()}</strong> sigs · {n - 1 - hover.index === 0 ? 'today' : `${n - 1 - hover.index}d ago`}
+          <strong>{hover.value.toLocaleString()}</strong> sigs · {n - 1 - hover.index === 0 ? t('time.today') : t('time.daysAgo', { value: n - 1 - hover.index })}
         </div>
       )}
     </div>

--- a/web/src/components/ui/WHTypeInfo.tsx
+++ b/web/src/components/ui/WHTypeInfo.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { CLASS_COLORS, CLASS_LABELS } from '../../data/wormholes';
+import { mass } from '../../i18n/format';
 import type { SystemClass } from '../../types';
 
 interface Props {
@@ -10,13 +12,6 @@ interface Props {
    *  (popover shows on mouse-enter, hides on leave). When omitted, a small
    *  `ⓘ` button is rendered and opens the popover on click. */
   children?: ReactNode;
-}
-
-function formatMass(kg: number): string {
-  if (kg >= 1_000_000_000) return `${(kg / 1_000_000_000).toFixed(2)} B kg`;
-  if (kg >= 1_000_000)     return `${(kg / 1_000_000).toFixed(0)} M kg`;
-  if (kg > 0)              return `${kg.toLocaleString()} kg`;
-  return '—';
 }
 
 function classKey(raw: string): SystemClass | null {
@@ -30,6 +25,7 @@ function classKey(raw: string): SystemClass | null {
 }
 
 export function WHTypeInfo({ code, children }: Props) {
+  const { t } = useTranslation();
   const types = useWormholeTypes();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLSpanElement>(null);
@@ -73,11 +69,11 @@ export function WHTypeInfo({ code, children }: Props) {
       </div>
       <div className="wh-type-info__row">
         <span className="wh-type-info__label">Total mass</span>
-        <span className="wh-type-info__value">{formatMass(spec.totalMass)}</span>
+        <span className="wh-type-info__value">{mass(t, spec.totalMass)}</span>
       </div>
       <div className="wh-type-info__row">
         <span className="wh-type-info__label">Max jump</span>
-        <span className="wh-type-info__value">{formatMass(spec.maxJumpMass)}</span>
+        <span className="wh-type-info__value">{mass(t, spec.maxJumpMass)}</span>
       </div>
     </div>
   );

--- a/web/src/i18n/README.md
+++ b/web/src/i18n/README.md
@@ -45,6 +45,25 @@ t('units.jumps', { count: n })   // "1 jump" / "3 jumps"
 Define plural forms with the `_one` / `_other` suffixes (see `units.jumps` in
 `common.json`); i18next picks the right one per language's plural rules.
 
+## Formatters
+
+Shared, i18n-aware formatters live in `format.ts` — use these instead of
+re-inventing per-component helpers:
+
+```tsx
+import { timeAgo, duration, expiresIn, mass, abbreviateValue, jumps } from '../../i18n/format';
+
+timeAgo(t, date)          // "just now" / "5m ago" / "2d ago"
+duration(t, seconds)      // "0s" / "5m 03s" / "2h 09m"  (counting up)
+expiresIn(t, ms)          // "expires in 2h 14m" / "expired"
+mass(t, kg)               // "1.44 B kg" / "500 M kg"
+abbreviateValue(value)    // "2.5B" / "500M" / "12K"  (pure, no t)
+jumps(t, n)               // "1 jump" / "3 jumps"
+```
+
+Pass the `t` from `useTranslation()`. For an absolute-date fallback past some
+age, branch yourself and call `europeanDate(date)`.
+
 ## Adding a string
 
 1. Add the key to `locales/en/common.json` (and the same key to every other
@@ -60,9 +79,9 @@ Define plural forms with the `_one` / `_other` suffixes (see `units.jumps` in
 
 ## Migration plan
 
-1. ~~Foundation: library, init, language switcher~~ ✅ (this scaffolding)
-2. Consolidate the scattered relative-time / mass / pluralisation formatters into
-   i18n-aware helpers (the trickiest part — do before mass extraction).
+1. ~~Foundation: library, init, language switcher~~ ✅
+2. ~~Consolidate the scattered relative-time / mass / pluralisation formatters into
+   i18n-aware helpers (`format.ts`)~~ ✅
 3. Extract strings component-by-component into `common.json` (split into feature
    namespaces as it grows).
 4. Add a real second language end-to-end to flush out text-overflow / format bugs.

--- a/web/src/i18n/format.ts
+++ b/web/src/i18n/format.ts
@@ -1,0 +1,75 @@
+import type { TFunction } from 'i18next';
+
+// Centralised, i18n-aware formatters. Previously these lived as near-duplicate
+// helper functions scattered across Toolbar, AdminPage, SignaturePane,
+// WHTypeInfo, KillboardPane, MapSidebar, etc. Keep new formatting logic here so
+// the translatable strings live in one place.
+
+// Em dash — a language-neutral "no value" placeholder.
+export const DASH = '—';
+
+const pad2 = (n: number) => (n < 10 ? `0${n}` : String(n));
+
+/**
+ * Relative "time ago": "just now" / "12s ago" / "5m ago" / "3h ago" / "2d ago".
+ * Accepts a Date or an epoch-ms number. For callers that want an absolute date
+ * past some age, branch on the age yourself and fall back to europeanDate().
+ */
+export function timeAgo(t: TFunction, when: Date | number): string {
+  const ms = when instanceof Date ? when.getTime() : when;
+  const secs = Math.floor((Date.now() - ms) / 1000);
+  if (secs < 5)     return t('time.justNow');
+  if (secs < 60)    return t('time.secondsAgo', { value: secs });
+  if (secs < 3600)  return t('time.minutesAgo', { value: Math.floor(secs / 60) });
+  if (secs < 86400) return t('time.hoursAgo',   { value: Math.floor(secs / 3600) });
+  return t('time.daysAgo', { value: Math.floor(secs / 86400) });
+}
+
+/** DD-MM-YYYY. Numeric, so not translated. */
+export function europeanDate(date: Date): string {
+  return `${pad2(date.getDate())}-${pad2(date.getMonth() + 1)}-${date.getFullYear()}`;
+}
+
+/**
+ * Elapsed duration (counting up): "0s" / "42s" / "5m 03s" / "2h 09m".
+ * Negative inputs clamp to 0.
+ */
+export function duration(t: TFunction, totalSeconds: number): string {
+  const s = totalSeconds < 0 ? 0 : totalSeconds;
+  if (s < 60) return t('duration.seconds', { value: s });
+  const m = Math.floor(s / 60);
+  if (m < 60) return t('duration.minutesSeconds', { minutes: m, seconds: pad2(s % 60) });
+  const h = Math.floor(m / 60);
+  return t('duration.hoursMinutes', { hours: h, minutes: pad2(m % 60) });
+}
+
+/** "expires in 2h 14m" / "expires in 14m" / "expired" from a millisecond remainder. */
+export function expiresIn(t: TFunction, ms: number): string {
+  if (ms <= 0) return t('share.expired');
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  return h > 0
+    ? t('share.expiresInHM', { hours: h, minutes: m })
+    : t('share.expiresInM', { minutes: m });
+}
+
+/** Wormhole mass: "1.44 B kg" / "500 M kg" / "123,456 kg" / em dash for <= 0. */
+export function mass(t: TFunction, kg: number): string {
+  if (kg >= 1_000_000_000) return t('mass.billionKg', { value: (kg / 1_000_000_000).toFixed(2) });
+  if (kg >= 1_000_000)     return t('mass.millionKg', { value: (kg / 1_000_000).toFixed(0) });
+  if (kg > 0)              return t('mass.kg',        { value: kg.toLocaleString() });
+  return DASH;
+}
+
+/** Compact ISK/number abbreviation: "2.5B" / "500M" / "12K" / "640". Suffixes are universal, no translation. */
+export function abbreviateValue(v: number): string {
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+  return String(Math.round(v));
+}
+
+/** Pluralised jump count: "1 jump" / "3 jumps". */
+export function jumps(t: TFunction, n: number): string {
+  return t('units.jumps', { count: n });
+}

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -12,5 +12,28 @@
   "units": {
     "jumps_one": "{{count}} Sprung",
     "jumps_other": "{{count}} Sprünge"
+  },
+  "time": {
+    "justNow": "gerade eben",
+    "secondsAgo": "vor {{value}}s",
+    "minutesAgo": "vor {{value}}m",
+    "hoursAgo": "vor {{value}}h",
+    "daysAgo": "vor {{value}}t",
+    "today": "heute"
+  },
+  "duration": {
+    "seconds": "{{value}}s",
+    "minutesSeconds": "{{minutes}}m {{seconds}}s",
+    "hoursMinutes": "{{hours}}h {{minutes}}m"
+  },
+  "share": {
+    "expired": "abgelaufen",
+    "expiresInHM": "läuft in {{hours}}h {{minutes}}m ab",
+    "expiresInM": "läuft in {{minutes}}m ab"
+  },
+  "mass": {
+    "billionKg": "{{value}} Mrd. kg",
+    "millionKg": "{{value}} Mio. kg",
+    "kg": "{{value}} kg"
   }
 }

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -12,5 +12,28 @@
   "units": {
     "jumps_one": "{{count}} jump",
     "jumps_other": "{{count}} jumps"
+  },
+  "time": {
+    "justNow": "just now",
+    "secondsAgo": "{{value}}s ago",
+    "minutesAgo": "{{value}}m ago",
+    "hoursAgo": "{{value}}h ago",
+    "daysAgo": "{{value}}d ago",
+    "today": "today"
+  },
+  "duration": {
+    "seconds": "{{value}}s",
+    "minutesSeconds": "{{minutes}}m {{seconds}}s",
+    "hoursMinutes": "{{hours}}h {{minutes}}m"
+  },
+  "share": {
+    "expired": "expired",
+    "expiresInHM": "expires in {{hours}}h {{minutes}}m",
+    "expiresInM": "expires in {{minutes}}m"
+  },
+  "mass": {
+    "billionKg": "{{value}} B kg",
+    "millionKg": "{{value}} M kg",
+    "kg": "{{value}} kg"
   }
 }


### PR DESCRIPTION
Stage 2 of the localization effort (targets `localization`, not main). Builds on the merged scaffolding.

## What
Replaces the near-duplicate `relative-time / duration / mass / ISK / pluralization` helpers that were copy-pasted across components with one shared, i18n-aware module — the trickiest pre-requisite before mass string extraction (stage 3).

- **New `web/src/i18n/format.ts`**: `timeAgo`, `europeanDate`, `duration`, `expiresIn`, `mass`, `abbreviateValue`, `jumps`. Strings come from the locale files (added `time` / `duration` / `share` / `mass` keys, with German translations).
- **Migrated call sites** (removed their local copies):
  - Toolbar — checked-at label, online-status tooltip age, proximity-chip jumps
  - AdminPage — `formatRelative` (6 sites across UsersTab / MapsTab / UsersReport / AuditTab)
  - SignaturePane — `elapsed` duration
  - WHTypeInfo — wormhole `mass`
  - KillboardPane — ISK abbreviation
  - MapSidebar — share-link expiry
  - A0Pane + UserStatsModal — jump counts / "today" / "Nd ago"
- **Bug fix**: proper pluralization fixes the long-standing "1 jumps" → "1 jump".

## Behavior
Output is preserved. One intentional minor unification: very recent timestamps now read "just now" under 5s where a couple of sites previously showed "Ns ago".

## Verification
- `yarn build` (`tsc -b` + Vite) passes. Typed `t()` keys check out, including the `_one`/`_other` plural for `units.jumps`.