### PR TITLE
i18n stage 3: extract ClosestSystems + Signature pane strings

### DIFF
--- a/web/src/components/ui/ClosestSystemsPane.tsx
+++ b/web/src/components/ui/ClosestSystemsPane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import type { DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
@@ -12,6 +13,7 @@ import { useEsiSearch } from '../../hooks/useEsiSearch';
 import { useMapStore } from '../../store/mapStore';
 import { useUserSetting } from '../../hooks/useUserSetting';
 import { setWaypoint, RouteSquares, KSPACE_CLASSES } from './routeUi';
+import { jumps as jumpsLabel } from '../../i18n/format';
 
 // EVE system IDs for the major trade hubs. Used as the initial seed only —
 // once the user has touched the list, theirs wins.
@@ -67,6 +69,7 @@ interface RowProps {
 }
 
 function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
+  const { t } = useTranslation();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: String(item.id) });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -79,7 +82,7 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
         <button
           type="button"
           className="scout-row__drag"
-          title="Drag to reorder"
+          title={t('closest.dragToReorder')}
           {...listeners}
           {...attributes}
         >
@@ -87,7 +90,7 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
         </button>
         <span className="scout-row__name">{item.name}</span>
         {item.isHome && (
-          <span className="scout-row__home" aria-label="Home" data-tooltip="Home">
+          <span className="scout-row__home" aria-label={t('closest.home')} data-tooltip={t('closest.home')}>
             <HouseIcon size={14} weight="regular" color="#f0c040" />
           </span>
         )}
@@ -95,14 +98,14 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
 
       <div className="scout-row__actions">
         <span className="scout-row__jumps">
-          {route ? `${route.jumps} jumps` : '— jumps'}
+          {route ? jumpsLabel(t, route.jumps) : t('closest.noJumps')}
         </span>
         <button
           type="button"
           className="sys-btn scout-row__btn scout-row__btn--icon"
           onClick={() => setWaypoint(item.id, item.name, true)}
-          aria-label="Set Destination"
-          data-tooltip="Set Destination"
+          aria-label={t('waypoint.setDestination')}
+          data-tooltip={t('waypoint.setDestination')}
         >
           <MapPinSimpleIcon size={14} weight="regular" color="#3ddc84" />
         </button>
@@ -110,8 +113,8 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
           type="button"
           className="sys-btn scout-row__btn scout-row__btn--icon"
           onClick={() => setWaypoint(item.id, item.name, false)}
-          aria-label="Add Waypoint"
-          data-tooltip="Add Waypoint"
+          aria-label={t('waypoint.addWaypoint')}
+          data-tooltip={t('waypoint.addWaypoint')}
         >
           <PathIcon size={14} weight="regular" color="#5a9af8" />
         </button>
@@ -122,7 +125,10 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
             onClick={onToggle}
             aria-expanded={isOpen}
           >
