### PR TITLE
i18n stage 3 (part 1): Toolbar + dialogs

### DIFF
--- a/web/src/components/ui/ConfirmModal.tsx
+++ b/web/src/components/ui/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 
 const SKIP_KEY = 'nexum.skipDeleteConfirm';
 
@@ -15,8 +16,13 @@ interface Props {
   showDontAskAgain?: boolean;
 }
 
-export function ConfirmModal({ message, onConfirm, onCancel, confirmLabel = 'Delete', showDontAskAgain = true }: Props) {
+export function ConfirmModal({ message, onConfirm, onCancel, confirmLabel, showDontAskAgain = true }: Props) {
+  const { t } = useTranslation();
   const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  // No custom label → the default "delete" action, which gets danger styling.
+  const isDelete = confirmLabel === undefined;
+  const label = confirmLabel ?? t('actions.delete');
 
   const handleConfirm = () => {
     if (showDontAskAgain && dontShowAgain) localStorage.setItem(SKIP_KEY, 'true');
@@ -27,7 +33,7 @@ export function ConfirmModal({ message, onConfirm, onCancel, confirmLabel = 'Del
     <div className="modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
       <div className="modal confirm-modal">
         <div className="modal__header">
-          <h2 className="modal__title">Are you sure?</h2>
+          <h2 className="modal__title">{t('confirm.title')}</h2>
         </div>
         <div className="modal__body">
           <p className="confirm-modal__message">{message}</p>
@@ -39,16 +45,16 @@ export function ConfirmModal({ message, onConfirm, onCancel, confirmLabel = 'Del
                 checked={dontShowAgain}
                 onChange={(e) => setDontShowAgain(e.target.checked)}
               />
-              Don't show this again
+              {t('confirm.dontShowAgain')}
             </label>
           )}
           <div className="modal__actions">
-            <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
+            <button className="btn btn--ghost" onClick={onCancel}>{t('actions.cancel')}</button>
             <button
-              className={confirmLabel === 'Delete' ? 'btn btn--danger' : 'btn btn--primary'}
+              className={isDelete ? 'btn btn--danger' : 'btn btn--primary'}
               onClick={handleConfirm}
             >
-              {confirmLabel}
+              {label}
             </button>
           </div>
         </div>

--- a/web/src/components/ui/CreateMapModal.tsx
+++ b/web/src/components/ui/CreateMapModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { XIcon } from '@phosphor-icons/react';
 import { api } from '../../api/client';
 import { useMapStore } from '../../store/mapStore';
@@ -21,6 +22,7 @@ const MAX_REGION_RESULTS = 8;
 // systems + stargates (POST /api/maps/from-region). Replaces the old dual
 // "+ Personal/Corp Map" buttons and the name PromptModal.
 export function CreateMapModal({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
   const maps         = useMapStore((s) => s.maps);
   const maxMaps      = useMapStore((s) => s.maxMaps);
   const maxCorpMaps  = useMapStore((s) => s.maxCorpMaps);
@@ -81,13 +83,13 @@ export function CreateMapModal({ onClose }: { onClose: () => void }) {
       const trimmed = name.trim();
       if (region) {
         await createFromRegion(region.id, trimmed, isCorp);
-        toast.success(`Created "${trimmed}" from ${region.name}`);
+        toast.success(t('createMap.created', { name: trimmed, region: region.name }));
       } else {
         await createMap(trimmed, isCorp);
       }
       onClose();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to create map');
+      setError(e instanceof Error ? e.message : t('createMap.createFailed'));
     } finally {
       setBusy(false);
     }
@@ -97,20 +99,20 @@ export function CreateMapModal({ onClose }: { onClose: () => void }) {
     <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div className="modal" role="dialog" aria-modal="true">
         <div className="modal__header">
-          <h2 className="modal__title">New Map</h2>
-          <button className="icon-btn" onClick={onClose} aria-label="Close">
+          <h2 className="modal__title">{t('createMap.title')}</h2>
+          <button className="icon-btn" onClick={onClose} aria-label={t('actions.close')}>
             <XIcon size={16} weight="bold" />
           </button>
         </div>
 
         <div className="modal__body">
           <label className="field">
-            <span>Map name</span>
+            <span>{t('createMap.mapName')}</span>
             <input
               type="text"
               value={name}
               autoFocus
-              placeholder="New Map"
+              placeholder={t('createMap.namePlaceholder')}
               onChange={(e) => { setName(e.target.value); setNameTouched(true); }}
               maxLength={200}
             />
@@ -118,29 +120,29 @@ export function CreateMapModal({ onClose }: { onClose: () => void }) {
 
           {canCorp && (
             <label className="field">
-              <span>Type</span>
+              <span>{t('createMap.type')}</span>
               <select value={isCorp ? 'corp' : 'personal'} onChange={(e) => setIsCorp(e.target.value === 'corp')}>
-                <option value="personal">Personal</option>
-                <option value="corp">Corp</option>
+                <option value="personal">{t('createMap.personal')}</option>
+                <option value="corp">{t('createMap.corp')}</option>
               </select>
             </label>
           )}
 
           <div className="field">
-            <span>Region (optional — blank for an empty map)</span>
+            <span>{t('createMap.regionLabel')}</span>
             <div className="search-field">
               <div className="search-field__wrap">
                 <input
                   type="text"
                   className={`search-field__input${region ? ' search-field__input--selected' : ''}`}
                   value={query}
-                  placeholder="Type to search regions…"
+                  placeholder={t('createMap.regionPlaceholder')}
                   autoComplete="off"
                   readOnly={!!region}
                   onChange={(e) => setQuery(e.target.value)}
                 />
                 {region && (
-                  <button type="button" className="search-field__clear" onClick={clearRegion} aria-label="Clear region">
+                  <button type="button" className="search-field__clear" onClick={clearRegion} aria-label={t('createMap.clearRegion')}>
                     ✕
                   </button>
                 )}
@@ -156,7 +158,7 @@ export function CreateMapModal({ onClose }: { onClose: () => void }) {
                       onMouseDown={(e) => { e.preventDefault(); selectRegion(r); }}
                     >
                       <span>{r.name}</span>
-                      <span className="search-results__class">{r.systemCount} systems</span>
+                      <span className="search-results__class">{t('units.systems', { count: r.systemCount })}</span>
                     </li>
                   ))}
                 </ul>
@@ -166,21 +168,20 @@ export function CreateMapModal({ onClose }: { onClose: () => void }) {
 
           {region && (
             <div className="map-sidebar__hint">
-              Seeds {region.systemCount} systems from {region.name}, positioned by their
-              in-game coordinates with all stargate links.
+              {t('createMap.regionHint', { count: region.systemCount, region: region.name })}
             </div>
           )}
           {limitForChoice && (
             <div className="map-sidebar__hint map-sidebar__hint--error">
-              {isCorp ? `Corp map limit reached (${maxCorpMaps}).` : `Personal map limit reached (${maxMaps}).`}
+              {isCorp ? t('createMap.corpLimit', { max: maxCorpMaps }) : t('createMap.personalLimit', { max: maxMaps })}
             </div>
           )}
           {error && <div className="map-sidebar__hint map-sidebar__hint--error">{error}</div>}
 
           <div className="modal__actions">
-            <button type="button" className="btn btn--ghost" onClick={onClose} disabled={busy}>Cancel</button>
+            <button type="button" className="btn btn--ghost" onClick={onClose} disabled={busy}>{t('actions.cancel')}</button>
             <button type="button" className="btn btn--primary" onClick={submit} disabled={!canSubmit}>
-              {busy ? 'Creating…' : 'Create map'}
+              {busy ? t('createMap.creating') : t('createMap.create')}
             </button>
           </div>
         </div>

--- a/web/src/components/ui/PromptModal.tsx
+++ b/web/src/components/ui/PromptModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 
 interface Props {
   title:         string;
@@ -13,7 +14,8 @@ interface Props {
 
 // Modal replacement for native prompt() — same purpose but composable with
 // the rest of the app's styling and z-index stacking.
-export function PromptModal({ title, message, defaultValue = '', placeholder, confirmLabel = 'OK', onConfirm, onCancel }: Props) {
+export function PromptModal({ title, message, defaultValue = '', placeholder, confirmLabel, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation();
   const [value, setValue] = useState(defaultValue);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -48,9 +50,9 @@ export function PromptModal({ title, message, defaultValue = '', placeholder, co
             style={{ width: '100%', marginTop: 8 }}
           />
           <div className="modal__actions">
-            <button className="btn btn--ghost" onClick={onCancel}>Cancel</button>
+            <button className="btn btn--ghost" onClick={onCancel}>{t('actions.cancel')}</button>
             <button className="btn btn--primary" onClick={submit} disabled={!value.trim()}>
-              {confirmLabel}
+              {confirmLabel ?? t('actions.ok')}
             </button>
           </div>
         </div>

--- a/web/src/components/ui/ProximityOptInModal.tsx
+++ b/web/src/components/ui/ProximityOptInModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Trans, useTranslation } from 'react-i18next';
 import { notifyPermissionChanged } from '../../hooks/useNotificationPermission';
 
 const ASKED_KEY = 'nexum.proximityOptInAsked';
@@ -14,6 +15,7 @@ const ASKED_KEY = 'nexum.proximityOptInAsked';
  *  - The user has already responded to this prompt (tracked in localStorage)
  */
 export function ProximityOptInModal() {
+  const { t } = useTranslation();
   const [show, setShow] = useState(false);
 
   useEffect(() => {
@@ -55,26 +57,19 @@ export function ProximityOptInModal() {
     <div className="modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) dismiss(); }}>
       <div className="modal" role="dialog" aria-modal="true">
         <div className="modal__header">
-          <h2 className="modal__title">Enable threat alerts?</h2>
+          <h2 className="modal__title">{t('proximityOptIn.title')}</h2>
         </div>
 
         <div className="modal__body proximity-optin__body">
-          <p>
-            New Eden is a dangerous place. Nexum can give you a desktop notification and
-            a short audio ping when you’re within a few jumps of an active <strong>incursion</strong>
-            {' '}or <strong>insurgency</strong> — so you don’t blindly autopilot into one.
-          </p>
-          <p className="proximity-optin__sub">
-            You can change the threshold or turn this off at any time in <em>Map Options →
-            Proximity Alerts</em>.
-          </p>
+          <p><Trans i18nKey="proximityOptIn.body" /></p>
+          <p className="proximity-optin__sub"><Trans i18nKey="proximityOptIn.sub" /></p>
 
           <div className="modal__actions">
             <button type="button" className="btn btn--ghost" onClick={dismiss}>
-              Maybe later
+              {t('proximityOptIn.maybeLater')}
             </button>
             <button type="button" className="btn btn--primary" onClick={enable}>
-              Enable notifications
+              {t('proximityOptIn.enable')}
             </button>
           </div>
         </div>

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -114,15 +114,15 @@ function useEveServerStatus(): EveStatus | null {
 // orphan session ("online for 6 hours but I crashed at lunchtime") is
 // instantly recognisable from the tooltip alone.
 function onlineTooltip(t: TFunction, online: boolean | null, lastLoginIso: string | null): string {
-  if (online === false) return 'Offline';
-  if (online === null)  return 'Status unknown';
-  if (!lastLoginIso)    return 'Online in EVE';
+  if (online === false) return t('toolbar.online.offline');
+  if (online === null)  return t('toolbar.online.statusUnknown');
+  if (!lastLoginIso)    return t('toolbar.online.onlineInEve');
   const ts = new Date(lastLoginIso);
-  if (!Number.isFinite(ts.getTime())) return 'Online in EVE';
+  if (!Number.isFinite(ts.getTime())) return t('toolbar.online.onlineInEve');
   // DD-MM-YYYY HH:MM UTC matches the rest of the app's date display.
   const pad = (n: number) => String(n).padStart(2, '0');
   const stamp = `${pad(ts.getUTCDate())}-${pad(ts.getUTCMonth() + 1)}-${ts.getUTCFullYear()} ${pad(ts.getUTCHours())}:${pad(ts.getUTCMinutes())} UTC`;
-  return `Online in EVE since ${stamp} (${timeAgo(t, ts)})`;
+  return t('toolbar.online.onlineSince', { stamp, age: timeAgo(t, ts) });
 }
 
 // Self-contained "checked Xs ago" label — owns its own 5 s tick so the rest of
@@ -134,7 +134,7 @@ function CheckedAtLabel({ checkedAt }: { checkedAt: Date }) {
     const id = setInterval(() => setTick((n) => n + 1), 5_000);
     return () => clearInterval(id);
   }, []);
-  return <span className="toolbar__checked-at">checked {timeAgo(t, checkedAt)}</span>;
+  return <span className="toolbar__checked-at">{t('toolbar.checkedAgo', { time: timeAgo(t, checkedAt) })}</span>;
 }
 
 // Persistent indicator for the nearest live threat (incursion / insurgency).
@@ -148,14 +148,14 @@ function ProximityChip() {
   // permanent "20 jumps — …" noise on most maps.
   if (!nearest || nearest.jumps > threshold) return null;
   const { label, Icon }: { label: string; Icon: PhosphorIcon } =
-    nearest.kind === 'incursion'   ? { label: 'Incursion',   Icon: WarningIcon } :
-    nearest.kind === 'insurgency'  ? { label: 'Insurgency',  Icon: SkullIcon } :
-    nearest.kind === 'hostile-sov' ? { label: 'Hostile sov', Icon: XCircleIcon } :
-    { label: 'Threat', Icon: QuestionIcon };
+    nearest.kind === 'incursion'   ? { label: t('toolbar.proximity.incursion'),  Icon: WarningIcon } :
+    nearest.kind === 'insurgency'  ? { label: t('toolbar.proximity.insurgency'), Icon: SkullIcon } :
+    nearest.kind === 'hostile-sov' ? { label: t('toolbar.proximity.hostileSov'), Icon: XCircleIcon } :
+    { label: t('toolbar.proximity.threat'), Icon: QuestionIcon };
   return (
     <span
       className="toolbar__proximity toolbar__proximity--alert"
-      data-tooltip={`Closest ${label.toLowerCase()} system`}
+      data-tooltip={t('toolbar.proximity.closest', { label: label.toLowerCase() })}
     >
       <span className="toolbar__proximity-icon"><Icon size={14} weight="bold" /></span>
       <span className="toolbar__proximity-text">
@@ -222,30 +222,30 @@ export function Toolbar() {
         <button
           className="toolbar__map-name-btn"
           onClick={() => setShowMaps((v) => !v)}
-          title="Switch map"
+          title={t('toolbar.switchMap')}
         >
           {(() => {
             const active = maps.find((m) => m.id === activeMapId);
             if (!active) return null;
             if (active.sharedWithMe) {
-              return <span className="toolbar__map-type toolbar__map-type--shared">Shared</span>;
+              return <span className="toolbar__map-type toolbar__map-type--shared">{t('toolbar.mapType.shared')}</span>;
             }
             if (!user?.corpMode) return null;
             return active.isCorpMap
-              ? <span className="toolbar__map-type toolbar__map-type--corp">Corp</span>
-              : <span className="toolbar__map-type toolbar__map-type--solo">Solo</span>;
+              ? <span className="toolbar__map-type toolbar__map-type--corp">{t('toolbar.mapType.corp')}</span>
+              : <span className="toolbar__map-type toolbar__map-type--solo">{t('toolbar.mapType.solo')}</span>;
           })()}
-          {mapName || 'No Map'}
+          {mapName || t('toolbar.noMap')}
           <span className="toolbar__caret">▾</span>
         </button>
 
         {mapLocked && (
           <span
             className="toolbar__locked-chip"
-            data-tooltip="Map is locked — systems and connections are frozen. Signatures, structures, and notes can still be edited."
+            data-tooltip={t('toolbar.lockedTooltip')}
           >
             <span className="toolbar__locked-icon">🔒</span>
-            Locked
+            {t('toolbar.locked')}
           </span>
         )}
 
@@ -265,11 +265,11 @@ export function Toolbar() {
                 onClick={async () => { setShowMaps(false); await switchMap(m.id); requestFitView(); }}
               >
                 {m.sharedWithMe
-                  ? <span className="map-dropdown__badge map-dropdown__badge--shared">Shared</span>
+                  ? <span className="map-dropdown__badge map-dropdown__badge--shared">{t('toolbar.mapType.shared')}</span>
                   : user?.corpMode && !m.isCorpMap
-                    ? <span className="map-dropdown__badge map-dropdown__badge--solo">Solo</span>
+                    ? <span className="map-dropdown__badge map-dropdown__badge--solo">{t('toolbar.mapType.solo')}</span>
                     : null}
-                {!m.sharedWithMe && m.isCorpMap && <span className="map-dropdown__badge map-dropdown__badge--corp">Corp</span>}
+                {!m.sharedWithMe && m.isCorpMap && <span className="map-dropdown__badge map-dropdown__badge--corp">{t('toolbar.mapType.corp')}</span>}
                 {m.locked    && <span className="map-dropdown__badge map-dropdown__badge--lock">🔒</span>}
                 {m.name}
               </button>
@@ -277,19 +277,19 @@ export function Toolbar() {
             <div className="map-dropdown__divider" />
             <span
               className={`map-dropdown__new-wrap${noCreateOption ? ' map-dropdown__new-wrap--disabled' : ''}`}
-              data-disabled-reason={noCreateOption ? 'Map limit reached' : undefined}
+              data-disabled-reason={noCreateOption ? t('toolbar.mapLimitReached') : undefined}
             >
               <button
                 className="map-dropdown__item map-dropdown__item--action"
                 onClick={() => { setShowMaps(false); setShowCreate(true); }}
                 disabled={noCreateOption}
               >
-                + New Map
+                {t('toolbar.newMap')}
               </button>
             </span>
             {canManageMaps && maps.length > 1 && !maps.find((m) => m.id === activeMapId)?.sharedWithMe && (
               <button className="map-dropdown__item map-dropdown__item--danger" onClick={() => { setShowMaps(false); setDeleteConfirm(true); }}>
-                Delete this map
+                {t('toolbar.deleteThisMap')}
               </button>
             )}
           </div>
@@ -298,7 +298,7 @@ export function Toolbar() {
 
       {/* Map name edit */}
       <div className="toolbar__option">
-        <label className="toolbar__option-label" htmlFor="map-name">Name</label>
+        <label className="toolbar__option-label" htmlFor="map-name">{t('toolbar.name')}</label>
         <input
           id="map-name"
           className="toolbar__map-name"
@@ -312,11 +312,11 @@ export function Toolbar() {
       <div className="toolbar__spacer" />
 
       <div className="toolbar__stats">
-        <span className="toolbar__stat" data-tooltip="Total Systems">
+        <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>
           <PlanetIcon size={16} weight="regular" />
           <span className="toolbar__stat-count">{systemCount}</span>
         </span>
-        <span className="toolbar__stat" data-tooltip="Total Connections">
+        <span className="toolbar__stat" data-tooltip={t('toolbar.totalConnections')}>
           <LinkSimpleIcon size={16} weight="regular" />
           <span className="toolbar__stat-count">{connectionCount}</span>
         </span>
@@ -330,8 +330,8 @@ export function Toolbar() {
         <button
           className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
           onClick={() => { window.location.hash = '#/admin/users'; }}
-          data-tooltip="Admin"
-          aria-label="Admin"
+          data-tooltip={t('toolbar.admin')}
+          aria-label={t('toolbar.admin')}
         >
           <ShieldStarIcon size={18} weight="regular" />
         </button>
@@ -339,8 +339,8 @@ export function Toolbar() {
       <button
         className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
         onClick={() => setShowStats(true)}
-        data-tooltip="User stats"
-        aria-label="User stats"
+        data-tooltip={t('toolbar.userStats')}
+        aria-label={t('toolbar.userStats')}
       >
         <ChartBarIcon size={18} weight="regular" />
       </button>
@@ -349,8 +349,8 @@ export function Toolbar() {
         className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
         onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
         aria-pressed={mapOptionsOpen}
-        data-tooltip="Map options"
-        aria-label="Map options"
+        data-tooltip={t('toolbar.mapOptions')}
+        aria-label={t('toolbar.mapOptions')}
       >
         <SlidersHorizontalIcon size={18} weight="regular" />
       </button>
@@ -365,8 +365,8 @@ export function Toolbar() {
               eveStatus.serverUp ? ' toolbar__status-dot--on' : ' toolbar__status-dot--off'
             }`}
             data-tooltip={
-              eveStatus == null ? 'Checking…' :
-              eveStatus.serverUp ? 'Tranquility: Online' : 'Tranquility: Offline'
+              eveStatus == null ? t('toolbar.checking') :
+              eveStatus.serverUp ? t('toolbar.tqOnline') : t('toolbar.tqOffline')
             }
           />
           <span className="toolbar__server-label">TQ</span>
@@ -383,8 +383,8 @@ export function Toolbar() {
               eveStatus.esiOnline ? ' toolbar__status-dot--on' : ' toolbar__status-dot--off'
             }`}
             data-tooltip={
-              eveStatus == null ? 'Checking…' :
-              eveStatus.esiOnline ? 'ESI: Online' : 'ESI: Offline'
+              eveStatus == null ? t('toolbar.checking') :
+              eveStatus.esiOnline ? t('toolbar.esiOnline') : t('toolbar.esiOffline')
             }
           />
           <span className="toolbar__server-label">ESI</span>
@@ -395,10 +395,10 @@ export function Toolbar() {
         className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
         onClick={() => setTrackJumps(!trackJumps)}
         aria-pressed={trackJumps}
-        aria-label={trackJumps ? 'Track jumps: on' : 'Track jumps: off'}
+        aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
         data-tooltip={trackJumps
-          ? 'Tracking jumps — new systems are added as you move'
-          : 'Not tracking jumps — only existing systems get the you-are-here indicator'}
+          ? t('toolbar.trackJumpsTooltipOn')
+          : t('toolbar.trackJumpsTooltipOff')}
       >
         <FootprintsIcon size={18} weight="regular" />
         <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
@@ -438,7 +438,7 @@ export function Toolbar() {
               {user.corpMode && (
                 <span
                   className={`role-badge role-badge--${user.role}`}
-                  title={`Role: ${user.role}`}
+                  title={t('toolbar.role', { role: user.role })}
                 >
                   {user.role}
                 </span>
@@ -449,8 +449,8 @@ export function Toolbar() {
           <button
             className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
             onClick={logout}
-            data-tooltip="Sign out"
-            aria-label="Sign out"
+            data-tooltip={t('toolbar.signOut')}
+            aria-label={t('toolbar.signOut')}
           >
             <SignOutIcon size={18} weight="regular" />
           </button>
@@ -462,7 +462,7 @@ export function Toolbar() {
     {showCreate && <CreateMapModal onClose={() => setShowCreate(false)} />}
     {deleteConfirm && (
       <ConfirmModal
-        message={`Delete "${mapName}"? This cannot be undone.`}
+        message={t('toolbar.deleteMapConfirm', { name: mapName })}
         onCancel={() => setDeleteConfirm(false)}
         onConfirm={async () => {
           setDeleteConfirm(false);

--- a/web/src/components/ui/UserStatsModal.tsx
+++ b/web/src/components/ui/UserStatsModal.tsx
@@ -101,37 +101,54 @@ function SigSparkline({ values }: { values: number[] }) {
   );
 }
 
-const PERIODS: { key: StatPeriod; label: string }[] = [
-  { key: 'day',     label: 'Today' },
-  { key: 'week',    label: 'This Week' },
-  { key: 'month',   label: 'This Month' },
-  { key: 'year',    label: 'This Year' },
-  { key: 'forever', label: 'All Time' },
+const PERIODS: { key: StatPeriod }[] = [
+  { key: 'day' },
+  { key: 'week' },
+  { key: 'month' },
+  { key: 'year' },
+  { key: 'forever' },
 ];
 
-const SIG_ROWS: { key: keyof SigBreakdown; label: string }[] = [
-  { key: 'wormhole', label: 'Wormhole' },
-  { key: 'data',     label: 'Data' },
-  { key: 'relic',    label: 'Relic' },
-  { key: 'gas',      label: 'Gas' },
-  { key: 'ore',      label: 'Ore' },
-  { key: 'combat',   label: 'Combat' },
+const SIG_ROWS: { key: keyof SigBreakdown }[] = [
+  { key: 'wormhole' },
+  { key: 'data' },
+  { key: 'relic' },
+  { key: 'gas' },
+  { key: 'ore' },
+  { key: 'combat' },
 ];
 
 interface Props { onClose: () => void; }
 
 export function UserStatsModal({ onClose }: Props) {
+  const { t } = useTranslation();
   const [period, setPeriod] = useState<StatPeriod>('day');
   const { stats, loading, error } = useStats(true);
 
   const current = stats?.[period];
+
+  const periodLabels: Record<StatPeriod, string> = {
+    day:     t('stats.period.day'),
+    week:    t('stats.period.week'),
+    month:   t('stats.period.month'),
+    year:    t('stats.period.year'),
+    forever: t('stats.period.forever'),
+  };
+  const sigLabels: Record<string, string> = {
+    wormhole: t('sigType.wormhole'),
+    data:     t('sigType.data'),
+    relic:    t('sigType.relic'),
+    gas:      t('sigType.gas'),
+    ore:      t('sigType.ore'),
+    combat:   t('sigType.combat'),
+  };
 
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal stats-modal" onClick={(e) => e.stopPropagation()}>
 
         <div className="modal__header">
-          <h2 className="modal__title">User Stats</h2>
+          <h2 className="modal__title">{t('stats.title')}</h2>
           <button className="modal__close" onClick={onClose}><XIcon size={14} weight="bold" /></button>
         </div>
 
@@ -142,13 +159,13 @@ export function UserStatsModal({ onClose }: Props) {
               className={`stats-modal__period-btn${period === p.key ? ' stats-modal__period-btn--active' : ''}`}
               onClick={() => setPeriod(p.key)}
             >
-              {p.label}
+              {periodLabels[p.key]}
             </button>
           ))}
         </div>
 
         <div className="modal__body">
-          {loading && <div className="stats-modal__loading">Loading…</div>}
+          {loading && <div className="stats-modal__loading">{t('stats.loading')}</div>}
           {error   && <div className="stats-modal__error">{error}</div>}
 
           {current && (
@@ -156,27 +173,27 @@ export function UserStatsModal({ onClose }: Props) {
               <div className="stats-modal__summary">
                 <div className="stats-modal__card">
                   <span className="stats-modal__card-value">{current.jumps.toLocaleString()}</span>
-                  <span className="stats-modal__card-label">Jumps</span>
+                  <span className="stats-modal__card-label">{t('stats.jumps')}</span>
                 </div>
                 <div className="stats-modal__card">
                   <span className="stats-modal__card-value">{current.signatures.total.toLocaleString()}</span>
-                  <span className="stats-modal__card-label">Signatures</span>
+                  <span className="stats-modal__card-label">{t('stats.signatures')}</span>
                 </div>
               </div>
 
               {stats?.daily && stats.daily.some((v) => v > 0) && (
                 <>
-                  <h3 className="stats-modal__section-title">Daily activity — last 30 days</h3>
+                  <h3 className="stats-modal__section-title">{t('stats.dailyActivity')}</h3>
                   <SigSparkline values={stats.daily} />
                 </>
               )}
 
-              <h3 className="stats-modal__section-title">Signatures by type</h3>
+              <h3 className="stats-modal__section-title">{t('stats.byType')}</h3>
               <table className="stats-modal__table">
                 <thead>
                   <tr className="stats-modal__head-row">
-                    <th className="stats-modal__th stats-modal__th--type">Type</th>
-                    <th className="stats-modal__th stats-modal__th--count">Count</th>
+                    <th className="stats-modal__th stats-modal__th--type">{t('stats.type')}</th>
+                    <th className="stats-modal__th stats-modal__th--count">{t('stats.count')}</th>
                     <th className="stats-modal__th stats-modal__th--pct">%</th>
                     <th className="stats-modal__th stats-modal__th--bar" />
                   </tr>
@@ -189,7 +206,7 @@ export function UserStatsModal({ onClose }: Props) {
                       : 0;
                     return (
                       <tr key={r.key} className="stats-modal__row">
-                        <td className="stats-modal__row-label">{r.label}</td>
+                        <td className="stats-modal__row-label">{sigLabels[r.key]}</td>
                         <td className="stats-modal__row-value">{count.toLocaleString()}</td>
                         <td className="stats-modal__row-pct">{pct}%</td>
                         <td className="stats-modal__row-bar">

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -37,6 +37,10 @@ void i18n
     },
     interpolation: { escapeValue: false }, // React already escapes output
     returnNull: false,
+    // <Trans> renders these inline tags straight from the locale string (no
+    // `components` prop needed) — used for the few sentences with embedded
+    // <strong>/<em> emphasis.
+    react: { transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'em', 'p'] },
   });
 
 export default i18n;

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -7,11 +7,68 @@
     "cancel": "Abbrechen",
     "delete": "Löschen",
     "copy": "Kopieren",
-    "close": "Schließen"
+    "close": "Schließen",
+    "ok": "OK"
+  },
+  "confirm": {
+    "title": "Bist du sicher?",
+    "dontShowAgain": "Nicht erneut anzeigen"
+  },
+  "proximityOptIn": {
+    "title": "Bedrohungswarnungen aktivieren?",
+    "body": "New Eden ist ein gefährlicher Ort. Nexum kann dir eine Desktop-Benachrichtigung und einen kurzen Ton geben, wenn du wenige Sprünge von einer aktiven <strong>Inkursion</strong> oder einem <strong>Aufstand</strong> entfernt bist — damit du nicht blind hineinfliegst.",
+    "sub": "Du kannst den Schwellenwert ändern oder dies jederzeit unter <em>Kartenoptionen → Näherungswarnungen</em> deaktivieren.",
+    "maybeLater": "Vielleicht später",
+    "enable": "Benachrichtigungen aktivieren"
   },
   "units": {
     "jumps_one": "{{count}} Sprung",
-    "jumps_other": "{{count}} Sprünge"
+    "jumps_other": "{{count}} Sprünge",
+    "systems_one": "{{count}} System",
+    "systems_other": "{{count}} Systeme"
+  },
+  "createMap": {
+    "title": "Neue Karte",
+    "mapName": "Kartenname",
+    "namePlaceholder": "Neue Karte",
+    "type": "Typ",
+    "personal": "Persönlich",
+    "corp": "Corp",
+    "regionLabel": "Region (optional — leer für eine leere Karte)",
+    "regionPlaceholder": "Zum Suchen tippen…",
+    "clearRegion": "Region löschen",
+    "regionHint": "Erstellt {{count}} Systeme aus {{region}}, positioniert nach ihren Ingame-Koordinaten mit allen Stargate-Verbindungen.",
+    "corpLimit": "Corp-Kartenlimit erreicht ({{max}}).",
+    "personalLimit": "Persönliches Kartenlimit erreicht ({{max}}).",
+    "createFailed": "Karte konnte nicht erstellt werden",
+    "created": "\"{{name}}\" aus {{region}} erstellt",
+    "creating": "Erstelle…",
+    "create": "Karte erstellen"
+  },
+  "sigType": {
+    "wormhole": "Wurmloch",
+    "data": "Daten",
+    "relic": "Relikt",
+    "gas": "Gas",
+    "ore": "Erz",
+    "combat": "Kampf"
+  },
+  "stats": {
+    "title": "Benutzerstatistik",
+    "loading": "Lädt…",
+    "jumps": "Sprünge",
+    "signatures": "Signaturen",
+    "dailyActivity": "Tägliche Aktivität — letzte 30 Tage",
+    "byType": "Signaturen nach Typ",
+    "type": "Typ",
+    "count": "Anzahl",
+    "period": {
+      "day": "Heute",
+      "week": "Diese Woche",
+      "month": "Dieser Monat",
+      "year": "Dieses Jahr",
+      "forever": "Gesamt"
+    }
   },
   "time": {
     "justNow": "gerade eben",

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -106,7 +106,7 @@
     "mapLimitReached": "Kartenlimit erreicht",
     "newMap": "+ Neue Karte",
     "deleteThisMap": "Diese Karte löschen",
-    "name": "Name",
+    "name": "Kartenname",
     "totalSystems": "Systeme gesamt",
     "totalConnections": "Verbindungen gesamt",
     "admin": "Verwaltung",

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -35,5 +35,51 @@
     "billionKg": "{{value}} Mrd. kg",
     "millionKg": "{{value}} Mio. kg",
     "kg": "{{value}} kg"
+  },
+  "toolbar": {
+    "switchMap": "Karte wechseln",
+    "noMap": "Keine Karte",
+    "mapType": {
+      "shared": "Geteilt",
+      "corp": "Corp",
+      "solo": "Solo"
+    },
+    "lockedTooltip": "Karte ist gesperrt — Systeme und Verbindungen sind eingefroren. Signaturen, Strukturen und Notizen können weiterhin bearbeitet werden.",
+    "locked": "Gesperrt",
+    "mapLimitReached": "Kartenlimit erreicht",
+    "newMap": "+ Neue Karte",
+    "deleteThisMap": "Diese Karte löschen",
+    "name": "Name",
+    "totalSystems": "Systeme gesamt",
+    "totalConnections": "Verbindungen gesamt",
+    "admin": "Admin",
+    "userStats": "Benutzerstatistik",
+    "mapOptions": "Kartenoptionen",
+    "checking": "Prüfe…",
+    "tqOnline": "Tranquility: Online",
+    "tqOffline": "Tranquility: Offline",
+    "esiOnline": "ESI: Online",
+    "esiOffline": "ESI: Offline",
+    "trackJumpsOn": "Sprünge verfolgen: an",
+    "trackJumpsOff": "Sprünge verfolgen: aus",
+    "trackJumpsTooltipOn": "Sprünge werden verfolgt — neue Systeme werden hinzugefügt, während du dich bewegst",
+    "trackJumpsTooltipOff": "Sprünge werden nicht verfolgt — nur vorhandene Systeme erhalten die Standortanzeige",
+    "signOut": "Abmelden",
+    "role": "Rolle: {{role}}",
+    "checkedAgo": "geprüft {{time}}",
+    "deleteMapConfirm": "\"{{name}}\" löschen? Dies kann nicht rückgängig gemacht werden.",
+    "online": {
+      "offline": "Offline",
+      "statusUnknown": "Status unbekannt",
+      "onlineInEve": "In EVE online",
+      "onlineSince": "In EVE online seit {{stamp}} ({{age}})"
+    },
+    "proximity": {
+      "incursion": "Inkursion",
+      "insurgency": "Aufstand",
+      "hostileSov": "Feindliche Sov",
+      "threat": "Bedrohung",
+      "closest": "Nächstes {{label}}-System"
+    }
   }
 }

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -109,7 +109,7 @@
     "name": "Name",
     "totalSystems": "Systeme gesamt",
     "totalConnections": "Verbindungen gesamt",
-    "admin": "Admin",
+    "admin": "Verwaltung",
     "userStats": "Benutzerstatistik",
     "mapOptions": "Kartenoptionen",
     "checking": "Prüfe…",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -7,11 +7,68 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "copy": "Copy",
-    "close": "Close"
+    "close": "Close",
+    "ok": "OK"
+  },
+  "confirm": {
+    "title": "Are you sure?",
+    "dontShowAgain": "Don't show this again"
+  },
+  "proximityOptIn": {
+    "title": "Enable threat alerts?",
+    "body": "New Eden is a dangerous place. Nexum can give you a desktop notification and a short audio ping when you're within a few jumps of an active <strong>incursion</strong> or <strong>insurgency</strong> — so you don't blindly autopilot into one.",
+    "sub": "You can change the threshold or turn this off at any time in <em>Map Options → Proximity Alerts</em>.",
+    "maybeLater": "Maybe later",
+    "enable": "Enable notifications"
   },
   "units": {
     "jumps_one": "{{count}} jump",
-    "jumps_other": "{{count}} jumps"
+    "jumps_other": "{{count}} jumps",
+    "systems_one": "{{count}} system",
+    "systems_other": "{{count}} systems"
+  },
+  "createMap": {
+    "title": "New Map",
+    "mapName": "Map name",
+    "namePlaceholder": "New Map",
+    "type": "Type",
+    "personal": "Personal",
+    "corp": "Corp",
+    "regionLabel": "Region (optional — blank for an empty map)",
+    "regionPlaceholder": "Type to search regions…",
+    "clearRegion": "Clear region",
+    "regionHint": "Seeds {{count}} systems from {{region}}, positioned by their in-game coordinates with all stargate links.",
+    "corpLimit": "Corp map limit reached ({{max}}).",
+    "personalLimit": "Personal map limit reached ({{max}}).",
+    "createFailed": "Failed to create map",
+    "created": "Created \"{{name}}\" from {{region}}",
+    "creating": "Creating…",
+    "create": "Create map"
+  },
+  "sigType": {
+    "wormhole": "Wormhole",
+    "data": "Data",
+    "relic": "Relic",
+    "gas": "Gas",
+    "ore": "Ore",
+    "combat": "Combat"
+  },
+  "stats": {
+    "title": "User Stats",
+    "loading": "Loading…",
+    "jumps": "Jumps",
+    "signatures": "Signatures",
+    "dailyActivity": "Daily activity — last 30 days",
+    "byType": "Signatures by type",
+    "type": "Type",
+    "count": "Count",
+    "period": {
+      "day": "Today",
+      "week": "This Week",
+      "month": "This Month",
+      "year": "This Year",
+      "forever": "All Time"
+    }
   },
   "time": {
     "justNow": "just now",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -35,5 +35,51 @@
     "billionKg": "{{value}} B kg",
     "millionKg": "{{value}} M kg",
     "kg": "{{value}} kg"
+  },
+  "toolbar": {
+    "switchMap": "Switch map",
+    "noMap": "No Map",
+    "mapType": {
+      "shared": "Shared",
+      "corp": "Corp",
+      "solo": "Solo"
+    },
+    "lockedTooltip": "Map is locked — systems and connections are frozen. Signatures, structures, and notes can still be edited.",
+    "locked": "Locked",
+    "mapLimitReached": "Map limit reached",
+    "newMap": "+ New Map",
+    "deleteThisMap": "Delete this map",
+    "name": "Name",
+    "totalSystems": "Total Systems",
+    "totalConnections": "Total Connections",
+    "admin": "Admin",
+    "userStats": "User stats",
+    "mapOptions": "Map options",
+    "checking": "Checking…",
+    "tqOnline": "Tranquility: Online",
+    "tqOffline": "Tranquility: Offline",
+    "esiOnline": "ESI: Online",
+    "esiOffline": "ESI: Offline",
+    "trackJumpsOn": "Track jumps: on",
+    "trackJumpsOff": "Track jumps: off",
+    "trackJumpsTooltipOn": "Tracking jumps — new systems are added as you move",
+    "trackJumpsTooltipOff": "Not tracking jumps — only existing systems get the you-are-here indicator",
+    "signOut": "Sign out",
+    "role": "Role: {{role}}",
+    "checkedAgo": "checked {{time}}",
+    "deleteMapConfirm": "Delete \"{{name}}\"? This cannot be undone.",
+    "online": {
+      "offline": "Offline",
+      "statusUnknown": "Status unknown",
+      "onlineInEve": "Online in EVE",
+      "onlineSince": "Online in EVE since {{stamp}} ({{age}})"
+    },
+    "proximity": {
+      "incursion": "Incursion",
+      "insurgency": "Insurgency",
+      "hostileSov": "Hostile sov",
+      "threat": "Threat",
+      "closest": "Closest {{label}} system"
+    }
   }
 }


### PR DESCRIPTION
Stage 3 of localization — extracting hardcoded UI strings into `common.json` (English + German). Stage 3 is being delivered as **a series of PRs** into `localization`; this is **part 1: the Toolbar + dialogs.**

## In this PR
- **Toolbar** — full top bar (map switcher, Shared/Corp/Solo badges, stat tooltips, TQ/ESI status, admin/stats/options/sign-out controls, online + proximity, role badge, checked-at, delete confirm).
- **Dialogs** — ConfirmModal, PromptModal, ProximityOptInModal (rich text via `<Trans>`), UserStatsModal, CreateMapModal.
- Infra: `<Trans>` enabled for inline `<strong>/<em>`; shared `sigType` namespace; `units.systems` plural; `actions.ok`.

## Follow-up PRs (not in this one)
MapSidebar · remaining modals (AddSystem, CommandPalette) · panels & panes · AdminPage · LandingPage + map components + leftovers.

## Conventions
- EVE-canonical data (system/ship/region/character names, WH codes/classes, TQ/ESI) left untranslated.
- Keys type-checked against the English resource; plurals via `_one`/`_other`.

## Verification
`yarn build` (`tsc -b` + Vite) passes.
