### PR TITLE
i18n: Admin page part 2 (Reports + Discord)

### DIFF
--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -497,43 +497,52 @@ function MapsTab() {
 
 type ReportKind = 'users' | 'systems' | 'ghost-sites';
 
-const REPORTS: { key: ReportKind; label: string }[] = [
-  { key: 'users',       label: 'Users'       },
-  { key: 'systems',     label: 'Systems'     },
-  { key: 'ghost-sites', label: 'Ghost sites' },
+const REPORTS: { key: ReportKind }[] = [
+  { key: 'users'       },
+  { key: 'systems'     },
+  { key: 'ghost-sites' },
 ];
 
+// 'ghost-sites' doesn't map cleanly onto a dotted i18n key, so spell the
+// sub-tab labels out rather than building keys dynamically.
+const REPORT_TAB_KEY: Record<ReportKind, 'admin.reports.tabs.users' | 'admin.reports.tabs.systems' | 'admin.reports.tabs.ghostSites'> = {
+  users:         'admin.reports.tabs.users',
+  systems:       'admin.reports.tabs.systems',
+  'ghost-sites': 'admin.reports.tabs.ghostSites',
+};
+
 type WindowKey = 'all' | '24h' | 'week' | 'month' | 'year';
-const WINDOW_OPTIONS: { value: WindowKey; label: string }[] = [
-  { value: 'all',   label: 'All time'   },
-  { value: '24h',   label: 'Past 24 hours' },
-  { value: 'week',  label: 'Past week'  },
-  { value: 'month', label: 'Past month' },
-  { value: 'year',  label: 'Past year'  },
+const WINDOW_OPTIONS: { value: WindowKey }[] = [
+  { value: 'all'   },
+  { value: '24h'   },
+  { value: 'week'  },
+  { value: 'month' },
+  { value: 'year'  },
 ];
 
 // Match the server's bucket choice: 24h → hourly, week/month → daily,
 // year/all → monthly. The chart title narrates whichever bucket is in play
 // so admins aren't reading "per day" against monthly points.
-function chartTitleFor(window: WindowKey): string {
+function chartTitleFor(t: TFunction, window: WindowKey): string {
   switch (window) {
-    case '24h':   return 'Signatures per hour (past 24 hours)';
-    case 'week':  return 'Signatures per day (past week)';
-    case 'month': return 'Signatures per day (past month)';
-    case 'year':  return 'Signatures per month (past year)';
-    case 'all':   return 'Signatures per month (all time)';
+    case '24h':   return t('admin.reports.systems.chart.hour24');
+    case 'week':  return t('admin.reports.systems.chart.dayWeek');
+    case 'month': return t('admin.reports.systems.chart.dayMonth');
+    case 'year':  return t('admin.reports.systems.chart.monthYear');
+    case 'all':   return t('admin.reports.systems.chart.monthAll');
   }
 }
 
 type UserFilterKey = 'all' | 'logins' | 'signatures' | 'structures';
-const USER_FILTER_OPTIONS: { value: UserFilterKey; label: string }[] = [
-  { value: 'all',        label: 'All users'   },
-  { value: 'logins',     label: 'Logins'      },
-  { value: 'signatures', label: 'Signatures'  },
-  { value: 'structures', label: 'Structures'  },
+const USER_FILTER_OPTIONS: { value: UserFilterKey }[] = [
+  { value: 'all'        },
+  { value: 'logins'     },
+  { value: 'signatures' },
+  { value: 'structures' },
 ];
 
 function ReportsTab() {
+  const { t } = useTranslation();
   const [path, navigate] = useHashRoute();
   const { user } = useAuth();
   const canSeeReports = !!user?.canViewReports;
@@ -545,7 +554,7 @@ function ReportsTab() {
 
   return (
     <>
-      <h2 className="admin-page__section-title">Reports</h2>
+      <h2 className="admin-page__section-title">{t('admin.reports.title')}</h2>
       <div className="admin-page__subtabs">
         {visibleReports.map((r) => (
           <button
@@ -553,7 +562,7 @@ function ReportsTab() {
             className={`admin-page__subtab${kind === r.key ? ' admin-page__subtab--active' : ''}`}
             onClick={() => navigate(`/admin/reports/${r.key}`)}
           >
-            {r.label}
+            {t(REPORT_TAB_KEY[r.key])}
           </button>
         ))}
       </div>
@@ -593,7 +602,8 @@ interface UserReportRow {
   sigTypeCounts:        Record<string, number>;
 }
 
-const SIG_TYPE_ORDER: { key: string; label: string }[] = [
+type SigTypeKey = 'data' | 'relic' | 'wormhole' | 'gas' | 'ore' | 'combat' | 'unknown';
+const SIG_TYPE_ORDER: { key: SigTypeKey; label: string }[] = [
   { key: 'data',     label: 'Data'     },
   { key: 'relic',    label: 'Relic'    },
   { key: 'wormhole', label: 'WH'       },
@@ -669,9 +679,9 @@ function UsersReport() {
     const qs = params.toString();
     api<{ users: UserReportRow[] }>(`/api/admin/reports/users${qs ? `?${qs}` : ''}`)
       .then((r) => { if (!cancelled) setRows(r.users); })
-      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load users report'); });
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : t('admin.reports.users.loadFailed')); });
     return () => { cancelled = true; };
-  }, [filter, window]);
+  }, [filter, window, t]);
 
   const sortedRows = useMemo(() => {
     if (!rows) return null;
@@ -706,7 +716,7 @@ function UsersReport() {
       'Systems added', 'Systems deleted',
       'Last corp structure (ISO)', 'Total structures',
       'Last corp signature (ISO)', 'Total signatures',
-      ...SIG_TYPE_ORDER.map((t) => t.label),
+      ...SIG_TYPE_ORDER.map((st) => st.label),
     ];
     const rows = sortedRows.map((u) => {
       const total = Object.values(u.sigTypeCounts).reduce((a, b) => a + b, 0);
@@ -725,7 +735,7 @@ function UsersReport() {
         String(u.totalCorpStructures),
         u.lastCorpSigAt    ?? '',
         String(total),
-        ...SIG_TYPE_ORDER.map((t) => String(u.sigTypeCounts[t.key] ?? 0)),
+        ...SIG_TYPE_ORDER.map((st) => String(u.sigTypeCounts[st.key] ?? 0)),
       ];
     });
     const csv = [header, ...rows].map((r) => r.map(csvEscape).join(',')).join('\r\n');
@@ -741,66 +751,66 @@ function UsersReport() {
   const controls = (
     <div className="admin-page__filter-bar">
       <div className="admin-page__filter-group">
-        <label className="admin-page__filter-label">Filter</label>
+        <label className="admin-page__filter-label">{t('admin.reports.filter')}</label>
         <select
           className="admin-modal__role-select"
           value={filter}
           onChange={(e) => setFilter(e.target.value as UserFilterKey)}
         >
-          {USER_FILTER_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          {USER_FILTER_OPTIONS.map((o) => <option key={o.value} value={o.value}>{t(`admin.reports.userFilters.${o.value}`)}</option>)}
         </select>
       </div>
       <div className="admin-page__filter-group">
-        <label className="admin-page__filter-label">Window</label>
+        <label className="admin-page__filter-label">{t('admin.reports.window')}</label>
         <select
           className="admin-modal__role-select"
           value={window}
           onChange={(e) => setWindow(e.target.value as WindowKey)}
           disabled={filter === 'all'}
-          title={filter === 'all' ? 'Pick a filter to apply a window' : ''}
+          title={filter === 'all' ? t('admin.reports.windowHint') : ''}
         >
-          {WINDOW_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          {WINDOW_OPTIONS.map((o) => <option key={o.value} value={o.value}>{t(`admin.reports.windowOptions.${o.value}`)}</option>)}
         </select>
       </div>
       <div className="admin-page__filter-spacer" />
       {sortedRows && sortedRows.length > 0 && (
         <button className="btn btn--ghost btn--sm" onClick={downloadCsv}>
-          ↓ Export as CSV
+          ↓ {t('admin.exportCsv')}
         </button>
       )}
     </div>
   );
 
   if (error) return <>{controls}<div className="admin-page__error">{error}</div></>;
-  if (!sortedRows) return <>{controls}<div className="admin-page__loading">Loading…</div></>;
-  if (!sortedRows.length) return <>{controls}<div className="admin-page__empty">No users match the current filter.</div></>;
+  if (!sortedRows) return <>{controls}<div className="admin-page__loading">{t('admin.loading')}</div></>;
+  if (!sortedRows.length) return <>{controls}<div className="admin-page__empty">{t('admin.reports.users.empty')}</div></>;
 
   return (
     <>
     {controls}
     <div className="admin-page__stat-grid">
-      <StatCard label="Total users"      value={summary.users}     accent />
-      <StatCard label="Unique corps"     value={summary.corps} />
-      <StatCard label="Unique alliances" value={summary.alliances} />
+      <StatCard label={t('admin.reports.users.totalUsers')}      value={summary.users}     accent />
+      <StatCard label={t('admin.reports.users.uniqueCorps')}     value={summary.corps} />
+      <StatCard label={t('admin.reports.users.uniqueAlliances')} value={summary.alliances} />
     </div>
     <table className="admin-modal__table admin-page__sortable">
       <thead>
         <tr>
-          <SortHeader label="Character"          colKey="name"           sort={sort} onSort={handleSort} />
-          <SortHeader label="Corp"               colKey="corp"           sort={sort} onSort={handleSort} />
-          <SortHeader label="Alliance"           colKey="alliance"       sort={sort} onSort={handleSort} />
-          <SortHeader label="Last login"           colKey="lastLogin"      sort={sort} onSort={handleSort} />
-          <SortHeader label="Systems added"        colKey="systemsAdded"   sort={sort} onSort={handleSort} />
-          <SortHeader label="Systems deleted"      colKey="systemsDeleted" sort={sort} onSort={handleSort} />
-          <SortHeader label="Last corp structure"  colKey="lastCorpStruct" sort={sort} onSort={handleSort} />
-          <SortHeader label="Total structures"     colKey="structTotal"    sort={sort} onSort={handleSort} />
-          <SortHeader label="Last corp signature"  colKey="lastCorpSig"    sort={sort} onSort={handleSort} />
-          <SortHeader label="Total signatures"     colKey="sigTotal"       sort={sort} onSort={handleSort} />
-          {SIG_TYPE_ORDER.map((t) => (
+          <SortHeader label={t('admin.reports.users.colCharacter')}         colKey="name"           sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colCorp')}              colKey="corp"           sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colAlliance')}          colKey="alliance"       sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colLastLogin')}         colKey="lastLogin"      sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colSystemsAdded')}      colKey="systemsAdded"   sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colSystemsDeleted')}    colKey="systemsDeleted" sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colLastCorpStructure')} colKey="lastCorpStruct" sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colTotalStructures')}   colKey="structTotal"    sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colLastCorpSignature')} colKey="lastCorpSig"    sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colTotalSignatures')}   colKey="sigTotal"       sort={sort} onSort={handleSort} />
+          {SIG_TYPE_ORDER.map((st) => (
             <SortHeader
-              key={t.key}
-              label={t.label}
-              colKey={`sig:${t.key}` as UserReportSortKey}
+              key={st.key}
+              label={t(`admin.reports.sig.${st.key}`)}
+              colKey={`sig:${st.key}` as UserReportSortKey}
               sort={sort}
               onSort={handleSort}
               align="center"
@@ -840,10 +850,10 @@ function UsersReport() {
               <td className="admin-modal__num">{u.totalCorpStructures > 0 ? u.totalCorpStructures : '—'}</td>
               <td className="admin-modal__when">{u.lastCorpSigAt ? formatRelative(t, u.lastCorpSigAt) : '—'}</td>
               <td className="admin-modal__num">{total > 0 ? total : '—'}</td>
-              {SIG_TYPE_ORDER.map((t) => {
-                const n = u.sigTypeCounts[t.key] ?? 0;
+              {SIG_TYPE_ORDER.map((st) => {
+                const n = u.sigTypeCounts[st.key] ?? 0;
                 return (
-                  <td key={t.key} className="admin-modal__num--center">
+                  <td key={st.key} className="admin-modal__num--center">
                     {n > 0 ? n : <span className="admin-modal__mono">—</span>}
                   </td>
                 );
@@ -913,6 +923,7 @@ const SIG_TYPE_COLORS: Record<string, string> = {
 type WhSortKey = 'whType' | 'count';
 
 function SystemsReport() {
+  const { t } = useTranslation();
   const [data, setData]   = useState<SystemsReportData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [whSort, setWhSort] = useState<{ key: WhSortKey; dir: SortDir }>({ key: 'count', dir: 'desc' });
@@ -932,9 +943,9 @@ function SystemsReport() {
     const qs = window === 'all' ? '' : `?window=${window}`;
     api<SystemsReportData>(`/api/admin/reports/systems${qs}`)
       .then((d) => { if (!cancelled) setData(d); })
-      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load systems report'); });
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : t('admin.reports.systems.loadFailed')); });
     return () => { cancelled = true; };
-  }, [window]);
+  }, [window, t]);
 
   const sortedWh = useMemo(() => {
     if (!data) return null;
@@ -953,38 +964,38 @@ function SystemsReport() {
   const controls = (
     <div className="admin-page__filter-bar">
       <div className="admin-page__filter-group">
-        <label className="admin-page__filter-label">Window</label>
+        <label className="admin-page__filter-label">{t('admin.reports.window')}</label>
         <select
           className="admin-modal__role-select"
           value={window}
           onChange={(e) => setWindow(e.target.value as WindowKey)}
         >
-          {WINDOW_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          {WINDOW_OPTIONS.map((o) => <option key={o.value} value={o.value}>{t(`admin.reports.windowOptions.${o.value}`)}</option>)}
         </select>
       </div>
     </div>
   );
 
   if (error) return <>{controls}<div className="admin-page__error">{error}</div></>;
-  if (!data || !sortedWh) return <>{controls}<div className="admin-page__loading">Loading…</div></>;
-  if (data.total === 0) return <>{controls}<div className="admin-page__empty">No signatures in this window.</div></>;
+  if (!data || !sortedWh) return <>{controls}<div className="admin-page__loading">{t('admin.loading')}</div></>;
+  if (data.total === 0) return <>{controls}<div className="admin-page__empty">{t('admin.reports.systems.empty')}</div></>;
 
   const donutEntries = SIG_TYPE_ORDER
-    .map((t) => ({ key: t.key, label: t.label, count: data.byType[t.key] ?? 0 }))
+    .map((st) => ({ key: st.key, label: t(`admin.reports.sig.${st.key}`), count: data.byType[st.key] ?? 0 }))
     .filter((e) => e.count > 0);
 
   return (
     <>
       {controls}
-      <h3 className="admin-page__report-heading">Signatures across all maps</h3>
+      <h3 className="admin-page__report-heading">{t('admin.reports.systems.heading')}</h3>
       <div className="admin-page__stat-grid">
-        <StatCard label="Total" value={data.total} accent />
-        {SIG_TYPE_ORDER.map((t) => {
-          const count = data.byType[t.key] ?? 0;
+        <StatCard label={t('admin.reports.systems.total')} value={data.total} accent />
+        {SIG_TYPE_ORDER.map((st) => {
+          const count = data.byType[st.key] ?? 0;
           return (
             <StatCard
-              key={t.key}
-              label={t.label}
+              key={st.key}
+              label={t(`admin.reports.sig.${st.key}`)}
               value={count}
               pct={data.total > 0 ? (count / data.total) * 100 : 0}
             />
@@ -994,7 +1005,7 @@ function SystemsReport() {
 
       <div className="admin-page__chart-row">
         <div className="admin-page__chart-card">
-          <div className="admin-page__chart-title">Signature type mix</div>
+          <div className="admin-page__chart-title">{t('admin.reports.systems.typeMix')}</div>
           <div className="admin-page__chart-canvas">
             <Doughnut
               data={{
@@ -1020,13 +1031,13 @@ function SystemsReport() {
         </div>
 
         <div className="admin-page__chart-card">
-          <div className="admin-page__chart-title">{chartTitleFor(window)}</div>
+          <div className="admin-page__chart-title">{chartTitleFor(t, window)}</div>
           <div className="admin-page__chart-canvas">
             <Line
               data={{
                 labels: data.dailyTotals.map((d) => d.day),
                 datasets: [{
-                  label:           'Signatures',
+                  label:           t('admin.reports.systems.sigLabel'),
                   data:            data.dailyTotals.map((d) => d.count),
                   borderColor:     '#7ab4f0',
                   backgroundColor: 'rgba(122,180,240,0.12)',
@@ -1061,15 +1072,15 @@ function SystemsReport() {
         </div>
       </div>
 
-      <h3 className="admin-page__report-heading">Wormhole types</h3>
+      <h3 className="admin-page__report-heading">{t('admin.reports.systems.whHeading')}</h3>
       {sortedWh.length === 0 ? (
-        <div className="admin-page__empty">No wormhole signatures with a recorded type yet.</div>
+        <div className="admin-page__empty">{t('admin.reports.systems.whEmpty')}</div>
       ) : (
         <table className="admin-modal__table admin-page__sortable admin-page__wh-table">
           <thead>
             <tr>
-              <SortHeader label="Type"  colKey="whType" sort={whSort} onSort={handleWhSort} />
-              <SortHeader label="Count" colKey="count"  sort={whSort} onSort={handleWhSort} />
+              <SortHeader label={t('admin.reports.systems.colType')}  colKey="whType" sort={whSort} onSort={handleWhSort} />
+              <SortHeader label={t('admin.reports.systems.colCount')} colKey="count"  sort={whSort} onSort={handleWhSort} />
             </tr>
           </thead>
           <tbody>
@@ -1129,6 +1140,7 @@ const GHOST_ACCESSORS: Record<GhostSortKey, (r: GhostSiteRow) => string | number
 };
 
 function GhostSitesReport() {
+  const { t } = useTranslation();
   const [rows, setRows]   = useState<GhostSiteRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [sort, setSort]   = useState<{ key: GhostSortKey; dir: SortDir }>({ key: 'region', dir: 'asc' });
@@ -1136,8 +1148,8 @@ function GhostSitesReport() {
   useEffect(() => {
     api<{ rows: GhostSiteRow[] }>('/api/admin/reports/ghost-sites')
       .then((d) => setRows(d.rows))
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load ghost sites report'));
-  }, []);
+      .catch((e) => setError(e instanceof Error ? e.message : t('admin.reports.ghost.loadFailed')));
+  }, [t]);
 
   const sorted = useMemo(() => {
     if (!rows) return null;
@@ -1152,26 +1164,26 @@ function GhostSitesReport() {
   }
 
   if (error)   return <div className="admin-page__error">{error}</div>;
-  if (!sorted) return <div className="admin-page__loading">Loading…</div>;
+  if (!sorted) return <div className="admin-page__loading">{t('admin.loading')}</div>;
 
   return (
     <>
-      <h3 className="admin-page__report-heading">Covert Research Facility observations</h3>
+      <h3 className="admin-page__report-heading">{t('admin.reports.ghost.heading')}</h3>
       {sorted.length === 0 ? (
-        <div className="admin-page__empty">No K-space ghost sites recorded yet.</div>
+        <div className="admin-page__empty">{t('admin.reports.ghost.empty')}</div>
       ) : (
         <table className="admin-modal__table admin-page__sortable">
           <thead>
             <tr>
-              <SortHeader label="Region"        colKey="region"        sort={sort} onSort={onSort} />
-              <SortHeader label="Constellation" colKey="constellation" sort={sort} onSort={onSort} />
-              <SortHeader label="System"        colKey="system"        sort={sort} onSort={onSort} />
-              <SortHeader label="Class"         colKey="class"         sort={sort} onSort={onSort} />
-              <SortHeader label="Sun"           colKey="sunType"       sort={sort} onSort={onSort} />
-              <SortHeader label="Planets"       colKey="planets"       sort={sort} onSort={onSort} />
-              <SortHeader label="Moons"         colKey="moons"         sort={sort} onSort={onSort} />
-              <SortHeader label="Observations"  colKey="observations"  sort={sort} onSort={onSort} />
-              <SortHeader label="Last seen"     colKey="lastSeen"      sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colRegion')}        colKey="region"        sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colConstellation')} colKey="constellation" sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colSystem')}        colKey="system"        sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colClass')}         colKey="class"         sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colSun')}           colKey="sunType"       sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colPlanets')}       colKey="planets"       sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colMoons')}         colKey="moons"         sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colObservations')}  colKey="observations"  sort={sort} onSort={onSort} />
+              <SortHeader label={t('admin.reports.ghost.colLastSeen')}      colKey="lastSeen"      sort={sort} onSort={onSort} />
             </tr>
           </thead>
           <tbody>
@@ -1315,6 +1327,7 @@ interface DiscordSettings {
 interface RegionOption { id: number; name: string }
 
 function DiscordTab() {
+  const { t } = useTranslation();
   const [data, setData]           = useState<DiscordSettings | null>(null);
   const [regionOpts, setRegionOpts] = useState<RegionOption[]>([]);
   const [error, setError]         = useState<string | null>(null);
@@ -1338,9 +1351,9 @@ function DiscordTab() {
       setRegionOpts(r.regions);
       setError(null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load Discord settings');
+      setError(e instanceof Error ? e.message : t('admin.discord.loadFailed'));
     }
-  }, []);
+  }, [t]);
   // load() is async and only setStates after its await (never synchronously),
   // so this fetch-on-mount of a reusable loader is safe; the rule is a false
   // positive here.
@@ -1355,7 +1368,7 @@ function DiscordTab() {
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Save failed');
+      setError(e instanceof Error ? e.message : t('admin.discord.saveFailed'));
     } finally {
       setSaving(false);
     }
@@ -1366,7 +1379,7 @@ function DiscordTab() {
     try {
       await api(`/api/admin/maps/${id}/discord`, { method: 'PATCH', body: JSON.stringify({ excluded }) });
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Update failed');
+      setError(e instanceof Error ? e.message : t('admin.discord.updateFailed'));
       load(); // reload to revert the optimistic toggle
     }
   }
@@ -1379,51 +1392,48 @@ function DiscordTab() {
     ? regionOpts.filter((o) => o.name.toLowerCase().includes(q) && !regions.includes(o.name)).slice(0, 8)
     : [];
 
-  if (!data && error) return (<><h2 className="admin-page__section-title">Discord</h2><div className="admin-page__error">{error}</div></>);
-  if (!data)          return (<><h2 className="admin-page__section-title">Discord</h2><div className="admin-page__loading">Loading…</div></>);
+  if (!data && error) return (<><h2 className="admin-page__section-title">{t('admin.discord.title')}</h2><div className="admin-page__error">{error}</div></>);
+  if (!data)          return (<><h2 className="admin-page__section-title">{t('admin.discord.title')}</h2><div className="admin-page__loading">{t('admin.loading')}</div></>);
   if (data.corpId == null) {
-    return (<><h2 className="admin-page__section-title">Discord</h2>
-      <div className="admin-page__empty">No corp context — Discord notifications apply to corp maps only.</div></>);
+    return (<><h2 className="admin-page__section-title">{t('admin.discord.title')}</h2>
+      <div className="admin-page__empty">{t('admin.discord.noCorp')}</div></>);
   }
 
   const dirty = allRegions !== data.allRegions || regions.slice().sort().join('|') !== data.regions.slice().sort().join('|');
 
   return (
     <>
-      <h2 className="admin-page__section-title">Discord notifications</h2>
+      <h2 className="admin-page__section-title">{t('admin.discord.titleNotifications')}</h2>
       {error && <div className="admin-page__error">{error}</div>}
-      <p className="discord-admin__hint">
-        Controls which wormhole notifications this corp&apos;s maps post to Discord. The webhook itself is set
-        server-side (DISCORD_WEBHOOK_URL). By default every map and region notifies — these settings only subtract.
-      </p>
+      <p className="discord-admin__hint">{t('admin.discord.hint')}</p>
 
       <section className="discord-admin__section">
-        <h3 className="discord-admin__heading">Regions</h3>
+        <h3 className="discord-admin__heading">{t('admin.discord.regions')}</h3>
         <label className="discord-admin__radio">
           <input type="radio" name="discord-regions" checked={allRegions} onChange={() => setAllRegions(true)} />
-          Notify for all regions
+          {t('admin.discord.notifyAll')}
         </label>
         <label className="discord-admin__radio">
           <input type="radio" name="discord-regions" checked={!allRegions} onChange={() => setAllRegions(false)} />
-          Only selected regions
+          {t('admin.discord.notifySelected')}
         </label>
 
         {!allRegions && (
           <div className="discord-admin__regions">
             <div className="discord-admin__chips">
               {regions.length === 0
-                ? <span className="admin-page__empty">No regions selected — nothing will notify until you add some.</span>
+                ? <span className="admin-page__empty">{t('admin.discord.noRegionsSelected')}</span>
                 : regions.map((r) => (
                     <span key={r} className="discord-admin__chip">
                       {r}
-                      <button type="button" onClick={() => removeRegion(r)} aria-label={`Remove ${r}`}>×</button>
+                      <button type="button" onClick={() => removeRegion(r)} aria-label={t('admin.discord.removeRegion', { name: r })}>×</button>
                     </span>
                   ))}
             </div>
             <input
               type="text"
               className="discord-admin__search"
-              placeholder="Type to search regions…"
+              placeholder={t('admin.discord.searchPlaceholder')}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
             />
@@ -1439,20 +1449,20 @@ function DiscordTab() {
 
         <div className="discord-admin__actions">
           <button className="btn btn--primary" disabled={!dirty || saving} onClick={saveRegions}>
-            {saving ? 'Saving…' : 'Save regions'}
+            {saving ? t('admin.discord.saving') : t('admin.discord.saveRegions')}
           </button>
-          {saved && <span className="discord-admin__saved">Saved</span>}
+          {saved && <span className="discord-admin__saved">{t('admin.discord.saved')}</span>}
         </div>
       </section>
 
       <section className="discord-admin__section">
-        <h3 className="discord-admin__heading">Excluded maps</h3>
-        <p className="discord-admin__hint">All maps notify by default. Tick a map to exclude it from Discord.</p>
+        <h3 className="discord-admin__heading">{t('admin.discord.excludedMaps')}</h3>
+        <p className="discord-admin__hint">{t('admin.discord.excludedHint')}</p>
         {data.maps.length === 0
-          ? <div className="admin-page__empty">No corp maps yet.</div>
+          ? <div className="admin-page__empty">{t('admin.discord.noCorpMaps')}</div>
           : (
             <table className="admin-modal__table">
-              <thead><tr><th>Map</th><th>Exclude</th></tr></thead>
+              <thead><tr><th>{t('admin.discord.colMap')}</th><th>{t('admin.discord.colExclude')}</th></tr></thead>
               <tbody>
                 {data.maps.map((m) => (
                   <tr key={m.id}>

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -80,6 +80,112 @@
       "colTarget": "Ziel",
       "colChange": "Änderung",
       "loadFailed": "Audit-Log konnte nicht geladen werden"
+    },
+    "reports": {
+      "title": "Berichte",
+      "tabs": {
+        "users": "Benutzer",
+        "systems": "Systeme",
+        "ghostSites": "Ghost-Sites"
+      },
+      "filter": "Filter",
+      "window": "Zeitraum",
+      "windowHint": "Wähle einen Filter, um einen Zeitraum anzuwenden",
+      "windowOptions": {
+        "all": "Gesamte Zeit",
+        "24h": "Letzte 24 Stunden",
+        "week": "Letzte Woche",
+        "month": "Letzter Monat",
+        "year": "Letztes Jahr"
+      },
+      "userFilters": {
+        "all": "Alle Benutzer",
+        "logins": "Logins",
+        "signatures": "Signaturen",
+        "structures": "Strukturen"
+      },
+      "sig": {
+        "data": "Daten",
+        "relic": "Relikt",
+        "wormhole": "WH",
+        "gas": "Gas",
+        "ore": "Erz",
+        "combat": "Kampf",
+        "unknown": "Unbekannt"
+      },
+      "users": {
+        "loadFailed": "Benutzerbericht konnte nicht geladen werden",
+        "empty": "Keine Benutzer entsprechen dem aktuellen Filter.",
+        "totalUsers": "Benutzer gesamt",
+        "uniqueCorps": "Eindeutige Corps",
+        "uniqueAlliances": "Eindeutige Allianzen",
+        "colCharacter": "Charakter",
+        "colCorp": "Corp",
+        "colAlliance": "Allianz",
+        "colLastLogin": "Letzter Login",
+        "colSystemsAdded": "Systeme hinzugefügt",
+        "colSystemsDeleted": "Systeme gelöscht",
+        "colLastCorpStructure": "Letzte Corp-Struktur",
+        "colTotalStructures": "Strukturen gesamt",
+        "colLastCorpSignature": "Letzte Corp-Signatur",
+        "colTotalSignatures": "Signaturen gesamt"
+      },
+      "systems": {
+        "loadFailed": "Systembericht konnte nicht geladen werden",
+        "empty": "Keine Signaturen in diesem Zeitraum.",
+        "heading": "Signaturen über alle Karten",
+        "total": "Gesamt",
+        "typeMix": "Signaturtyp-Verteilung",
+        "sigLabel": "Signaturen",
+        "chart": {
+          "hour24": "Signaturen pro Stunde (letzte 24 Stunden)",
+          "dayWeek": "Signaturen pro Tag (letzte Woche)",
+          "dayMonth": "Signaturen pro Tag (letzter Monat)",
+          "monthYear": "Signaturen pro Monat (letztes Jahr)",
+          "monthAll": "Signaturen pro Monat (gesamte Zeit)"
+        },
+        "whHeading": "Wurmlochtypen",
+        "whEmpty": "Noch keine Wurmloch-Signaturen mit erfasstem Typ.",
+        "colType": "Typ",
+        "colCount": "Anzahl"
+      },
+      "ghost": {
+        "loadFailed": "Ghost-Sites-Bericht konnte nicht geladen werden",
+        "heading": "Beobachtungen von Covert Research Facilities",
+        "empty": "Noch keine K-Space-Ghost-Sites erfasst.",
+        "colRegion": "Region",
+        "colConstellation": "Konstellation",
+        "colSystem": "System",
+        "colClass": "Klasse",
+        "colSun": "Sonne",
+        "colPlanets": "Planeten",
+        "colMoons": "Monde",
+        "colObservations": "Beobachtungen",
+        "colLastSeen": "Zuletzt gesehen"
+      }
+    },
+    "discord": {
+      "title": "Discord",
+      "titleNotifications": "Discord-Benachrichtigungen",
+      "loadFailed": "Discord-Einstellungen konnten nicht geladen werden",
+      "saveFailed": "Speichern fehlgeschlagen",
+      "updateFailed": "Aktualisierung fehlgeschlagen",
+      "noCorp": "Kein Corp-Kontext — Discord-Benachrichtigungen gelten nur für Corp-Karten.",
+      "hint": "Legt fest, welche Wurmloch-Benachrichtigungen die Karten dieser Corp an Discord senden. Der Webhook selbst wird serverseitig gesetzt (DISCORD_WEBHOOK_URL). Standardmäßig benachrichtigt jede Karte und Region — diese Einstellungen schränken nur ein.",
+      "regions": "Regionen",
+      "notifyAll": "Für alle Regionen benachrichtigen",
+      "notifySelected": "Nur ausgewählte Regionen",
+      "noRegionsSelected": "Keine Regionen ausgewählt — es wird nichts benachrichtigt, bis du welche hinzufügst.",
+      "removeRegion": "{{name}} entfernen",
+      "searchPlaceholder": "Tippen, um Regionen zu suchen…",
+      "saving": "Speichert…",
+      "saveRegions": "Regionen speichern",
+      "saved": "Gespeichert",
+      "excludedMaps": "Ausgeschlossene Karten",
+      "excludedHint": "Alle Karten benachrichtigen standardmäßig. Hake eine Karte an, um sie von Discord auszuschließen.",
+      "noCorpMaps": "Noch keine Corp-Karten.",
+      "colMap": "Karte",
+      "colExclude": "Ausschließen"
     }
   },
   "proximityOptIn": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -80,6 +80,112 @@
       "colTarget": "Target",
       "colChange": "Change",
       "loadFailed": "Failed to load audit log"
+    },
+    "reports": {
+      "title": "Reports",
+      "tabs": {
+        "users": "Users",
+        "systems": "Systems",
+        "ghostSites": "Ghost sites"
+      },
+      "filter": "Filter",
+      "window": "Window",
+      "windowHint": "Pick a filter to apply a window",
+      "windowOptions": {
+        "all": "All time",
+        "24h": "Past 24 hours",
+        "week": "Past week",
+        "month": "Past month",
+        "year": "Past year"
+      },
+      "userFilters": {
+        "all": "All users",
+        "logins": "Logins",
+        "signatures": "Signatures",
+        "structures": "Structures"
+      },
+      "sig": {
+        "data": "Data",
+        "relic": "Relic",
+        "wormhole": "WH",
+        "gas": "Gas",
+        "ore": "Ore",
+        "combat": "Combat",
+        "unknown": "Unknown"
+      },
+      "users": {
+        "loadFailed": "Failed to load users report",
+        "empty": "No users match the current filter.",
+        "totalUsers": "Total users",
+        "uniqueCorps": "Unique corps",
+        "uniqueAlliances": "Unique alliances",
+        "colCharacter": "Character",
+        "colCorp": "Corp",
+        "colAlliance": "Alliance",
+        "colLastLogin": "Last login",
+        "colSystemsAdded": "Systems added",
+        "colSystemsDeleted": "Systems deleted",
+        "colLastCorpStructure": "Last corp structure",
+        "colTotalStructures": "Total structures",
+        "colLastCorpSignature": "Last corp signature",
+        "colTotalSignatures": "Total signatures"
+      },
+      "systems": {
+        "loadFailed": "Failed to load systems report",
+        "empty": "No signatures in this window.",
+        "heading": "Signatures across all maps",
+        "total": "Total",
+        "typeMix": "Signature type mix",
+        "sigLabel": "Signatures",
+        "chart": {
+          "hour24": "Signatures per hour (past 24 hours)",
+          "dayWeek": "Signatures per day (past week)",
+          "dayMonth": "Signatures per day (past month)",
+          "monthYear": "Signatures per month (past year)",
+          "monthAll": "Signatures per month (all time)"
+        },
+        "whHeading": "Wormhole types",
+        "whEmpty": "No wormhole signatures with a recorded type yet.",
+        "colType": "Type",
+        "colCount": "Count"
+      },
+      "ghost": {
+        "loadFailed": "Failed to load ghost sites report",
+        "heading": "Covert Research Facility observations",
+        "empty": "No K-space ghost sites recorded yet.",
+        "colRegion": "Region",
+        "colConstellation": "Constellation",
+        "colSystem": "System",
+        "colClass": "Class",
+        "colSun": "Sun",
+        "colPlanets": "Planets",
+        "colMoons": "Moons",
+        "colObservations": "Observations",
+        "colLastSeen": "Last seen"
+      }
+    },
+    "discord": {
+      "title": "Discord",
+      "titleNotifications": "Discord notifications",
+      "loadFailed": "Failed to load Discord settings",
+      "saveFailed": "Save failed",
+      "updateFailed": "Update failed",
+      "noCorp": "No corp context — Discord notifications apply to corp maps only.",
+      "hint": "Controls which wormhole notifications this corp's maps post to Discord. The webhook itself is set server-side (DISCORD_WEBHOOK_URL). By default every map and region notifies — these settings only subtract.",
+      "regions": "Regions",
+      "notifyAll": "Notify for all regions",
+      "notifySelected": "Only selected regions",
+      "noRegionsSelected": "No regions selected — nothing will notify until you add some.",
+      "removeRegion": "Remove {{name}}",
+      "searchPlaceholder": "Type to search regions…",
+      "saving": "Saving…",
+      "saveRegions": "Save regions",
+      "saved": "Saved",
+      "excludedMaps": "Excluded maps",
+      "excludedHint": "All maps notify by default. Tick a map to exclude it from Discord.",
+      "noCorpMaps": "No corp maps yet.",
+      "colMap": "Map",
+      "colExclude": "Exclude"
     }
   },
   "proximityOptIn": {


### PR DESCRIPTION
## Admin page i18n — part 2 (Reports + Discord)

Completes the Admin page localization. Extends the `admin` namespace (added in #64) with `reports.*` and `discord.*` in both `en/common.json` and `de/common.json`.

### What's translated
- **Reports tab** — section title and sub-tab labels (Users / Systems / Ghost sites), the Filter and Window controls plus their option lists
  - **Users report** — stat cards (total users / unique corps / unique alliances), all sortable column headers, per-sig-type columns, empty/loading states
  - **Systems report** — headings, stat cards, both chart titles (window-aware), the "Signatures type mix" donut, wormhole-types table
  - **Ghost sites report** — heading, column headers, empty/loading states
- **Discord tab** — section titles, the webhook hint, region radios / chips / search box, save-button states, the excluded-maps table

### Deliberately left untranslated
- CSV export field names (data portability) — `SIG_TYPE_ORDER` keeps its English `.label` for the export; the UI columns render translated short labels via the `reports.sig` keys
- Role enum values, env var names (`DISCORD_WEBHOOK_URL`), and EVE-canonical data (region/system/wormhole names, tickers)

### Notes
- Narrowed `SIG_TYPE_ORDER`'s `key` to a literal union (`SigTypeKey`) so the dynamic `reports.sig.<key>` lookups type-check.
- Renamed `.map((t) => …)` callbacks that shadowed the translation `t`.

Verified with `yarn build`. Based directly on `localization` (no stacking).