-            {isOpen ? `Hide ${routeMode} route` : `Show ${routeMode} route`}
+            {(() => {
+              const mode = routeMode === 'secure' ? t('a0.modeSecure') : t('a0.modeShortest');
+              return isOpen ? t('a0.hideRoute', { mode }) : t('a0.showRoute', { mode });
+            })()}
           </button>
         )}
         {onRemove && (
@@ -130,8 +136,8 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
             type="button"
             className="sys-btn scout-row__btn scout-row__btn--icon"
             onClick={onRemove}
-            aria-label="Remove from list"
-            data-tooltip="Remove from list"
+            aria-label={t('closest.removeFromList')}
+            data-tooltip={t('closest.removeFromList')}
           >
             <XIcon size={14} weight="regular" color="#e25a5a" />
           </button>
@@ -144,6 +150,7 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
 }
 
 export function ClosestSystemsPane() {
+  const { t } = useTranslation();
   const location  = useCharacterLocation();
   const routeMode = useMapStore((s) => s.routeMode);
   const homeSystem = useMapStore(useShallow((s) => {
@@ -263,7 +270,7 @@ export function ClosestSystemsPane() {
   if (!canRoute) {
     return (
       <div className="scout-pane__empty">
-        Sign in and dock in K-space to see jumps to hubs.
+        {t('closest.signIn')}
       </div>
     );
   }
@@ -327,7 +334,7 @@ export function ClosestSystemsPane() {
           className="sys-btn scout-pane__add"
           onClick={() => setAdding(true)}
         >
-          <PlusIcon size={14} weight="bold" /> Add System
+          <PlusIcon size={14} weight="bold" /> {t('addSystem.add')}
         </button>
       ) : (
         <div className="scout-pane__add-row" ref={addRowRef}>
@@ -335,7 +342,7 @@ export function ClosestSystemsPane() {
             ref={inputRef}
             className="scout-pane__add-input"
             type="text"
-            placeholder="Search system name…"
+            placeholder={t('closest.searchPlaceholder')}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleAddKeyDown}
@@ -346,8 +353,8 @@ export function ClosestSystemsPane() {
             className="sys-btn scout-row__btn scout-row__btn--icon"
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => { setAdding(false); setQuery(''); }}
-            aria-label="Cancel"
-            data-tooltip="Cancel"
+            aria-label={t('actions.cancel')}
+            data-tooltip={t('actions.cancel')}
           >
             <XIcon size={14} weight="regular" color="#e25a5a" />
           </button>
@@ -378,7 +385,7 @@ export function ClosestSystemsPane() {
               >
                 <span className="scout-pane__add-result-name">{r.name}</span>
                 <span className="scout-pane__add-result-region">
-                  {already ? 'on list' : (r.regionName ?? r.systemClass)}
+                  {already ? t('closest.onList') : (r.regionName ?? r.systemClass)}
                 </span>
               </li>
             );
@@ -392,7 +399,7 @@ export function ClosestSystemsPane() {
           className="scout-pane__add-empty"
           style={{ position: 'fixed', top: dropdownPos.top, left: dropdownPos.left, width: dropdownPos.width }}
         >
-          No systems match "{query}"
+          {t('closest.noMatch', { query })}
         </div>,
         document.body,
       )}

--- a/web/src/components/ui/Sidebar.tsx
+++ b/web/src/components/ui/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import type { DragEndEvent, Modifier } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
@@ -31,12 +32,6 @@ type Side    = 'left' | 'right';
 type PanelId = 'thera' | 'turnur' | 'a0' | 'closest';
 
 const DEFAULT_ORDER: PanelId[] = ['closest', 'thera', 'turnur', 'a0'];
-const PANEL_TITLES: Record<PanelId, string> = {
-  thera:   'Thera Connections',
-  turnur:  'Turnur Connections',
-  a0:      'Nearby A0 Suns',
-  closest: 'Closest Systems',
-};
 const VALID_PANEL_IDS: ReadonlySet<PanelId> = new Set(DEFAULT_ORDER);
 
 // The panels form a single vertical column, so a drag should only ever move a
@@ -56,6 +51,13 @@ function sanitiseOrder(raw: unknown): PanelId[] {
 }
 
 export function Sidebar() {
+  const { t } = useTranslation();
+  const panelTitle: Record<PanelId, string> = {
+    thera:   t('sidebar.thera'),
+    turnur:  t('sidebar.turnur'),
+    a0:      t('sidebar.a0'),
+    closest: t('sidebar.closest'),
+  };
   // Cross-device prefs via useUserSetting (server-backed JSONB).
   const [sideRaw,      setSide]      = useUserSetting<Side>(SIDE_KEY, 'left');
   const side: Side = sideRaw === 'right' ? 'right' : 'left';
@@ -117,8 +119,8 @@ export function Sidebar() {
           type="button"
           className="sidebar__expand-tab"
           onClick={() => setCollapsed(false)}
-          data-tooltip="Expand sidebar"
-          aria-label="Expand sidebar"
+          data-tooltip={t('sidebar.expand')}
+          aria-label={t('sidebar.expand')}
         >
           {side === 'left'
             ? <CaretRightIcon size={14} weight="bold" />
@@ -142,15 +144,15 @@ export function Sidebar() {
         onPointerDown={startResize}
         role="separator"
         aria-orientation="vertical"
-        aria-label="Resize sidebar"
+        aria-label={t('sidebar.resize')}
       />
       <div className="sidebar__header">
         <button
           type="button"
           className="icon-btn"
           onClick={swapSide}
-          data-tooltip={`Move sidebar to ${side === 'left' ? 'right' : 'left'}`}
-          aria-label={`Move sidebar to ${side === 'left' ? 'right' : 'left'}`}
+          data-tooltip={side === 'left' ? t('sidebar.moveToRight') : t('sidebar.moveToLeft')}
+          aria-label={side === 'left' ? t('sidebar.moveToRight') : t('sidebar.moveToLeft')}
         >
           {side === 'left'
             ? <ArrowLineRightIcon size={14} weight="bold" />
@@ -160,8 +162,8 @@ export function Sidebar() {
           type="button"
           className="icon-btn"
           onClick={() => setCollapsed(true)}
-          data-tooltip="Collapse sidebar"
-          aria-label="Collapse sidebar"
+          data-tooltip={t('sidebar.collapse')}
+          aria-label={t('sidebar.collapse')}
         >
           {side === 'left'
             ? <CaretLeftIcon  size={14} weight="bold" />
@@ -173,7 +175,7 @@ export function Sidebar() {
         <SortableContext items={order} strategy={verticalListSortingStrategy}>
           <div className="sidebar__content">
             {order.map(id => (
-              <DraggableCard key={id} id={id} title={PANEL_TITLES[id]}>
+              <DraggableCard key={id} id={id} title={panelTitle[id]}>
                 {cards[id]}
               </DraggableCard>
             ))}

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -147,6 +147,9 @@ function ElapsedCell({ iso, className }: { iso: string | undefined; className?: 
 }
 
 export function SignaturePane({ systemId }: { systemId: string }) {
+  const { t } = useTranslation();
+  const sigTypeLabel = (type: SigType) =>
+    type === 'unknown' ? t('sigType.unknown') : SIG_TYPE_LABELS[type];
   const activeMapId     = useMapStore((s) => s.activeMapId);
   const map             = useMapStore((s) => s.map);
   const currentSystemId = useMapStore((s) => s.currentSystemId);
@@ -218,7 +221,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
     api<Signature[]>(`/api/maps/${activeMapId}/systems/${systemId}/signatures`)
       .then(setSigs)
-      .catch(() => toast.error('Failed to load signatures'));
+      .catch(() => toast.error(t('signatures.loadFailed')));
   }, [activeMapId, systemId, isShareMode]);
 
   // Live sync: when a remote client changes this system's sigs, re-fetch in
@@ -265,7 +268,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       api(`/api/maps/${activeMapId}/systems/${systemId}/signatures/${id}`, {
         method: 'PATCH',
         body: JSON.stringify(payload),
-      }).catch(() => toast.error('Failed to save signature'));
+      }).catch(() => toast.error(t('signatures.saveFailed')));
     }, 500));
   };
 
@@ -283,7 +286,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
     }
 
     api(`/api/maps/${activeMapId}/systems/${systemId}/signatures/${id}`, { method: 'DELETE' })
-      .catch(() => toast.error('Failed to delete signature'));
+      .catch(() => toast.error(t('signatures.deleteFailed')));
   };
 
   const processPaste = useCallback(async (parsed: ParsedSig[]) => {
@@ -348,9 +351,9 @@ export function SignaturePane({ systemId }: { systemId: string }) {
         const currentName  = map.systems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
         const selectedName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown';
         setPendingAction({
-          message: `Your character is currently in ${currentName}, but you are pasting signatures into ${selectedName}. Continue?`,
+          message: t('signatures.pasteDifferentSystem', { current: currentName, selected: selectedName }),
           fn: () => processPaste(parsed),
-          confirmLabel: 'Ok',
+          confirmLabel: t('actions.ok'),
           showDontAskAgain: false,
         });
         return;
@@ -361,7 +364,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
     window.addEventListener('paste', handlePaste);
     return () => window.removeEventListener('paste', handlePaste);
-  }, [activeMapId, systemId, currentSystemId, map.systems, processPaste]);
+  }, [activeMapId, systemId, currentSystemId, map.systems, processPaste, t]);
 
   const addSig = async () => {
     if (!activeMapId) return;
@@ -378,7 +381,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   };
 
   const deleteSelected = () => confirm(
-    `Delete ${selected.size} selected signature${selected.size !== 1 ? 's' : ''}?`,
+    t('signatures.deleteSelectedConfirm', { count: selected.size }),
     () => { for (const id of selected) deleteSig(id); },
   );
 
@@ -388,7 +391,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   };
 
   const deleteAll = () => confirm(
-    `Delete all ${sigsRef.current.length} signature${sigsRef.current.length !== 1 ? 's' : ''}?`,
+    t('signatures.deleteAllConfirm', { count: sigsRef.current.length }),
     () => { for (const sig of sigsRef.current) deleteSig(sig.id); },
   );
 
@@ -463,11 +466,11 @@ export function SignaturePane({ systemId }: { systemId: string }) {
     )}
     <div className="sig-pane">
       {!isShareMode && sigs.length === 0 && (
-        <p className="sig-pane__hint">You can copy and paste signatures directly from the Probe scanner in Eve. To do this, open your probe scanner.  Press control A to select them all, then control C to copy.  Use control V to paste them here</p>
+        <p className="sig-pane__hint">{t('signatures.pasteHint')}</p>
       )}
       {canEdit && !isShareMode && (
         <div className="sig-pane__toolbar">
-          <button className="icon-btn" onClick={addSig} title="Add signature">Add signature</button>
+          <button className="icon-btn" onClick={addSig} title={t('signatures.addSignature')}>{t('signatures.addSignature')}</button>
           {selected.size > 0 && (
             <>
               <select
@@ -478,25 +481,25 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                   setSelectedType(e.target.value as SigType);
                   e.target.value = '';
                 }}
-                aria-label="Set type for selected signatures"
+                aria-label={t('signatures.setTypeAria')}
               >
-                <option value="">Set type ({selected.size})…</option>
-                <option value="unknown">Unknown</option>
-                <option value="wormhole">Wormhole</option>
-                <option value="data">Data</option>
-                <option value="relic">Relic</option>
-                <option value="combat">Combat</option>
-                <option value="gas">Gas</option>
-                <option value="ore">Ore</option>
+                <option value="">{t('signatures.setType', { count: selected.size })}</option>
+                <option value="unknown">{t('sigType.unknown')}</option>
+                <option value="wormhole">{t('sigType.wormhole')}</option>
+                <option value="data">{t('sigType.data')}</option>
+                <option value="relic">{t('sigType.relic')}</option>
+                <option value="combat">{t('sigType.combat')}</option>
+                <option value="gas">{t('sigType.gas')}</option>
+                <option value="ore">{t('sigType.ore')}</option>
               </select>
               <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteSelected}>
-                Delete selected ({selected.size})
+                {t('signatures.deleteSelected', { count: selected.size })}
               </button>
             </>
           )}
           {sigs.length > 0 && (
             <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteAll}>
-              Delete all
+              {t('signatures.deleteAll')}
             </button>
           )}
         </div>
@@ -504,7 +507,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
       {sigs.length === 0 ? (
         <div className={`sig-pane__empty${isShareMode ? ' sig-pane__empty--shared' : ''}`}>
-          {isShareMode ? 'No signatures scanned' : 'No signatures scanned — paste from probe scanner to import'}
+          {isShareMode ? t('signatures.emptyShared') : t('signatures.empty')}
         </div>
       ) : (
         <table className="sig-table">
@@ -538,35 +541,35 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 </th>
               )}
               <th className="sig-th sig-th--sortable" onClick={() => handleSort('sigId')}>
-                ID{sortInd('sigId')}
+                {t('signatures.colId')}{sortInd('sigId')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('id', e)} />
               </th>
               <th className="sig-th sig-th--sortable" onClick={() => handleSort('sigType')}>
-                Type{sortInd('sigType')}
+                {t('signatures.colType')}{sortInd('sigType')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('type', e)} />
               </th>
               <th className="sig-th sig-th--sortable" onClick={() => handleSort('whType')}>
-                WH{sortInd('whType')}
+                {t('signatures.colWh')}{sortInd('whType')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('whtype', e)} />
               </th>
               <th className="sig-th sig-th--sortable" onClick={() => handleSort('whLeadsTo')}>
-                Leads To{sortInd('whLeadsTo')}
+                {t('signatures.colLeadsTo')}{sortInd('whLeadsTo')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('leadsto', e)} />
               </th>
               <th className="sig-th sig-th--sortable" onClick={() => handleSort('name')}>
-                Name{sortInd('name')}
+                {t('signatures.colName')}{sortInd('name')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('name', e)} />
               </th>
               <th className="sig-th">
-                Notes
+                {t('signatures.colNotes')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
               </th>
               <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('createdAt')}>
-                Age{sortInd('createdAt')}
+                {t('signatures.colAge')}{sortInd('createdAt')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('created', e)} />
               </th>
               <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('updatedAt')}>
