### PR TITLE
i18n stage 3: extract pane strings (Activity, A0, Notes)

### DIFF
--- a/web/src/components/ui/A0Pane.tsx
+++ b/web/src/components/ui/A0Pane.tsx
@@ -46,22 +46,22 @@ export function A0Pane() {
   if (!canRoute) {
     return (
       <div className="scout-pane__empty">
-        Sign in and dock in K-space to see nearby A0 systems.
+        {t('a0.signIn')}
       </div>
     );
   }
 
   if (all.length === 0 || (closest.length === 0 && Object.keys(routes).length === 0)) {
-    return <div className="scout-pane__empty">Computing routes…</div>;
+    return <div className="scout-pane__empty">{t('a0.computing')}</div>;
   }
 
   if (closest.length === 0) {
-    return <div className="scout-pane__empty">No A0 systems reachable.</div>;
+    return <div className="scout-pane__empty">{t('a0.noneReachable')}</div>;
   }
 
   return (
     <div className="scout-pane">
-      <div className="scout-pane__note">Showing the {TOP_N} closest A0 systems.</div>
+      <div className="scout-pane__note">{t('a0.showing', { count: TOP_N })}</div>
       {closest.map(s => {
         const route   = routes[String(s.id)];
         const isOpen  = expanded.has(s.id);
@@ -79,8 +79,8 @@ export function A0Pane() {
                 type="button"
                 className="sys-btn scout-row__btn scout-row__btn--icon"
                 onClick={() => setWaypoint(s.id, s.name, true)}
-                aria-label="Set Destination"
-                data-tooltip="Set Destination"
+                aria-label={t('waypoint.setDestination')}
+                data-tooltip={t('waypoint.setDestination')}
               >
                 <MapPinSimpleIcon size={14} weight="regular" color="#3ddc84" />
               </button>
@@ -88,8 +88,8 @@ export function A0Pane() {
                 type="button"
                 className="sys-btn scout-row__btn scout-row__btn--icon"
                 onClick={() => setWaypoint(s.id, s.name, false)}
-                aria-label="Add Waypoint"
-                data-tooltip="Add Waypoint"
+                aria-label={t('waypoint.addWaypoint')}
+                data-tooltip={t('waypoint.addWaypoint')}
               >
                 <PathIcon size={14} weight="regular" color="#5a9af8" />
               </button>
@@ -100,7 +100,10 @@ export function A0Pane() {
                   onClick={() => toggleExpanded(s.id)}
                   aria-expanded={isOpen}
                 >
-                  {isOpen ? `Hide ${routeMode} route` : `Show ${routeMode} route`}
+                  {(() => {
+                    const mode = routeMode === 'secure' ? t('a0.modeSecure') : t('a0.modeShortest');
+                    return isOpen ? t('a0.hideRoute', { mode }) : t('a0.showRoute', { mode });
+                  })()}
                 </button>
               )}
             </div>

--- a/web/src/components/ui/ActivityPane.tsx
+++ b/web/src/components/ui/ActivityPane.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { api } from '../../api/client';
 import { useUserSetting } from '../../hooks/useUserSetting';
 
@@ -31,6 +33,7 @@ function MiniLineChart({ title, values, color, signed = false }: {
    *  series where the sign carries meaning. */
   signed?: boolean;
 }) {
+  const { t } = useTranslation();
   const [hover, setHover] = useState<HoverState | null>(null);
   const n      = values.length;
   const avg    = n > 0 ? values.reduce((s, v) => s + v, 0) / n : 0;
@@ -160,7 +163,7 @@ function MiniLineChart({ title, values, color, signed = false }: {
           }}
         >
           <span className="activity-chart__tooltip-value">{hover.value.toLocaleString()}</span>
-          <span className="activity-chart__tooltip-when">{hoursAgoLabel(SLOTS - 1 - slotOfIdx(hover.index))}</span>
+          <span className="activity-chart__tooltip-when">{hoursAgoLabel(t, SLOTS - 1 - slotOfIdx(hover.index))}</span>
         </div>
       )}
       </div>
@@ -168,13 +171,13 @@ function MiniLineChart({ title, values, color, signed = false }: {
   );
 }
 
-function hoursAgoLabel(h: number): string {
-  if (h <= 0) return 'this hour';
-  if (h === 1) return '1h ago';
-  return `${h}h ago`;
+function hoursAgoLabel(t: TFunction, h: number): string {
+  if (h <= 0) return t('activity.thisHour');
+  return t('time.hoursAgo', { value: h });
 }
 
 function ActivityChartsView({ data }: { data: HourlyPoint[] }) {
+  const { t } = useTranslation();
   // Per-chart visibility — defaults on, persisted cross-device via
   // users.ui_settings. Keys mirror the toggle labels in Map Options.
   const [showJumps]     = useUserSetting<boolean>('nexum.activity.showJumps',     true);
@@ -193,42 +196,42 @@ function ActivityChartsView({ data }: { data: HourlyPoint[] }) {
 
   const anyVisible = showJumps || showShipKills || showPodKills || showNpcKills || showNpcDelta;
   if (!anyVisible) {
-    return <div className="sig-pane__empty">All charts hidden. Toggle them on in Map Options → Activity.</div>;
+    return <div className="sig-pane__empty">{t('activity.allHidden')}</div>;
   }
 
   return (
     <div className="activity-pane">
       {showJumps && (
         <MiniLineChart
-          title="Jumps"
+          title={t('mapSidebar.activityJumps')}
           values={data.map((p) => p.jumps)}
           color="#4dd9ac"
         />
       )}
       {showShipKills && (
         <MiniLineChart
-          title="Ship Kills"
+          title={t('mapSidebar.activityShipKills')}
           values={data.map((p) => p.shipKills)}
           color="#e05a5a"
         />
       )}
       {showPodKills && (
         <MiniLineChart
-          title="Pod Kills"
+          title={t('mapSidebar.activityPodKills')}
           values={data.map((p) => p.podKills)}
           color="#c084fc"
         />
       )}
       {showNpcKills && (
         <MiniLineChart
-          title="NPC Kills"
+          title={t('mapSidebar.activityNpcKills')}
           values={data.map((p) => p.npcKills)}
           color="#5a9af8"
         />
       )}
       {showNpcDelta && (
         <MiniLineChart
-          title="NPC Delta"
+          title={t('mapSidebar.activityNpcDelta')}
           values={npcDelta}
           color="#f59e0b"
           signed
@@ -239,6 +242,7 @@ function ActivityChartsView({ data }: { data: HourlyPoint[] }) {
 }
 
 export function ActivityPane({ eveSystemId }: { eveSystemId: number | null }) {
+  const { t } = useTranslation();
   const [data, setData]       = useState<HourlyPoint[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -258,8 +262,8 @@ export function ActivityPane({ eveSystemId }: { eveSystemId: number | null }) {
     return () => clearInterval(id);
   }, [eveSystemId]);
 
-  if (!eveSystemId) return <div className="sig-pane__empty">No EVE system linked</div>;
-  if (loading)      return <div className="sig-pane__empty">Loading activity…</div>;
+  if (!eveSystemId) return <div className="sig-pane__empty">{t('panes.noEveSystem')}</div>;
+  if (loading)      return <div className="sig-pane__empty">{t('activity.loading')}</div>;
 
   return <ActivityChartsView data={data} />;
 }

--- a/web/src/components/ui/NotesEditor.tsx
+++ b/web/src/components/ui/NotesEditor.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import MDEditor, { getCommands } from '@uiw/react-md-editor';
 import rehypeSanitize from 'rehype-sanitize';
 
@@ -42,6 +43,7 @@ function readNotesHeight(): number {
 }
 
 export function NotesEditor({ value, onChange, compact = false, readOnly = false }: Props) {
+  const { t } = useTranslation();
   const [focused, setFocused] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   // Initial height for the full pane, read once from localStorage at mount.
@@ -99,7 +101,7 @@ export function NotesEditor({ value, onChange, compact = false, readOnly = false
       if (readOnly) return <div className="notes-editor notes-editor--empty" />;
       return (
         <div className="notes-editor notes-editor--empty" onClick={enterEdit}>
-          <span className="notes-editor__placeholder">Add note…</span>
+          <span className="notes-editor__placeholder">{t('panes.addNote')}</span>
         </div>
       );
     }

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -245,6 +245,29 @@
     "addFailed": "Freigabe konnte nicht hinzugefügt werden",
     "revokeFailed": "Freigabe konnte nicht widerrufen werden"
   },
+  "panes": {
+    "noEveSystem": "Kein EVE-System verknüpft",
+    "addNote": "Notiz hinzufügen…"
+  },
+  "waypoint": {
+    "setDestination": "Ziel festlegen",
+    "addWaypoint": "Wegpunkt hinzufügen"
+  },
+  "a0": {
+    "signIn": "Melde dich an und docke in K-Space, um nahe A0-Systeme zu sehen.",
+    "computing": "Berechne Routen…",
+    "noneReachable": "Keine A0-Systeme erreichbar.",
+    "showing": "Die {{count}} nächsten A0-Systeme werden angezeigt.",
+    "showRoute": "{{mode}} Route anzeigen",
+    "hideRoute": "{{mode}} Route ausblenden",
+    "modeShortest": "kürzeste",
+    "modeSecure": "sichere"
+  },
+  "activity": {
+    "thisHour": "diese Stunde",
+    "allHidden": "Alle Diagramme ausgeblendet. Aktiviere sie unter Kartenoptionen → Aktivität.",
+    "loading": "Aktivität wird geladen…"
+  },
   "sigType": {
     "wormhole": "Wurmloch",
     "data": "Daten",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -245,6 +245,29 @@
     "addFailed": "Failed to add share",
     "revokeFailed": "Failed to revoke share"
   },
+  "panes": {
+    "noEveSystem": "No EVE system linked",
+    "addNote": "Add note…"
+  },
+  "waypoint": {
+    "setDestination": "Set Destination",
+    "addWaypoint": "Add Waypoint"
+  },
+  "a0": {
+    "signIn": "Sign in and dock in K-space to see nearby A0 systems.",
+    "computing": "Computing routes…",
+    "noneReachable": "No A0 systems reachable.",
+    "showing": "Showing the {{count}} closest A0 systems.",
+    "showRoute": "Show {{mode}} route",
+    "hideRoute": "Hide {{mode}} route",
+    "modeShortest": "shortest",
+    "modeSecure": "secure"
+  },
+  "activity": {
+    "thisHour": "this hour",
+    "allHidden": "All charts hidden. Toggle them on in Map Options → Activity.",
+    "loading": "Loading activity…"
+  },
   "sigType": {
     "wormhole": "Wormhole",
     "data": "Data",


### PR DESCRIPTION
Stage 3 of localization — **panes (part 1)**, based directly on `localization` (no stacking this time).

## In this PR
- **ActivityPane** — chart titles (reusing the `mapSidebar.activity*` labels), the hours-ago tooltip (`time.hoursAgo` / "this hour"), and the all-hidden / loading / no-system empty states.
- **A0Pane** — sign-in / computing / none-reachable / "showing N closest" states, Set Destination + Add Waypoint (shared `waypoint` namespace), and Show/Hide-route with a translated route mode.
- **NotesEditor** — the "Add note…" placeholder.

New namespaces: `panes`, `activity`, `waypoint`, `a0` (English + German).

## Still to come (next panes PR)
KillboardPane (finish), StructuresPane, ClosestSystemsPane, SignaturePane (finish), then the big panels (SystemPanel, ConnectionPanel), AdminPage, LandingPage + map components.

## Verification
`yarn build` passes.
