### PR TITLE
i18n: map components (SystemNode, ConnectionEdge, intel badge)

### DIFF
--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getBezierPath, getStraightPath, getSmoothStepPath,
   EdgeLabelRenderer, BaseEdge,
@@ -49,6 +50,7 @@ export const ConnectionEdge = memo(({
   id, sourceX, sourceY, targetX, targetY,
   sourcePosition, targetPosition, data, selected,
 }: EdgeProps) => {
+  const { t } = useTranslation();
   const conn = data as unknown as MapConnection & { edgeStyle?: string; connectionThickness?: 'thin' | 'standard' | 'thick' | 'extra' };
   const selectConnection = useMapStore((s) => s.selectConnection);
   const now = useNow30s();
@@ -89,9 +91,9 @@ export const ConnectionEdge = memo(({
   const timeLabel = (() => {
     if (eolState) return { text: eolState.label, cls: eolState.cls };
     switch (timeStatus) {
-      case 'lessThan24h': return { text: '< 24h',  cls: 'connection-label__eol' };
-      case 'lessThan4h':  return { text: '< 4 hrs', cls: 'connection-label__eol' };
-      case 'lessThan1h':  return { text: '< 1 hr',  cls: 'connection-label__eol' };
+      case 'lessThan24h': return { text: t('mapEdge.lessThan24h'), cls: 'connection-label__eol' };
+      case 'lessThan4h':  return { text: t('mapEdge.lessThan4h'),  cls: 'connection-label__eol' };
+      case 'lessThan1h':  return { text: t('mapEdge.lessThan1h'),  cls: 'connection-label__eol' };
       case 'expired':     return { text: '!',        cls: 'connection-label__crit' };
       default:            return null;
     }

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Handle, Position, useConnection } from '@xyflow/react';
 import {
   HouseIcon, LockIcon, WarningIcon, SkullIcon, LightningIcon,
@@ -31,6 +32,7 @@ import { truesecColor } from '../../utils/truesec';
 type SystemNodeData = MapSystem & { selected: boolean };
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
+  const { t } = useTranslation();
   const sys = data as unknown as SystemNodeData;
   const color = CLASS_COLORS[sys.systemClass];
   const selectSystem    = useMapStore((s) => s.selectSystem);
@@ -121,8 +123,8 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
     : (() => {
         const names = Array.from(new Set(scoutMatches.map(c => c.outSystemName)));
         return names.length === 1
-          ? `${names[0]} connection${scoutMatches.length > 1 ? 's' : ''}`
-          : `${names.join(' & ')} connections`;
+          ? t('mapNode.scoutConnections', { name: names[0], count: scoutMatches.length })
+          : t('mapNode.scoutConnectionsMulti', { names: names.join(' & ') });
       })();
   const isTarget        = connection.inProgress && connection.fromNode?.id !== sys.id;
 
@@ -205,7 +207,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <span className="system-node__fleet-tooltip">
               {fleetHere.map((m) => (
                 <span key={m.characterId} className="system-node__fleet-tooltip-row">
-                  {m.characterName ?? `Character ${m.characterId}`}
+                  {m.characterName ?? t('mapNode.characterFallback', { id: m.characterId })}
                 </span>
               ))}
             </span>
@@ -217,18 +219,18 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <span className="system-node__presence-tooltip">
               {presenceHere.map((v) => (
                 <span key={v.characterId} className="system-node__presence-tooltip-row">
-                  {v.characterName || `Character ${v.characterId}`}
+                  {v.characterName || t('mapNode.characterFallback', { id: v.characterId })}
                 </span>
               ))}
             </span>
           </span>
         )}
         {sys.isHome && (
-          <span className="system-node__home-icon" aria-label="Home system">
+          <span className="system-node__home-icon" aria-label={t('mapNode.homeSystem')}>
             <HouseIcon size={14} weight="regular" />
           </span>
         )}
-        <span className="system-node__name">{sys.name || 'Unknown'}</span>
+        <span className="system-node__name">{sys.name || t('mapNode.unknown')}</span>
         {sys.security != null && Number.isFinite(Number(sys.security)) && (
           <span className="system-node__truesec" style={{ color: truesecColor(Number(sys.security)) }}>
             {Number(sys.security).toFixed(1)}
@@ -252,35 +254,35 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <span className="system-node__kill-icon">
               <SwordIcon size={14} weight="regular" />
               <span className="system-node__kill-tooltip">
-                {myKills.shipKills} ship · {myKills.podKills} pod kills this hour
+                {t('mapNode.killsTooltip', { ships: myKills.shipKills, pods: myKills.podKills })}
               </span>
             </span>
           )}
           {isA0 && (
             <span className="system-node__a0-icon">
               <SunIcon size={14} weight="regular" />
-              <span className="system-node__a0-tooltip">A0 sun</span>
+              <span className="system-node__a0-tooltip">{t('mapNode.a0Sun')}</span>
             </span>
           )}
           {isIceBelt && (
             <span className="system-node__ice-icon">
               <SnowflakeIcon size={14} weight="regular" />
-              <span className="system-node__ice-tooltip">Ice belt system</span>
+              <span className="system-node__ice-tooltip">{t('mapNode.iceBelt')}</span>
             </span>
           )}
           {incursion && (
             <span className="system-node__incursion-icon">
               <WarningIcon size={14} weight="regular" />
-              <span className="system-node__incursion-tooltip">Incursion System</span>
+              <span className="system-node__incursion-tooltip">{t('mapNode.incursion')}</span>
             </span>
           )}
           {storm && (
             <span className={`system-node__storm-icon system-node__storm-icon--${storm.stormType}`}>
               <LightningIcon size={14} weight="regular" />
               <span className="system-node__storm-tooltip">
-                <span className="system-node__storm-tooltip__title">{storm.stormName} storm</span>
-                <span>Last report: {storm.lastReport}</span>
-                {storm.reportedBy && <span>By: {storm.reportedBy}</span>}
+                <span className="system-node__storm-tooltip__title">{t('mapNode.stormTitle', { name: storm.stormName })}</span>
+                <span>{t('mapNode.stormLastReport', { value: storm.lastReport })}</span>
+                {storm.reportedBy && <span>{t('mapNode.stormReportedBy', { value: storm.reportedBy })}</span>}
               </span>
             </span>
           )}
@@ -292,7 +294,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
           {insurgency && (
             <span className="system-node__insurgency-icon">
               <SkullIcon size={14} weight="regular" />
-              <span className="system-node__insurgency-tooltip">Insurgency System</span>
+              <span className="system-node__insurgency-tooltip">{t('mapNode.insurgency')}</span>
             </span>
           )}
           {scoutMatches.length > 0 && (
@@ -328,7 +330,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
 
       {!compactMode && showStatics && sys.statics.length > 0 && (
         <div className="system-node__statics">
-          <div className="title">Statics</div>
+          <div className="title">{t('mapNode.statics')}</div>
           {sys.statics.map((s) => {
             const dest = WORMHOLE_DESTINATIONS[s];
             return (
@@ -356,7 +358,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <img className="system-node__incursion-logo" src={incursion.factionLogoUrl} alt={incursion.factionName} />
           )}
           <span className="system-node__incursion-label">
-            {incursion.isStaging ? 'Staging' : 'Incursion'}
+            {incursion.isStaging ? t('mapNode.staging') : t('mapNode.incursionBadge')}
             <span className="system-node__incursion-badge-tooltip">{incursion.factionName}</span>
           </span>
         </div>
@@ -368,7 +370,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <img className="system-node__insurgency-logo" src={insurgency.factionLogoUrl} alt={insurgency.factionName} />
           )}
           <span className="system-node__insurgency-label">
-            {insurgency.corruptionState > 0 ? 'Corrupted' : 'Suppressed'}
+            {insurgency.corruptionState > 0 ? t('mapNode.corrupted') : t('mapNode.suppressed')}
             <span className="system-node__insurgency-badge-tooltip">{insurgency.factionName}</span>
           </span>
         </div>

--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -154,7 +154,7 @@ export function SystemPanel() {
   const incursion  = findIncursion(incursions, sys.eveSystemId);
   const insurgency = findInsurgency(insurgencies, sys.eveSystemId);
   const intelColor = resolveIntelColor(sys.intel, customIntel);
-  const intelLabel = resolveIntelLabel(sys.intel, customIntel);
+  const intelLabel = resolveIntelLabel(sys.intel, customIntel, t);
 
   const setWaypoint = (clearOtherWaypoints: boolean) => {
     if (!sys.eveSystemId) return;

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -777,5 +777,31 @@
       "threat": "Bedrohung",
       "closest": "Nächstes {{label}}-System"
     }
+  },
+  "mapNode": {
+    "unknown": "Unbekannt",
+    "homeSystem": "Heimatsystem",
+    "characterFallback": "Charakter {{id}}",
+    "killsTooltip": "{{ships}} Schiff · {{pods}} Pod-Kills diese Stunde",
+    "a0Sun": "A0-Sonne",
+    "iceBelt": "Eisgürtel-System",
+    "incursion": "Inkursionssystem",
+    "insurgency": "Aufstandssystem",
+    "stormTitle": "{{name}}-Sturm",
+    "stormLastReport": "Letzte Meldung: {{value}}",
+    "stormReportedBy": "Von: {{value}}",
+    "statics": "Statics",
+    "staging": "Staging",
+    "incursionBadge": "Inkursion",
+    "corrupted": "Korrumpiert",
+    "suppressed": "Unterdrückt",
+    "scoutConnections_one": "{{name}}-Verbindung",
+    "scoutConnections_other": "{{name}}-Verbindungen",
+    "scoutConnectionsMulti": "{{names}}-Verbindungen"
+  },
+  "mapEdge": {
+    "lessThan24h": "< 24 Std",
+    "lessThan4h": "< 4 Std",
+    "lessThan1h": "< 1 Std"
   }
 }

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -777,5 +777,31 @@
       "threat": "Threat",
       "closest": "Closest {{label}} system"
     }
+  },
+  "mapNode": {
+    "unknown": "Unknown",
+    "homeSystem": "Home system",
+    "characterFallback": "Character {{id}}",
+    "killsTooltip": "{{ships}} ship · {{pods}} pod kills this hour",
+    "a0Sun": "A0 sun",
+    "iceBelt": "Ice belt system",
+    "incursion": "Incursion System",
+    "insurgency": "Insurgency System",
+    "stormTitle": "{{name}} storm",
+    "stormLastReport": "Last report: {{value}}",
+    "stormReportedBy": "By: {{value}}",
+    "statics": "Statics",
+    "staging": "Staging",
+    "incursionBadge": "Incursion",
+    "corrupted": "Corrupted",
+    "suppressed": "Suppressed",
+    "scoutConnections_one": "{{name}} connection",
+    "scoutConnections_other": "{{name}} connections",
+    "scoutConnectionsMulti": "{{names}} connections"
+  },
+  "mapEdge": {
+    "lessThan24h": "< 24h",
+    "lessThan4h": "< 4 hrs",
+    "lessThan1h": "< 1 hr"
   }
 }

--- a/web/src/utils/intelColors.ts
+++ b/web/src/utils/intelColors.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next';
 import type { BuiltinIntel, CustomIntel, SystemIntel } from '../types';
 
 /** Canonical colour for each built-in intel value. Used as the base for
@@ -10,6 +11,15 @@ const BUILTIN_COLORS: Record<BuiltinIntel, string> = {
 };
 
 const BUILTIN_KEYS = new Set<string>(['friendly', 'hostile', 'occupied', 'empty']);
+
+// Built-in intel labels reuse the right-click menu's translations so the
+// sidebar badge and the context menu always read the same.
+const BUILTIN_LABEL_KEYS: Record<BuiltinIntel, 'ctxMenu.intelFriendly' | 'ctxMenu.intelHostile' | 'ctxMenu.intelOccupied' | 'ctxMenu.intelEmpty'> = {
+  friendly: 'ctxMenu.intelFriendly',
+  hostile:  'ctxMenu.intelHostile',
+  occupied: 'ctxMenu.intelOccupied',
+  empty:    'ctxMenu.intelEmpty',
+};
 
 export function isBuiltinIntel(value: string): value is BuiltinIntel {
   return BUILTIN_KEYS.has(value);
@@ -28,12 +38,14 @@ export function resolveIntelColor(intel: SystemIntel | null | undefined, customs
 
 /** Resolve an intel tag to its human-readable label. Mirrors
  *  [[resolveIntelColor]] for label lookups (right-click checkmarks,
- *  sidebar swatches). Returns the raw id when nothing matches so debugging
- *  isn't blind. */
-export function resolveIntelLabel(intel: SystemIntel | null | undefined, customs: CustomIntel[]): string | null {
+ *  sidebar swatches). Built-in tags are translated via `t` when supplied
+ *  (falls back to a capitalised id otherwise); custom labels are user data
+ *  and pass through untouched. Returns the raw id when nothing matches so
+ *  debugging isn't blind. */
+export function resolveIntelLabel(intel: SystemIntel | null | undefined, customs: CustomIntel[], t?: TFunction): string | null {
   if (!intel) return null;
   if (isBuiltinIntel(intel)) {
-    return intel.charAt(0).toUpperCase() + intel.slice(1);
+    return t ? t(BUILTIN_LABEL_KEYS[intel]) : intel.charAt(0).toUpperCase() + intel.slice(1);
   }
   const match = customs.find((c) => c.id === intel);
   return match ? match.label : intel;


### PR DESCRIPTION
## Map components i18n (SystemNode + ConnectionEdge + intel badge)

Localises the on-canvas map components. Adds `mapNode` and `mapEdge` namespaces to `en/common.json` and `de/common.json`.

### What's translated
- **SystemNode** — unknown-name fallback, "Home system" aria-label, fleet/presence character fallbacks, all icon tooltips (kills, A0 sun, ice belt, incursion, insurgency, storm, scout connections — pluralised), the "Statics" heading, and the incursion (Staging/Incursion) and insurgency (Corrupted/Suppressed) badges.
- **ConnectionEdge** — the legacy categorical EOL fallback labels (`< 24h` / `< 4 hrs` / `< 1 hr`).
- **Intel badge** — `resolveIntelLabel` now takes an optional `TFunction` and translates the built-in intel tags via the existing `ctxMenu.intel*` keys, so the SystemPanel badge reads the same as the right-click menu. Custom intel labels stay as user data.

### Deliberately left untranslated
- EVE-canonical data: system / class / region / wormhole names, effect names and `EFFECT_MODIFIERS` attribute lines
- Symbolic/numeric labels: `JG`, the live `Xh Ym` EOL countdown, mass `> 50%` / `< 50%` / `< 10%`

Verified with `yarn build`. Based directly on `localization` (no stacking).

This clears the map components from stage 3 — **LandingPage** is the last remaining piece before a full second-language pass (stage 4).