-                Updated{sortInd('updatedAt')}
+                {t('signatures.colUpdated')}{sortInd('updatedAt')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
               </th>
               {!isShareMode && <th />}
@@ -602,7 +605,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 <td>
                   {isShareMode ? (
                     <span className={`sig-text sig-text--type sig-select--type-${sig.sigType}`}>
-                      {SIG_TYPE_LABELS[sig.sigType]}
+                      {sigTypeLabel(sig.sigType)}
                     </span>
                   ) : (
                     <select
@@ -610,8 +613,8 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                       value={sig.sigType}
                       onChange={(e) => updateSig(sig.id, { sigType: e.target.value as SigType })}
                     >
-                      {(Object.keys(SIG_TYPE_LABELS) as SigType[]).map((t) => (
-                        <option key={t} value={t}>{SIG_TYPE_LABELS[t]}</option>
+                      {(Object.keys(SIG_TYPE_LABELS) as SigType[]).map((st) => (
+                        <option key={st} value={st}>{sigTypeLabel(st)}</option>
                       ))}
                     </select>
                   )}
@@ -649,7 +652,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                       className="sig-input"
                       value={sig.name}
                       onChange={(e) => updateSig(sig.id, { name: e.target.value })}
-                      placeholder="Site name"
+                      placeholder={t('signatures.namePlaceholder')}
                     />
                   )}
                 </td>
@@ -676,7 +679,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                       <button
                         className="icon-btn icon-btn--danger"
                         onClick={() => deleteSig(sig.id)}
-                        title="Delete"
+                        title={t('actions.delete')}
                       ><XIcon size={12} weight="bold" /></button>
                     )}
                   </td>

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -251,6 +251,17 @@
     "noEveSystem": "Kein EVE-System verknüpft",
     "addNote": "Notiz hinzufügen…"
   },
+  "sidebar": {
+    "thera": "Thera-Verbindungen",
+    "turnur": "Turnur-Verbindungen",
+    "a0": "Nahe A0-Sonnen",
+    "closest": "Nächste Systeme",
+    "expand": "Seitenleiste ausklappen",
+    "resize": "Seitenleiste anpassen",
+    "collapse": "Seitenleiste einklappen",
+    "moveToLeft": "Seitenleiste nach links verschieben",
+    "moveToRight": "Seitenleiste nach rechts verschieben"
+  },
   "waypoint": {
     "setDestination": "Ziel festlegen",
     "addWaypoint": "Wegpunkt hinzufügen"

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -255,6 +255,16 @@
     "setDestination": "Ziel festlegen",
     "addWaypoint": "Wegpunkt hinzufügen"
   },
+  "closest": {
+    "dragToReorder": "Zum Neuordnen ziehen",
+    "home": "Heimat",
+    "noJumps": "— Sprünge",
+    "removeFromList": "Aus Liste entfernen",
+    "signIn": "Melde dich an und docke in K-Space, um Sprünge zu Hubs zu sehen.",
+    "searchPlaceholder": "Systemname suchen…",
+    "onList": "auf Liste",
+    "noMatch": "Keine Systeme passen zu \"{{query}}\""
+  },
   "a0": {
     "signIn": "Melde dich an und docke in K-Space, um nahe A0-Systeme zu sehen.",
     "computing": "Berechne Routen…",
@@ -313,12 +323,40 @@
     "loadMore": "Mehr laden ({{count}} verbleibend)"
   },
   "sigType": {
+    "unknown": "Unbekannt",
     "wormhole": "Wurmloch",
     "data": "Daten",
     "relic": "Relikt",
     "gas": "Gas",
     "ore": "Erz",
     "combat": "Kampf"
+  },
+  "signatures": {
+    "pasteHint": "Du kannst Signaturen direkt aus dem Sondenscanner in EVE kopieren und einfügen. Öffne dazu deinen Sondenscanner. Drücke Strg+A, um alle auszuwählen, dann Strg+C zum Kopieren. Mit Strg+V hier einfügen.",
+    "pasteDifferentSystem": "Dein Charakter ist derzeit in {{current}}, aber du fügst Signaturen in {{selected}} ein. Fortfahren?",
+    "loadFailed": "Signaturen konnten nicht geladen werden",
+    "saveFailed": "Signatur konnte nicht gespeichert werden",
+    "deleteFailed": "Signatur konnte nicht gelöscht werden",
+    "deleteSelectedConfirm_one": "{{count}} ausgewählte Signatur löschen?",
+    "deleteSelectedConfirm_other": "{{count}} ausgewählte Signaturen löschen?",
+    "deleteAllConfirm_one": "Alle {{count}} Signatur löschen?",
+    "deleteAllConfirm_other": "Alle {{count}} Signaturen löschen?",
+    "addSignature": "Signatur hinzufügen",
+    "setTypeAria": "Typ für ausgewählte Signaturen festlegen",
+    "setType": "Typ festlegen ({{count}})…",
+    "deleteSelected": "Ausgewählte löschen ({{count}})",
+    "deleteAll": "Alle löschen",
+    "emptyShared": "Keine Signaturen gescannt",
+    "empty": "Keine Signaturen gescannt — aus dem Sondenscanner einfügen, um zu importieren",
+    "colId": "ID",
+    "colType": "Typ",
+    "colWh": "WH",
+    "colLeadsTo": "Führt zu",
+    "colName": "Name",
+    "colNotes": "Notizen",
+    "colAge": "Alter",
+    "colUpdated": "Aktualisiert",
+    "namePlaceholder": "Seitenname"
   },
   "stats": {
     "title": "Benutzerstatistik",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -251,6 +251,17 @@
     "noEveSystem": "No EVE system linked",
     "addNote": "Add note…"
   },
+  "sidebar": {
+    "thera": "Thera Connections",
+    "turnur": "Turnur Connections",
+    "a0": "Nearby A0 Suns",
+    "closest": "Closest Systems",
+    "expand": "Expand sidebar",
+    "resize": "Resize sidebar",
+    "collapse": "Collapse sidebar",
+    "moveToLeft": "Move sidebar to left",
+    "moveToRight": "Move sidebar to right"
+  },
   "waypoint": {
     "setDestination": "Set Destination",
     "addWaypoint": "Add Waypoint"

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -255,6 +255,16 @@
     "setDestination": "Set Destination",
     "addWaypoint": "Add Waypoint"
   },
+  "closest": {
+    "dragToReorder": "Drag to reorder",
+    "home": "Home",
+    "noJumps": "— jumps",
+    "removeFromList": "Remove from list",
+    "signIn": "Sign in and dock in K-space to see jumps to hubs.",
+    "searchPlaceholder": "Search system name…",
+    "onList": "on list",
+    "noMatch": "No systems match \"{{query}}\""
+  },
   "a0": {
     "signIn": "Sign in and dock in K-space to see nearby A0 systems.",
     "computing": "Computing routes…",
@@ -313,12 +323,40 @@
     "loadMore": "Load more ({{count}} remaining)"
   },
   "sigType": {
+    "unknown": "Unknown",
     "wormhole": "Wormhole",
     "data": "Data",
     "relic": "Relic",
     "gas": "Gas",
     "ore": "Ore",
     "combat": "Combat"
+  },
+  "signatures": {
+    "pasteHint": "You can copy and paste signatures directly from the Probe scanner in Eve. To do this, open your probe scanner.  Press control A to select them all, then control C to copy.  Use control V to paste them here",
+    "pasteDifferentSystem": "Your character is currently in {{current}}, but you are pasting signatures into {{selected}}. Continue?",
+    "loadFailed": "Failed to load signatures",
+    "saveFailed": "Failed to save signature",
+    "deleteFailed": "Failed to delete signature",
+    "deleteSelectedConfirm_one": "Delete {{count}} selected signature?",
+    "deleteSelectedConfirm_other": "Delete {{count}} selected signatures?",
+    "deleteAllConfirm_one": "Delete all {{count}} signature?",
+    "deleteAllConfirm_other": "Delete all {{count}} signatures?",
+    "addSignature": "Add signature",
+    "setTypeAria": "Set type for selected signatures",
+    "setType": "Set type ({{count}})…",
+    "deleteSelected": "Delete selected ({{count}})",
+    "deleteAll": "Delete all",
+    "emptyShared": "No signatures scanned",
+    "empty": "No signatures scanned — paste from probe scanner to import",
+    "colId": "ID",
+    "colType": "Type",
+    "colWh": "WH",
+    "colLeadsTo": "Leads To",
+    "colName": "Name",
+    "colNotes": "Notes",
+    "colAge": "Age",
+    "colUpdated": "Updated",
+    "namePlaceholder": "Site name"
   },
   "stats": {
     "title": "User Stats",


### PR DESCRIPTION
Stage 3 of localization — **panes (final)**: ClosestSystemsPane + SignaturePane. This finishes all the system-info panes.

## In this PR
- **ClosestSystemsPane** — drag-to-reorder, home, remove, no-jumps placeholder, sign-in state, search/cancel, "on list", no-match. Reuses `waypoint`, `a0.showRoute`, `addSystem.add`, and the `jumps()` formatter.
- **SignaturePane** — paste hint + the cross-system paste confirm, type select + labels (`sigType` + new `sigType.unknown`), bulk set-type / delete-selected / delete-all (pluralised), table headers (with sort arrows preserved), placeholders, empty states, and error toasts.

## Untranslated (intentional)
EVE-canonical data; the `ABC-123` sig-ID format example.

Also fixed another `.map((t) => …)` that shadowed the translation `t` (same pattern as the Structures fix).

New namespaces: `closest`, `signatures`; `sigType.unknown` (English + German).

## Verification
`yarn build` passes.
