### PR TITLE
i18n: landing page

### DIFF
--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import type { Icon } from '@phosphor-icons/react';
 import {
   GraphIcon, MapTrifoldIcon, GaugeIcon, MagnifyingGlassIcon, SelectionIcon, ImageIcon, HourglassIcon,
@@ -15,291 +16,107 @@ interface LastCharacter { characterId: number; characterName: string; }
 
 // Categorised feature sections that mirror the README's Key features tree.
 // Cards still render through the same `landing__feature` template; each
-// section gets a heading rendered above its grid.
-interface FeatureItem { icon: Icon; title: string; desc: string }
-interface FeatureSection { title: string; items: FeatureItem[] }
+// section gets a heading rendered above its grid. Titles and descriptions
+// live in the `landing` i18n namespace, keyed by these ids.
+type SectionId = 'mapping' | 'personalCorp' | 'sysIntel' | 'liveOps' | 'productivity';
+type FeatureId =
+  | 'interactiveMap' | 'seedRegion' | 'whIntel' | 'rollingCalc' | 'whPicker'
+  | 'multiSelect' | 'pngExport' | 'sigAging'
+  | 'soloCorp' | 'multiMap' | 'mergeMaps' | 'realtime' | 'mapLocking' | 'rbac'
+  | 'systemPanel' | 'sigMgmt' | 'structImport' | 'autoStruct' | 'activityCharts'
+  | 'sovStation' | 'killboard' | 'effectDigest' | 'standings'
+  | 'scout' | 'a0' | 'iceBelt' | 'storms' | 'proximity' | 'discordNotif'
+  | 'routePlanner' | 'locationTracking' | 'presence' | 'onlineStatus'
+  | 'commandPalette' | 'homeHotkey' | 'killHighlights' | 'userStats'
+  | 'serverStatus' | 'demoMap' | 'sidebar';
+type CorpFeatureId =
+  | 'multiCorp' | 'adminDash' | 'userMgmt' | 'mapMgmt' | 'usersReport'
+  | 'systemsReport' | 'timeWindowed' | 'auditLog' | 'corpTicker' | 'perCharAttr';
+
+interface FeatureItem { icon: Icon; id: FeatureId }
+interface FeatureSection { id: SectionId; items: FeatureItem[] }
 
 const FEATURE_SECTIONS: FeatureSection[] = [
   {
-    title: 'Mapping',
+    id: 'mapping',
     items: [
-      {
-        icon: GraphIcon,
-        title: 'Interactive map',
-        desc: 'Drag systems, draw connections, set wormhole class / type / status per connection. Snap-to-grid and an optional minimap.',
-      },
-      {
-        icon: MapTrifoldIcon,
-        title: 'Seed a map from a region',
-        desc: 'Spin up a new map pre-populated with an entire EVE region — every system laid out from CCP\'s 2D star-map projection (a Dotlan-style layout) with all stargate connections drawn. Pick a region when creating a map, or leave it blank for an empty one.',
-      },
-      {
-        icon: GaugeIcon,
-        title: 'Wormhole intel',
-        desc: 'Per-connection mass status (stable / destabilized / critical), end-of-life flag with countdown, K162-aware static identification, and frig-hole / gas-site auto-tagging from sig type.',
-      },
-      {
-        icon: ArrowsClockwiseIcon,
-        title: 'Rolling calculator',
-        desc: 'Plan and track collapsing a hole from its connection panel. Models the ±10% mass variance and forecasts each pass safe / may-collapse / will-collapse against the worst case. Define a roller ship (cold + prop-on mass, or pull your flown ship from ESI), step through passes with side-tracking that warns before a pass strands you on the far side, and see an "≈ N passes left" estimate. Cumulative mass syncs live to everyone viewing the hole.',
-      },
-      {
-        icon: MagnifyingGlassIcon,
-        title: 'Wormhole type picker',
-        desc: 'Searchable popover for assigning the exact wormhole type to a connection. Statics quick-info on hover shows destination class, mass, and lifetime.',
-      },
-      {
-        icon: SelectionIcon,
-        title: 'Multi-select bulk operations',
-        desc: 'Shift-click to select multiple systems or signatures, then bulk-assign type, delete, or rename in a single action.',
-      },
-      {
-        icon: ImageIcon,
-        title: 'PNG export',
-        desc: 'Render the current map — with sig counts, connections, and status — to a PNG you can drop into a fleet ping or a corp Discord.',
-      },
-      {
-        icon: HourglassIcon,
-        title: 'Wormhole sig aging',
-        desc: 'Wormhole sigs tint by their position in the WH type\'s known lifetime — yellow at 50%, orange at 90%, red past expected close. Catches forgotten chains before they collapse on someone.',
-      },
+      { icon: GraphIcon,           id: 'interactiveMap' },
+      { icon: MapTrifoldIcon,      id: 'seedRegion'     },
+      { icon: GaugeIcon,           id: 'whIntel'        },
+      { icon: ArrowsClockwiseIcon, id: 'rollingCalc'    },
+      { icon: MagnifyingGlassIcon, id: 'whPicker'       },
+      { icon: SelectionIcon,       id: 'multiSelect'    },
+      { icon: ImageIcon,           id: 'pngExport'      },
+      { icon: HourglassIcon,       id: 'sigAging'       },
     ],
   },
   {
-    title: 'Personal & corp maps',
+    id: 'personalCorp',
     items: [
-      {
-        icon: UsersIcon,
-        title: 'Solo / Corp split',
-        desc: 'Every user has personal maps that are always private; in corp mode each corp also gets shared corp maps. Cross-corp visibility is opt-in via a single env flag.',
-      },
-      {
-        icon: StackIcon,
-        title: 'Multi-map support',
-        desc: 'Each character (or corp) can maintain multiple independent maps up to configured limits — separate chains for separate ops without losing context.',
-      },
-      {
-        icon: ArrowsMergeIcon,
-        title: 'Merge maps',
-        desc: 'Fold one map into another. The destination is kept as the source of truth — only missing systems and connections are added, with signatures, structures, and notes merged in, and new systems slotted into the existing layout. Corp maps opt in per role as a merge source and/or destination.',
-      },
-      {
-        icon: BroadcastIcon,
-        title: 'Real-time collaboration',
-        desc: 'Edits sync live to everyone viewing the same map — systems, connections, rename/lock, signatures, structures, and merges all appear for other viewers within moments, no refresh. Streamed per map (you only get events for maps you can see), with your own changes echo-suppressed and an auto-resync on reconnect.',
-      },
-      {
-        icon: LockIcon,
-        title: 'Map locking',
-        desc: 'Admins can freeze a corp map\'s topology. Systems and connections lock for non-admins, but signatures, structures, and per-system notes stay editable so ops continue while the layout is pinned.',
-      },
-      {
-        icon: ShieldCheckIcon,
-        title: 'Role-based access',
-        desc: 'Four tiers — readonly, edit, full, admin — gating corp-map actions. Personal maps stay yours regardless of role.',
-      },
+      { icon: UsersIcon,       id: 'soloCorp'   },
+      { icon: StackIcon,       id: 'multiMap'   },
+      { icon: ArrowsMergeIcon, id: 'mergeMaps'  },
+      { icon: BroadcastIcon,   id: 'realtime'   },
+      { icon: LockIcon,        id: 'mapLocking' },
+      { icon: ShieldCheckIcon, id: 'rbac'       },
     ],
   },
   {
-    title: 'System intelligence',
+    id: 'sysIntel',
     items: [
-      {
-        icon: CardsIcon,
-        title: 'System panel',
-        desc: 'Per-system cards for signatures, structures, NPC stations, notes, killboard, and activity charts. Cards are reorderable via drag-and-drop and persist per-user.',
-      },
-      {
-        icon: WaveformIcon,
-        title: 'Signature management',
-        desc: 'Paste straight from the probe scanner. Tracks created / updated age per signature, auto-deletes sigs missing from a re-paste, and supports bulk type assignment for multi-select.',
-      },
-      {
-        icon: BuildingsIcon,
-        title: 'Structure import',
-        desc: 'Paste EVE overview data to import player-owned structures with names, types, owners, and notes in one operation.',
-      },
-      {
-        icon: SparkleIcon,
-        title: 'Auto-discovered structures',
-        desc: 'Your corp\'s citadels (via ESI when a member with the Station Manager role logs in) and any publicly-listed structures from a third-party feed appear automatically in the structures pane as read-only entries — already tinted by your standings toward the owner.',
-      },
-      {
-        icon: ChartLineIcon,
-        title: 'Activity charts',
-        desc: '24-hour rolling history of jumps, ship / pod kills, and NPC kills per system, polled from ESI hourly. The poller persists data for every k-space system — not just ones someone has opened — so charts populate the moment you view a new system.',
-      },
-      {
-        icon: FlagBannerIcon,
-        title: 'Sovereignty & station data',
-        desc: 'Live alliance / corp / faction sov info and NPC station services, with in-game waypoint and destination actions.',
-      },
-      {
-        icon: SwordIcon,
-        title: 'Killboard pane',
-        desc: 'Recent zKillboard activity per system, with NPC-only kills hidden by default (toggle to include). Rows tint red when a hostile actor is in the chain or a blue gets killed; blue when a friendly scores or a hostile dies. Recent kills also bubble up as highlights on the map.',
-      },
-      {
-        icon: SparkleIcon,
-        title: 'Chain-wide effect digest',
-        desc: 'A one-line summary at the top of the system info panel lists every Pulsar / Wolf-Rayet / Magnetar / etc. on the current chain. Hover for the modifier list; click to centre.',
-      },
-      {
-        icon: HandshakeIcon,
-        title: 'Standings overlay',
-        desc: 'Your EVE contact list (personal, corp, and alliance — fetched via ESI on login and re-pullable on demand) drives a chain-wide visual layer. Sov holders show inline P/C/A standing pills; structures resolved via their EVE structure ID tint by owner-corp standing; sov-holder system nodes get a coloured halo so hostile territory stands out on the map.',
-      },
+      { icon: CardsIcon,      id: 'systemPanel'    },
+      { icon: WaveformIcon,   id: 'sigMgmt'        },
+      { icon: BuildingsIcon,  id: 'structImport'   },
+      { icon: SparkleIcon,    id: 'autoStruct'     },
+      { icon: ChartLineIcon,  id: 'activityCharts' },
+      { icon: FlagBannerIcon, id: 'sovStation'     },
+      { icon: SwordIcon,      id: 'killboard'      },
+      { icon: SparkleIcon,    id: 'effectDigest'   },
+      { icon: HandshakeIcon,  id: 'standings'      },
     ],
   },
   {
-    title: 'Live ops',
+    id: 'liveOps',
     items: [
-      {
-        icon: PathIcon,
-        title: 'Scout connections',
-        desc: 'Thera and Turnur public Eve-Scout connections surfaced into the sidebar so you can jump straight to known holes.',
-      },
-      {
-        icon: StarIcon,
-        title: 'A0 sun detection',
-        desc: 'Auto-flags systems with A0 (yellow) suns visible via ESI for capital-friendly skirmish planning.',
-      },
-      {
-        icon: SnowflakeIcon,
-        title: 'Ice belt systems',
-        desc: 'Flags Empire-space systems that spawn ice anomalies with a ❄ icon — handy when staging mining ops or looking for an alternate harvest spot. Static dataset committed in-repo and resolved to system IDs at startup.',
-      },
-      {
-        icon: LightningIcon,
-        title: 'Storm tracking',
-        desc: 'Active null-sec storms — Electric, Gamma, Exotic, Plasma — sourced from the community-maintained EveScout Rescue stormtrack feed surface as a colour-coded ⚡ on matching system nodes. Tooltip shows storm name, last report, and reporter. Refreshed every 30 minutes.',
-      },
-      {
-        icon: WarningIcon,
-        title: 'Proximity alerts',
-        desc: 'Browser notification plus an audio ping when you\'re within a configurable number of jumps of an active incursion, pirate insurgency, or a sov-holding system whose corp / alliance you\'ve set to red. Persistent toolbar chip shows the nearest threat at a glance.',
-      },
-      {
-        icon: BellRingingIcon,
-        title: 'Discord notifications',
-        desc: 'Push corp chain intel to a Discord channel so alerts land even when nobody\'s watching the tab. Fires server-side on an inbound K162 or a new wormhole connection, scoped to corp maps. Admins filter which regions and maps notify from the admin panel. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel.',
-      },
-      {
-        icon: NavigationArrowIcon,
-        title: 'Route planner',
-        desc: 'Server-side BFS over stargates plus your live chain, so a route through a wormhole hop is a single click.',
-      },
-      {
-        icon: MapPinIcon,
-        title: 'Location tracking',
-        desc: 'Opt-in live character location dot in the toolbar, plus a per-map "you are here" indicator that updates every 10 seconds via ESI.',
-      },
-      {
-        icon: UsersIcon,
-        title: 'Pilot presence',
-        desc: 'See where everyone viewing the same map is right now — a blue dot (pilot name on hover) marks each other viewer\'s current system, live as they jump. Covers anyone with the map open, not just your fleet; opt-in and nothing is stored.',
-      },
-      {
-        icon: BroadcastIcon,
-        title: 'Online status',
-        desc: 'Toolbar dot shows whether each logged-in user is currently signed into EVE Online, so you can see at a glance who\'s actually on grid.',
-      },
+      { icon: PathIcon,            id: 'scout'            },
+      { icon: StarIcon,            id: 'a0'               },
+      { icon: SnowflakeIcon,       id: 'iceBelt'          },
+      { icon: LightningIcon,       id: 'storms'           },
+      { icon: WarningIcon,         id: 'proximity'        },
+      { icon: BellRingingIcon,     id: 'discordNotif'     },
+      { icon: NavigationArrowIcon, id: 'routePlanner'     },
+      { icon: MapPinIcon,          id: 'locationTracking' },
+      { icon: UsersIcon,           id: 'presence'         },
+      { icon: BroadcastIcon,       id: 'onlineStatus'     },
     ],
   },
   {
-    title: 'Productivity & UX',
+    id: 'productivity',
     items: [
-      {
-        icon: CommandIcon,
-        title: 'Command palette',
-        desc: '⌘ / Ctrl + K opens a fuzzy search across systems, sigs, and actions — jump to a system, set a waypoint, or toggle a pane without touching the mouse.',
-      },
-      {
-        icon: HouseIcon,
-        title: 'Home hotkey',
-        desc: 'Hit H to jump the viewport back to your home system from any panel. Right-click a system to set or change which one is home.',
-      },
-      {
-        icon: SkullIcon,
-        title: 'Recent-kill highlights',
-        desc: 'Systems with kills in the last hour get a coloured halo so you can see fresh activity at a glance across the chain.',
-      },
-      {
-        icon: ChartBarIcon,
-        title: 'User stats modal',
-        desc: 'Per-character totals: jumps, signatures by type, broken down by day / week / month / year / forever.',
-      },
-      {
-        icon: PulseIcon,
-        title: 'Server status widget',
-        desc: 'Live Tranquility server status, player count, and ESI health in the toolbar. Cross-tab cached so all your open windows share a single ESI poll.',
-      },
-      {
-        icon: EyeIcon,
-        title: 'Demo map',
-        desc: 'The landing page mounts a non-editable demo map so visitors can see what the tool does before logging in.',
-      },
-      {
-        icon: SidebarIcon,
-        title: 'Collapsible sidebar',
-        desc: 'Map Options, Connections, Proximity Alerts, Stale System Fade, and Shortcuts each expand or collapse independently. Per-section state persists per browser via localStorage.',
-      },
+      { icon: CommandIcon,  id: 'commandPalette' },
+      { icon: HouseIcon,    id: 'homeHotkey'     },
+      { icon: SkullIcon,    id: 'killHighlights' },
+      { icon: ChartBarIcon, id: 'userStats'      },
+      { icon: PulseIcon,    id: 'serverStatus'   },
+      { icon: EyeIcon,      id: 'demoMap'        },
+      { icon: SidebarIcon,  id: 'sidebar'        },
     ],
   },
 ];
 
 // "For corporations" section in the README mirrored here. Hidden behind
 // CORP_ID at the deployment level; admin-only at the UI level.
-const CORP_FEATURES: FeatureItem[] = [
-  {
-    icon: BuildingsIcon,
-    title: 'Multi-corp deployments',
-    desc: 'CORP_ID accepts a comma-separated list of corporation IDs. One Nexum instance can host several corps; each corp\'s maps stay scoped to its own members unless CORP_MAP_SHARED=true.',
-  },
-  {
-    icon: SquaresFourIcon,
-    title: 'Admin dashboard',
-    desc: 'A dedicated /admin page with four tabs: Users, Maps, Reports, and Audit log. Admins reach it from the toolbar\'s Admin button.',
-  },
-  {
-    icon: UserGearIcon,
-    title: 'User management',
-    desc: 'Change roles, block / unblock, and force an ESI corp-membership re-check on demand. Self-block, self-demote, and changes to ADMIN_CHAR_ID are guarded against.',
-  },
-  {
-    icon: MapTrifoldIcon,
-    title: 'Map management',
-    desc: 'Admins see every corp map with owner avatar, corp ticker, system / connection counts, lock state, and last-active time. Force-lock, force-unlock, and force-delete are one-click each.',
-  },
-  {
-    icon: TableIcon,
-    title: 'Users report',
-    desc: 'Per-character last login, systems added / deleted, structures added, signatures broken down by type, and last-corp-activity timestamps. Sortable, filterable by activity and time window, exportable as CSV.',
-  },
-  {
-    icon: ChartDonutIcon,
-    title: 'Systems report',
-    desc: 'Aggregate corp-map signatures with a sig-type donut, a daily / monthly activity line chart (bucketing adapts to the window), and a sortable wormhole-type breakdown.',
-  },
-  {
-    icon: ClockIcon,
-    title: 'Time-windowed reporting',
-    desc: 'Every report can be scoped to past 24 hours, week, month, year, or all time. Chart bucketing adapts automatically: hourly for 24h, daily for week / month, monthly for year and all-time.',
-  },
-  {
-    icon: ClipboardTextIcon,
-    title: 'Audit log',
-    desc: 'Every admin action — role change, block / unblock, force-lock, force-delete, ESI corp change, auto-block on corp departure — is recorded with actor, target, old → new value, and timestamp. Exportable as CSV.',
-  },
-  {
-    icon: TagIcon,
-    title: 'Corp ticker resolution',
-    desc: 'Corp IDs in the Users and Maps reports are resolved to in-game tickers via ESI, with a 1-hour in-memory cache to keep report loads cheap.',
-  },
-  {
-    icon: IdentificationCardIcon,
-    title: 'Per-character attribution',
-    desc: 'Sigs, structures, and system add / delete actions are recorded with the user who made them, so reports can answer "who has been scanning what" with no manual logging.',
-  },
+const CORP_FEATURES: { icon: Icon; id: CorpFeatureId }[] = [
+  { icon: BuildingsIcon,          id: 'multiCorp'     },
+  { icon: SquaresFourIcon,        id: 'adminDash'     },
+  { icon: UserGearIcon,           id: 'userMgmt'      },
+  { icon: MapTrifoldIcon,         id: 'mapMgmt'       },
+  { icon: TableIcon,              id: 'usersReport'   },
+  { icon: ChartDonutIcon,         id: 'systemsReport' },
+  { icon: ClockIcon,              id: 'timeWindowed'  },
+  { icon: ClipboardTextIcon,      id: 'auditLog'      },
+  { icon: TagIcon,                id: 'corpTicker'    },
+  { icon: IdentificationCardIcon, id: 'perCharAttr'   },
 ];
 
 const VERT_SRC = `#version 300 es
@@ -420,19 +237,23 @@ function useShaderCanvas(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
   }, [canvasRef]);
 }
 
-const LOGIN_ERRORS: Record<string, string> = {
-  not_in_corp:       'Your character is not a member of the corporation that runs this Nexum instance. Access is restricted to corp members only.',
-  corp_check_failed: 'Could not verify your corporation membership due to an ESI error. Please try again in a moment.',
-};
+// Map a login ?error= param to a typed translation key so the lookup stays
+// type-safe; anything unrecognised falls back to the generic message.
+function loginErrorKey(param: string): 'landing.errors.not_in_corp' | 'landing.errors.corp_check_failed' | 'landing.errors.unknown' {
+  if (param === 'not_in_corp')       return 'landing.errors.not_in_corp';
+  if (param === 'corp_check_failed') return 'landing.errors.corp_check_failed';
+  return 'landing.errors.unknown';
+}
 
 export function LandingPage() {
+  const { t } = useTranslation();
   const [lastChar, setLastChar] = useState<LastCharacter | null>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useShaderCanvas(canvasRef);
 
   const errorParam = new URLSearchParams(window.location.search).get('error');
-  const errorMessage = errorParam ? (LOGIN_ERRORS[errorParam] ?? 'An unknown error occurred. Please try again.') : null;
+  const errorMessage = errorParam ? t(loginErrorKey(errorParam)) : null;
 
   useEffect(() => {
     try {
@@ -461,13 +282,13 @@ export function LandingPage() {
         <div className="landing__header-fade" />
         <div className="landing__logo">◈</div>
         <h1 className="landing__title">Nexum</h1>
-        <p className="landing__tagline">Wormhole chain mapping for EVE Online</p>
+        <p className="landing__tagline">{t('landing.tagline')}</p>
       </header>
 
       <div className="landing__content">
                 <div className="landing__demo">
           <p className="landing__demo-note">
-            ◈ Interactive demo — a simplified preview. Sign in to access signatures, kill feeds, connection tracking, activity history, and more.
+            {t('landing.demoNote')}
           </p>
           <DemoMap />
         </div>
@@ -488,15 +309,15 @@ export function LandingPage() {
                   className="landing__returning-avatar"
                 />
                 <div className="landing__returning-info">
-                  <span className="landing__returning-label">Continue as</span>
+                  <span className="landing__returning-label">{t('landing.cta.continueAs')}</span>
                   <span className="landing__returning-name">{lastChar.characterName}</span>
                 </div>
               </a>
               <p className="landing__note">
-                Session expired — click your portrait to log back in via EVE SSO.
+                {t('landing.cta.sessionExpired')}
               </p>
               <a href={apiUrl('/auth/login')} className="landing__switch-link">
-                Log in as a different character
+                {t('landing.cta.switchChar')}
               </a>
             </>
           ) : (
@@ -504,14 +325,14 @@ export function LandingPage() {
               <a href={apiUrl('/auth/login')} className="landing__login-wrap">
                 <img
                   src="/vendor/eve-sso-login-white-large.png"
-                  alt="Log in with EVE Online"
+                  alt={t('landing.cta.loginAlt')}
                   width="270"
                   height="45"
                   className="landing__eve-btn"
                 />
               </a>
               <p className="landing__note">
-                Secure EVE SSO login — no passwords stored. Character identity only.
+                {t('landing.cta.secureLogin')}
               </p>
             </>
           )}
@@ -522,20 +343,20 @@ export function LandingPage() {
             className="landing__discord-btn"
           >
             <DiscordLogoIcon size={20} weight="fill" />
-            <span>Join the Nexum Discord</span>
+            <span>{t('landing.cta.joinDiscord')}</span>
           </a>
         </div>
         {FEATURE_SECTIONS.map((section) => (
-          <section key={section.title} className="landing__section landing__section--features">
-            <h2 className="landing__section-title">{section.title}</h2>
+          <section key={section.id} className="landing__section landing__section--features">
+            <h2 className="landing__section-title">{t(`landing.sections.${section.id}`)}</h2>
             <section className="landing__features">
               {section.items.map((f) => {
                 const Icon = f.icon;
                 return (
-                  <div key={f.title} className="landing__feature">
+                  <div key={f.id} className="landing__feature">
                     <span className="landing__feature-icon"><Icon size="1em" weight="duotone" /></span>
-                    <h3 className="landing__feature-title">{f.title}</h3>
-                    <p className="landing__feature-desc">{f.desc}</p>
+                    <h3 className="landing__feature-title">{t(`landing.features.${f.id}.title`)}</h3>
+                    <p className="landing__feature-desc">{t(`landing.features.${f.id}.desc`)}</p>
                   </div>
                 );
               })}
@@ -545,20 +366,18 @@ export function LandingPage() {
 
         {/* ── Corp / alliance features ───────────────────────── */}
         <section className="landing__section landing__section--features" id="for-corporations">
-          <h2 className="landing__section-title">For Corporations</h2>
+          <h2 className="landing__section-title">{t('landing.sections.forCorps')}</h2>
           <p className="landing__section-body">
-            Run Nexum as a shared deployment for your corp or alliance. Members get
-            visible-to-the-corp chain maps and private personal maps in one tool, with
-            role-based permissions, admin tooling, and per-character activity reporting.
+            {t('landing.forCorpsBody')}
           </p>
           <section className="landing__features">
             {CORP_FEATURES.map((f) => {
               const Icon = f.icon;
               return (
-                <div key={f.title} className="landing__feature">
+                <div key={f.id} className="landing__feature">
                   <span className="landing__feature-icon"><Icon size="1em" weight="duotone" /></span>
-                  <h3 className="landing__feature-title">{f.title}</h3>
-                  <p className="landing__feature-desc">{f.desc}</p>
+                  <h3 className="landing__feature-title">{t(`landing.corpFeatures.${f.id}.title`)}</h3>
+                  <p className="landing__feature-desc">{t(`landing.corpFeatures.${f.id}.desc`)}</p>
                 </div>
               );
             })}
@@ -567,22 +386,20 @@ export function LandingPage() {
 
         {/* ── Compare CTA ───────────────────────────────────── */}
         <section className="landing__section landing__compare">
-          <h2 className="landing__section-title">How does Nexum compare?</h2>
+          <h2 className="landing__section-title">{t('landing.sections.compare')}</h2>
           <p className="landing__section-body">
-            See how Nexum stacks up against Pathfinder, Tripwire and Wanderer —
-            features, hosting and cost, side by side.
+            {t('landing.compareBody')}
           </p>
           <a href="/compare/" className="landing__compare-link">
-            Compare Nexum vs Pathfinder, Tripwire &amp; Wanderer →
+            {t('landing.compareLink')}
           </a>
         </section>
 
         {/* ── Discord CTA ──────────────────────────────────── */}
         <section className="landing__section landing__compare">
-          <h2 className="landing__section-title">Got questions, ideas, or bugs?</h2>
+          <h2 className="landing__section-title">{t('landing.sections.discordCta')}</h2>
           <p className="landing__section-body">
-            Drop into the Nexum Discord — feedback, feature requests, scanning
-            chat and o7s all welcome.
+            {t('landing.discordCtaBody')}
           </p>
           <a
             href="https://discord.gg/KG8SMXrhZ4"
@@ -591,145 +408,122 @@ export function LandingPage() {
             className="landing__discord-btn"
           >
             <DiscordLogoIcon size={20} weight="fill" />
-            <span>Join the Nexum Discord</span>
+            <span>{t('landing.cta.joinDiscord')}</span>
           </a>
         </section>
 
         {/* ── About Nexum ───────────────────────────────────── */}
         <section className="landing__section" id="about-nexum">
-          <h2 className="landing__section-title">About Nexum</h2>
+          <h2 className="landing__section-title">{t('landing.sections.about')}</h2>
           <p className="landing__section-body">
-            Nexum is a wormhole and exploration tool. It can be used for mapping routes and logging signatures. It was heavily inspired by Pathfinder — but with Pathfinder no longer actively developed (no new release since 2020), rather than complain about it, Nexum was created.
+            {t('landing.aboutBody1')}
           </p>
           <p className="landing__section-body">
-            Nexum is built by a single developer.  I'm adding features as we go but get in contact if you want support or feature requests
+            {t('landing.aboutBody2')}
           </p>
         </section>
 
         {/* ── About Me ──────────────────────────────────────── */}
         <section className="landing__section" id="about-me">
-          <h2 className="landing__section-title">About Me</h2>
+          <h2 className="landing__section-title">{t('landing.sections.aboutMe')}</h2>
           <div className="landing__about-me">
             <p className="landing__section-body">
-              Nexum is written by Addelee as a solo project.  I've played eve since Beta back in 2003. You might see me hanging out in the Help channels or the Scanning channel.  I've played in all areas of space from living in wormholes and thera, running missions in High Sec, gate camping in lowsec and now, null life with Goonswarm.
-              <br/><br/>As a day job, I am a programmer and run <a href='https://area404.org' target="_blank" className="landing__faq-link">Area 404</a>.  Because of this, I decided I'd write this tool.  I'm an avid explorer in Eve therefore I wanted a tool that worked for me.
-              <br/><br/>Nexum is open source and I welcome anyone to contribute.  I would definitely appreciate feedback and any bugs you encounter so please flag things on <a href="https://github.com/GQuantrill/eve-nexum/issues" target='_blank' className="landing__faq-link"> GitHub</a>
+              <Trans
+                i18nKey="landing.aboutMe"
+                components={{
+                  area404: <a href="https://area404.org" target="_blank" className="landing__faq-link" />,
+                  gh: <a href="https://github.com/GQuantrill/eve-nexum/issues" target="_blank" className="landing__faq-link" />,
+                }}
+              />
             </p>
-            
+
             <img src={portraitImg} alt="Portrait" className="landing__portrait" />
           </div>
         </section>
 
         {/* ── Tech Stack ────────────────────────────────────── */}
         <section className="landing__section" id="tech-stack">
-          <h2 className="landing__section-title">Tech Stack</h2>
+          <h2 className="landing__section-title">{t('landing.sections.techStack')}</h2>
           <p className="landing__section-body">
-            Nexum is held together with the finest space-age materials money and caffeine can buy.
-            The frontend is <strong>React</strong> with <strong>TypeScript</strong> — because arguing with a compiler
-            is still more productive than arguing with a nullsec alliance.
-            Maps are rendered with <strong>ReactFlow</strong>, which handles all the node-dragging
-            shenanigans so I didn't have to.
-            State is managed by <strong>Zustand</strong>, which is delightfully small and has never once
-            told me to "just use Redux".
+            <Trans i18nKey="landing.techStack1" />
           </p>
           <p className="landing__section-body">
-            The backend is <strong>Node.js</strong> with <strong>Express</strong> — proven, boring, and it works.
-            Data lives in <strong>PostgreSQL</strong>, seeded with CCP's Static Data Export so Nexum
-            actually knows what J213422 is without asking the ESI every five seconds.
-            Authentication is handled by <strong>EVE Online SSO</strong> — your credentials never touch
-            this server, which is exactly how it should be.
+            <Trans i18nKey="landing.techStack2" />
           </p>
           <p className="landing__section-body">
-            Live system intelligence comes from the <strong>EVE ESI</strong> (CCP's official API) and kill
-            data from <strong>zKillboard</strong>. The whole thing is containerised with <strong>Docker </strong>
-             and proxied through <strong>nginx</strong>, because someone has to keep the lights on while
-            you're getting evicted from your wormhole.
+            <Trans i18nKey="landing.techStack3" />
           </p>
         </section>
 
         {/* ── FAQs ──────────────────────────────────────────── */}
         <section className="landing__section" id="faqs">
-          <h2 className="landing__section-title">FAQs</h2>
+          <h2 className="landing__section-title">{t('landing.sections.faqs')}</h2>
           <div className="landing__faq-list">
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">Why Nexum?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.whyNexum.q')}</h3>
               <p className="landing__faq-a">
-                Nexum is the Latin word for a bond or connection — which felt appropriate for a tool built
-                around mapping the connections between wormhole systems. It also sounds vaguely like
-                something you'd find floating in a C6 magnetar, which was really the deciding factor.
+                {t('landing.faq.whyNexum.a')}
               </p>
             </div>
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">Can I use multiple accounts?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.multipleAccounts.q')}</h3>
               <p className="landing__faq-a">
-                Yes — each EVE character gets their own set of maps. Just log in with a different character
-                via EVE SSO and Nexum will keep their maps completely separate. No cross-contamination,
-                no accidental sharing of your super-secret wormhole chain with your alt corp.
+                {t('landing.faq.multipleAccounts.a')}
               </p>
             </div>
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">Is my data safe?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.dataSafe.q')}</h3>
               <p className="landing__faq-a">
-                Nexum never sees your EVE password — authentication is handled entirely by CCP's EVE SSO.
-                The only thing stored is your character identity and the maps you build. Your map data
-                lives in a private database and is not shared with anyone. That said, don't use Nexum
-                for your alliance's top-secret invasion route — no tool on the internet is a substitute
-                for good operational security.
+                {t('landing.faq.dataSafe.a')}
               </p>
             </div>
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">Can I report bugs, add feedback and request features?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.reportBugs.q')}</h3>
               <p className="landing__faq-a">
-                Absolutely. The project is open source on{' '}
-                <a href="https://github.com/GQuantrill/eve-nexum" target="_blank" rel="noopener noreferrer" className="landing__faq-link">
-                  GitHub
-                </a>
-                {' '}— open an issue for bugs or feature requests, or submit a pull request if you're feeling
-                brave. Feedback via in-game mail to the character tied to this account also works if GitHub
-                isn't your thing.
+                <Trans
+                  i18nKey="landing.faq.reportBugs.a"
+                  components={{
+                    gh: <a href="https://github.com/GQuantrill/eve-nexum" target="_blank" rel="noopener noreferrer" className="landing__faq-link" />,
+                  }}
+                />
               </p>
             </div>
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">Can I run this myself?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.runYourself.q')}</h3>
               <p className="landing__faq-a">
-                Yes — Nexum is fully self-hostable. The source is on{' '}
-                <a href="https://github.com/GQuantrill/eve-nexum" target="_blank" rel="noopener noreferrer" className="landing__faq-link">
-                  GitHub
-                </a>
-                {' '}and the whole stack spins up with a single <code>docker compose up</code>.
-                You'll need to register your own EVE application on the{' '}
-                <a href="https://developers.eveonline.com" target="_blank" rel="noopener noreferrer" className="landing__faq-link">
-                  CCP developer portal
-                </a>
-                {' '}to get SSO credentials, but beyond that the README covers everything —
-                including importing the EVE static data and pointing Traefik at it if that's your thing.
-                If something breaks, open an issue. If you fix it, please open a PR.
-
-                <br/><br/>It isn't the most technical thing to run up but I'd recommend you have basic knownledge of docker and whatever server your running on (Linux?)
+                <Trans
+                  i18nKey="landing.faq.runYourself.a"
+                  components={{
+                    gh: <a href="https://github.com/GQuantrill/eve-nexum" target="_blank" rel="noopener noreferrer" className="landing__faq-link" />,
+                    devportal: <a href="https://developers.eveonline.com" target="_blank" rel="noopener noreferrer" className="landing__faq-link" />,
+                    code: <code />,
+                  }}
+                />
               </p>
             </div>
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">But you're a Goon, why would we trust you?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.goonTrust.q')}</h3>
               <p className="landing__faq-a">
-                Fair question, and honestly the correct instinct to have in New Eden. The code is fully
-                open source — you're welcome to read every line, run it yourself, or have someone you trust
-                audit it. Nexum has no interest in your scouting routes, your corp's killboard shame, or
-                whatever you've got parked in that C5. The worst thing a Goon has ever done in a wormhole
-                is get evicted from one, and I'd like to help you avoid that fate.
+                {t('landing.faq.goonTrust.a')}
               </p>
             </div>
 
             <div className="landing__faq-item">
-              <h3 className="landing__faq-q">Do you have a roadmap for new features?</h3>
+              <h3 className="landing__faq-q">{t('landing.faq.roadmap.q')}</h3>
               <p className="landing__faq-a">
-                Loosely. Currently the system only works with solo players.  The next logical thing would be to implement this for Corporations and Alliances.  Once I iron out any bugs from this initial launch, I'll start work on that.<br/> This does assume real life work doesn't get in the way!
-                <br/><br/>If you have any pressing feature you want, drop me a message ingame and we can chat.
+                <Trans i18nKey="landing.faq.roadmap.a" />
+              </p>
+            </div>
+             <div className="landing__faq-item">
+              <h3 className="landing__faq-q">{t('landing.faq.donateIsk.q')}</h3>
+              <p className="landing__faq-a">
+                {t('landing.faq.donateIsk.a')}
               </p>
             </div>
 
@@ -737,9 +531,10 @@ export function LandingPage() {
         </section>
 
         <footer className="landing__footer">
-          EVE Online and the EVE logo are the registered trademarks of CCP hf. All rights reserved worldwide.
-          Nexum is a third-party tool and is not affiliated with or endorsed by CCP hf. ·{' '}
-          <a href="/license/">License &amp; EVE IP notice</a>
+          <Trans
+            i18nKey="landing.footer"
+            components={{ license: <a href="/license/" /> }}
+          />
         </footer>
       </div>
     </div>

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -778,6 +778,286 @@
       "closest": "Nächstes {{label}}-System"
     }
   },
+  "landing": {
+    "tagline": "Wurmloch-Kettenkartierung für EVE Online",
+    "demoNote": "◈ Interaktive Demo — eine vereinfachte Vorschau. Melde dich an, um Signaturen, Kill-Feeds, Verbindungsverfolgung, Aktivitätsverlauf und mehr zu nutzen.",
+    "cta": {
+      "continueAs": "Weiter als",
+      "sessionExpired": "Sitzung abgelaufen — klicke auf dein Porträt, um dich erneut über EVE SSO anzumelden.",
+      "switchChar": "Mit einem anderen Charakter anmelden",
+      "secureLogin": "Sichere EVE-SSO-Anmeldung — keine Passwörter gespeichert. Nur Charakteridentität.",
+      "loginAlt": "Mit EVE Online anmelden",
+      "joinDiscord": "Tritt dem Nexum-Discord bei"
+    },
+    "errors": {
+      "not_in_corp": "Dein Charakter ist kein Mitglied der Corporation, die diese Nexum-Instanz betreibt. Der Zugriff ist auf Corp-Mitglieder beschränkt.",
+      "corp_check_failed": "Deine Corporation-Mitgliedschaft konnte aufgrund eines ESI-Fehlers nicht überprüft werden. Bitte versuche es gleich noch einmal.",
+      "unknown": "Ein unbekannter Fehler ist aufgetreten. Bitte versuche es erneut."
+    },
+    "sections": {
+      "mapping": "Kartierung",
+      "personalCorp": "Persönliche & Corp-Karten",
+      "sysIntel": "System-Informationen",
+      "liveOps": "Live-Ops",
+      "productivity": "Produktivität & UX",
+      "forCorps": "Für Corporations",
+      "compare": "Wie schneidet Nexum ab?",
+      "discordCta": "Fragen, Ideen oder Bugs?",
+      "about": "Über Nexum",
+      "aboutMe": "Über mich",
+      "techStack": "Tech-Stack",
+      "faqs": "FAQ"
+    },
+    "features": {
+      "interactiveMap": {
+        "title": "Interaktive Karte",
+        "desc": "Ziehe Systeme, zeichne Verbindungen, lege Wurmloch-Klasse / -Typ / -Status pro Verbindung fest. Raster-Einrasten und eine optionale Minikarte."
+      },
+      "seedRegion": {
+        "title": "Karte aus einer Region erzeugen",
+        "desc": "Erstelle eine neue Karte, vorbefüllt mit einer ganzen EVE-Region — jedes System angeordnet nach CCPs 2D-Sternenkartenprojektion (ein Dotlan-artiges Layout) mit allen eingezeichneten Stargate-Verbindungen. Wähle beim Erstellen einer Karte eine Region aus oder lass sie für eine leere Karte frei."
+      },
+      "whIntel": {
+        "title": "Wurmloch-Informationen",
+        "desc": "Massenstatus pro Verbindung (stabil / destabilisiert / kritisch), End-of-Life-Markierung mit Countdown, K162-bewusste Static-Erkennung und automatische Markierung von Frig-Holes / Gas-Sites anhand des Sig-Typs."
+      },
+      "rollingCalc": {
+        "title": "Rolling-Rechner",
+        "desc": "Plane und verfolge das Schließen eines Lochs direkt aus dem Verbindungspanel. Modelliert die ±10%-Massenvarianz und prognostiziert jeden Durchflug als sicher / könnte-schließen / wird-schließen gegen den schlimmsten Fall. Definiere ein Roller-Schiff (kalte Masse + Prop-an, oder hole dein geflogenes Schiff aus ESI), gehe Durchflüge mit Seitenverfolgung durch, die dich warnt, bevor ein Durchflug dich auf der anderen Seite strandet, und sieh eine Schätzung \"≈ N Durchflüge übrig\". Die kumulierte Masse wird live mit allen synchronisiert, die das Loch betrachten."
+      },
+      "whPicker": {
+        "title": "Wurmlochtyp-Auswahl",
+        "desc": "Durchsuchbares Popover, um einer Verbindung den genauen Wurmlochtyp zuzuweisen. Die Static-Schnellinfo beim Überfahren zeigt Zielklasse, Masse und Lebensdauer."
+      },
+      "multiSelect": {
+        "title": "Mehrfachauswahl-Massenaktionen",
+        "desc": "Mit Shift-Klick mehrere Systeme oder Signaturen auswählen und dann in einer Aktion den Typ zuweisen, löschen oder umbenennen."
+      },
+      "pngExport": {
+        "title": "PNG-Export",
+        "desc": "Rendere die aktuelle Karte — mit Sig-Zahlen, Verbindungen und Status — als PNG, das du in ein Flotten-Ping oder einen Corp-Discord werfen kannst."
+      },
+      "sigAging": {
+        "title": "Wurmloch-Sig-Alterung",
+        "desc": "Wurmloch-Sigs werden je nach ihrer Position in der bekannten Lebensdauer des WH-Typs eingefärbt — gelb bei 50%, orange bei 90%, rot nach dem erwarteten Schließen. Erfasst vergessene Ketten, bevor sie jemandem zusammenbrechen."
+      },
+      "soloCorp": {
+        "title": "Solo- / Corp-Trennung",
+        "desc": "Jeder Benutzer hat persönliche Karten, die immer privat sind; im Corp-Modus erhält jede Corp zusätzlich gemeinsame Corp-Karten. Corp-übergreifende Sichtbarkeit ist über eine einzige Umgebungsvariable aktivierbar."
+      },
+      "multiMap": {
+        "title": "Mehrkarten-Unterstützung",
+        "desc": "Jeder Charakter (oder jede Corp) kann mehrere unabhängige Karten bis zu konfigurierten Grenzen pflegen — getrennte Ketten für getrennte Ops, ohne den Kontext zu verlieren."
+      },
+      "mergeMaps": {
+        "title": "Karten zusammenführen",
+        "desc": "Füge eine Karte in eine andere ein. Das Ziel bleibt die maßgebliche Quelle — nur fehlende Systeme und Verbindungen werden hinzugefügt, mit eingearbeiteten Signaturen, Strukturen und Notizen, und neue Systeme werden in das bestehende Layout eingefügt. Corp-Karten geben sich pro Rolle als Zusammenführungsquelle und/oder -ziel frei."
+      },
+      "realtime": {
+        "title": "Echtzeit-Zusammenarbeit",
+        "desc": "Änderungen werden live mit allen synchronisiert, die dieselbe Karte betrachten — Systeme, Verbindungen, Umbenennen/Sperren, Signaturen, Strukturen und Zusammenführungen erscheinen für andere Betrachter binnen Momenten, ohne Neuladen. Pro Karte gestreamt (du erhältst nur Ereignisse für Karten, die du sehen kannst), mit echo-unterdrückten eigenen Änderungen und automatischer Resynchronisierung beim erneuten Verbinden."
+      },
+      "mapLocking": {
+        "title": "Karten-Sperre",
+        "desc": "Admins können die Topologie einer Corp-Karte einfrieren. Systeme und Verbindungen werden für Nicht-Admins gesperrt, aber Signaturen, Strukturen und Notizen pro System bleiben bearbeitbar, sodass Ops weiterlaufen, während das Layout fixiert ist."
+      },
+      "rbac": {
+        "title": "Rollenbasierter Zugriff",
+        "desc": "Vier Stufen — readonly, edit, full, admin — steuern Corp-Karten-Aktionen. Persönliche Karten bleiben unabhängig von der Rolle deine."
+      },
+      "systemPanel": {
+        "title": "System-Panel",
+        "desc": "Karten pro System für Signaturen, Strukturen, NPC-Stationen, Notizen, Killboard und Aktivitätsdiagramme. Die Karten sind per Drag-and-Drop umsortierbar und bleiben pro Benutzer erhalten."
+      },
+      "sigMgmt": {
+        "title": "Signaturverwaltung",
+        "desc": "Füge direkt aus dem Sondenscanner ein. Verfolgt das Erstellungs- / Aktualisierungsalter pro Signatur, löscht beim erneuten Einfügen fehlende Sigs automatisch und unterstützt Massentyp-Zuweisung für die Mehrfachauswahl."
+      },
+      "structImport": {
+        "title": "Struktur-Import",
+        "desc": "Füge EVE-Übersichtsdaten ein, um spielereigene Strukturen mit Namen, Typen, Besitzern und Notizen in einem Vorgang zu importieren."
+      },
+      "autoStruct": {
+        "title": "Automatisch erkannte Strukturen",
+        "desc": "Die Citadels deiner Corp (über ESI, wenn sich ein Mitglied mit der Rolle Station Manager anmeldet) und alle öffentlich gelisteten Strukturen aus einem Drittanbieter-Feed erscheinen automatisch im Strukturen-Bereich als schreibgeschützte Einträge — bereits nach deinem Standing gegenüber dem Besitzer eingefärbt."
+      },
+      "activityCharts": {
+        "title": "Aktivitätsdiagramme",
+        "desc": "24-Stunden-Rollverlauf von Sprüngen, Schiffs- / Pod-Kills und NPC-Kills pro System, stündlich aus ESI abgefragt. Der Poller speichert Daten für jedes K-Space-System — nicht nur für geöffnete — sodass die Diagramme sich füllen, sobald du ein neues System ansiehst."
+      },
+      "sovStation": {
+        "title": "Souveränitäts- & Stationsdaten",
+        "desc": "Live-Sov-Infos zu Allianz / Corp / Fraktion und NPC-Stationsdienste, mit Wegpunkt- und Ziel-Aktionen im Spiel."
+      },
+      "killboard": {
+        "title": "Killboard-Bereich",
+        "desc": "Aktuelle zKillboard-Aktivität pro System, wobei reine NPC-Kills standardmäßig ausgeblendet sind (umschaltbar). Zeilen färben sich rot, wenn ein feindlicher Akteur in der Kette ist oder ein Blauer getötet wird; blau, wenn ein Freundlicher punktet oder ein Feindlicher stirbt. Aktuelle Kills tauchen auch als Hervorhebungen auf der Karte auf."
+      },
+      "effectDigest": {
+        "title": "Ketten-Effektübersicht",
+        "desc": "Eine einzeilige Zusammenfassung oben im System-Infopanel listet jeden Pulsar / Wolf-Rayet / Magnetar / usw. in der aktuellen Kette. Fahre für die Modifikatorliste darüber; klicke zum Zentrieren."
+      },
+      "standings": {
+        "title": "Standings-Overlay",
+        "desc": "Deine EVE-Kontaktliste (persönlich, Corp und Allianz — bei der Anmeldung über ESI abgerufen und auf Anfrage erneut abrufbar) treibt eine kettenweite visuelle Ebene an. Sov-Halter zeigen inline P/C/A-Standing-Pillen; Strukturen, die über ihre EVE-Struktur-ID aufgelöst werden, färben sich nach dem Standing der Besitzer-Corp; Knoten von Sov-Halter-Systemen erhalten einen farbigen Heiligenschein, damit feindliches Territorium auf der Karte heraussticht."
+      },
+      "scout": {
+        "title": "Scout-Verbindungen",
+        "desc": "Öffentliche Eve-Scout-Verbindungen von Thera und Turnur werden in die Seitenleiste eingeblendet, sodass du direkt zu bekannten Löchern springen kannst."
+      },
+      "a0": {
+        "title": "A0-Sonnenerkennung",
+        "desc": "Markiert automatisch Systeme mit A0-Sonnen (gelb), die über ESI sichtbar sind, für kapitaltaugliche Scharmützelplanung."
+      },
+      "iceBelt": {
+        "title": "Eisgürtel-Systeme",
+        "desc": "Markiert Systeme im Imperiumsraum, die Eisanomalien spawnen, mit einem ❄-Symbol — praktisch beim Aufbau von Mining-Ops oder bei der Suche nach einem alternativen Abbauort. Statischer Datensatz im Repo eingecheckt und beim Start zu System-IDs aufgelöst."
+      },
+      "storms": {
+        "title": "Sturmverfolgung",
+        "desc": "Aktive Nullsec-Stürme — Electric, Gamma, Exotic, Plasma — bezogen aus dem von der Community gepflegten EveScout-Rescue-Stormtrack-Feed erscheinen als farbcodiertes ⚡ an passenden Systemknoten. Der Tooltip zeigt Sturmname, letzte Meldung und Melder. Alle 30 Minuten aktualisiert."
+      },
+      "proximity": {
+        "title": "Näherungsalarme",
+        "desc": "Browser-Benachrichtigung plus ein Audio-Ping, wenn du innerhalb einer konfigurierbaren Anzahl von Sprüngen einer aktiven Inkursion, eines Piratenaufstands oder eines Sov-haltenden Systems bist, dessen Corp / Allianz du auf rot gesetzt hast. Ein dauerhafter Toolbar-Chip zeigt die nächste Bedrohung auf einen Blick."
+      },
+      "discordNotif": {
+        "title": "Discord-Benachrichtigungen",
+        "desc": "Schiebe Corp-Ketten-Intel in einen Discord-Kanal, damit Alarme auch ankommen, wenn niemand den Tab beobachtet. Wird serverseitig bei einem eingehenden K162 oder einer neuen Wurmlochverbindung ausgelöst, beschränkt auf Corp-Karten. Admins filtern im Admin-Panel, welche Regionen und Karten benachrichtigen. Best-effort und ratenbegrenzungsbewusst; Massenaktionen wie Regions-Seeding spammen den Kanal nie zu."
+      },
+      "routePlanner": {
+        "title": "Routenplaner",
+        "desc": "Serverseitige BFS über Stargates plus deine Live-Kette, sodass eine Route durch einen Wurmlochsprung ein einziger Klick ist."
+      },
+      "locationTracking": {
+        "title": "Standortverfolgung",
+        "desc": "Optionaler Live-Standortpunkt des Charakters in der Toolbar plus eine \"Du bist hier\"-Anzeige pro Karte, die alle 10 Sekunden über ESI aktualisiert wird."
+      },
+      "presence": {
+        "title": "Piloten-Präsenz",
+        "desc": "Sieh, wo sich gerade alle befinden, die dieselbe Karte betrachten — ein blauer Punkt (Pilotenname beim Überfahren) markiert das aktuelle System jedes anderen Betrachters, live während sie springen. Erfasst jeden mit geöffneter Karte, nicht nur deine Flotte; optional und nichts wird gespeichert."
+      },
+      "onlineStatus": {
+        "title": "Online-Status",
+        "desc": "Ein Toolbar-Punkt zeigt, ob jeder angemeldete Benutzer gerade in EVE Online eingeloggt ist, sodass du auf einen Blick siehst, wer tatsächlich aktiv ist."
+      },
+      "commandPalette": {
+        "title": "Befehlspalette",
+        "desc": "⌘ / Strg + K öffnet eine unscharfe Suche über Systeme, Sigs und Aktionen — springe zu einem System, setze einen Wegpunkt oder schalte einen Bereich um, ohne die Maus zu berühren."
+      },
+      "homeHotkey": {
+        "title": "Heimat-Hotkey",
+        "desc": "Drücke H, um den Viewport aus jedem Panel zu deinem Heimatsystem zurückzuspringen. Rechtsklicke ein System, um festzulegen oder zu ändern, welches die Heimat ist."
+      },
+      "killHighlights": {
+        "title": "Hervorhebung aktueller Kills",
+        "desc": "Systeme mit Kills in der letzten Stunde erhalten einen farbigen Heiligenschein, sodass du frische Aktivität auf einen Blick über die ganze Kette siehst."
+      },
+      "userStats": {
+        "title": "Benutzerstatistik-Fenster",
+        "desc": "Summen pro Charakter: Sprünge, Signaturen nach Typ, aufgeschlüsselt nach Tag / Woche / Monat / Jahr / gesamt."
+      },
+      "serverStatus": {
+        "title": "Serverstatus-Widget",
+        "desc": "Live-Status des Tranquility-Servers, Spielerzahl und ESI-Gesundheit in der Toolbar. Tab-übergreifend zwischengespeichert, sodass alle deine offenen Fenster eine einzige ESI-Abfrage teilen."
+      },
+      "demoMap": {
+        "title": "Demo-Karte",
+        "desc": "Die Landingpage bindet eine nicht editierbare Demo-Karte ein, damit Besucher sehen können, was das Tool kann, bevor sie sich anmelden."
+      },
+      "sidebar": {
+        "title": "Einklappbare Seitenleiste",
+        "desc": "Kartenoptionen, Verbindungen, Näherungsalarme, Verblassen veralteter Systeme und Tastenkürzel lassen sich jeweils unabhängig auf- oder zuklappen. Der Zustand pro Abschnitt bleibt pro Browser über localStorage erhalten."
+      }
+    },
+    "corpFeatures": {
+      "multiCorp": {
+        "title": "Multi-Corp-Deployments",
+        "desc": "CORP_ID akzeptiert eine kommagetrennte Liste von Corporation-IDs. Eine Nexum-Instanz kann mehrere Corps hosten; die Karten jeder Corp bleiben auf ihre eigenen Mitglieder beschränkt, sofern nicht CORP_MAP_SHARED=true gesetzt ist."
+      },
+      "adminDash": {
+        "title": "Admin-Dashboard",
+        "desc": "Eine dedizierte /admin-Seite mit vier Tabs: Benutzer, Karten, Berichte und Audit-Log. Admins erreichen sie über die Schaltfläche Verwaltung in der Toolbar."
+      },
+      "userMgmt": {
+        "title": "Benutzerverwaltung",
+        "desc": "Rollen ändern, sperren / entsperren und eine ESI-Corp-Mitgliedschafts-Neuprüfung auf Anfrage erzwingen. Selbst-Sperre, Selbst-Herabstufung und Änderungen an ADMIN_CHAR_ID sind abgesichert."
+      },
+      "mapMgmt": {
+        "title": "Kartenverwaltung",
+        "desc": "Admins sehen jede Corp-Karte mit Besitzer-Avatar, Corp-Ticker, System- / Verbindungszahlen, Sperrzustand und letzter Aktivitätszeit. Zwangssperren, Zwangsentsperren und Zwangslöschen sind jeweils ein Klick."
+      },
+      "usersReport": {
+        "title": "Benutzerbericht",
+        "desc": "Pro Charakter: letzter Login, hinzugefügte / gelöschte Systeme, hinzugefügte Strukturen, Signaturen nach Typ aufgeschlüsselt und Zeitstempel der letzten Corp-Aktivität. Sortierbar, filterbar nach Aktivität und Zeitraum, als CSV exportierbar."
+      },
+      "systemsReport": {
+        "title": "Systembericht",
+        "desc": "Aggregierte Corp-Karten-Signaturen mit einem Sig-Typ-Donut, einem täglichen / monatlichen Aktivitäts-Liniendiagramm (die Bucketing-Größe passt sich dem Zeitraum an) und einer sortierbaren Aufschlüsselung nach Wurmlochtyp."
+      },
+      "timeWindowed": {
+        "title": "Zeitfenster-Berichte",
+        "desc": "Jeder Bericht kann auf die letzten 24 Stunden, eine Woche, einen Monat, ein Jahr oder die gesamte Zeit beschränkt werden. Das Diagramm-Bucketing passt sich automatisch an: stündlich für 24h, täglich für Woche / Monat, monatlich für Jahr und gesamte Zeit."
+      },
+      "auditLog": {
+        "title": "Audit-Log",
+        "desc": "Jede Admin-Aktion — Rollenänderung, Sperren / Entsperren, Zwangssperre, Zwangslöschung, ESI-Corp-Wechsel, Auto-Sperre beim Corp-Austritt — wird mit Akteur, Ziel, alt → neu-Wert und Zeitstempel erfasst. Als CSV exportierbar."
+      },
+      "corpTicker": {
+        "title": "Corp-Ticker-Auflösung",
+        "desc": "Corp-IDs in den Benutzer- und Kartenberichten werden über ESI zu In-Game-Tickern aufgelöst, mit einem 1-stündigen In-Memory-Cache, um Berichtsladevorgänge günstig zu halten."
+      },
+      "perCharAttr": {
+        "title": "Zuordnung pro Charakter",
+        "desc": "Sigs, Strukturen sowie System-Hinzufügen- / -Löschen-Aktionen werden mit dem Benutzer erfasst, der sie ausgeführt hat, sodass Berichte ohne manuelle Protokollierung beantworten können, \"wer was gescannt hat\"."
+      }
+    },
+    "forCorpsBody": "Betreibe Nexum als gemeinsames Deployment für deine Corp oder Allianz. Mitglieder erhalten für die Corp sichtbare Kettenkarten und private persönliche Karten in einem Tool, mit rollenbasierten Berechtigungen, Admin-Werkzeugen und Aktivitätsberichten pro Charakter.",
+    "compareBody": "Sieh, wie sich Nexum gegen Pathfinder, Tripwire und Wanderer schlägt — Funktionen, Hosting und Kosten, direkt nebeneinander.",
+    "compareLink": "Nexum vs Pathfinder, Tripwire & Wanderer vergleichen →",
+    "discordCtaBody": "Komm in den Nexum-Discord — Feedback, Feature-Wünsche, Scanning-Chat und o7s sind alle willkommen.",
+    "aboutBody1": "Nexum ist ein Wurmloch- und Erkundungstool. Es kann zum Kartieren von Routen und zum Protokollieren von Signaturen verwendet werden. Es war stark von Pathfinder inspiriert — doch da Pathfinder nicht mehr aktiv entwickelt wird (kein neues Release seit 2020), wurde Nexum erstellt, statt sich darüber zu beschweren.",
+    "aboutBody2": "Nexum wird von einem einzigen Entwickler gebaut. Ich füge nach und nach Funktionen hinzu, aber melde dich, wenn du Support oder Feature-Wünsche hast.",
+    "aboutMe": "Nexum wird von Addelee als Soloprojekt geschrieben. Ich spiele EVE seit der Beta im Jahr 2003. Vielleicht siehst du mich in den Help-Kanälen oder im Scanning-Kanal abhängen. Ich habe in allen Bereichen des Alls gespielt — vom Leben in Wurmlöchern und Thera über Missionen im High Sec und Gate-Camping im Lowsec bis hin zum Null-Leben mit Goonswarm.<br></br><br></br>Im Hauptberuf bin ich Programmierer und betreibe <area404>Area 404</area404>. Deshalb habe ich beschlossen, dieses Tool zu schreiben. Ich bin ein begeisterter Entdecker in EVE und wollte daher ein Tool, das für mich funktioniert.<br></br><br></br>Nexum ist Open Source und ich heiße jeden willkommen, beizutragen. Über Feedback und gemeldete Bugs würde ich mich sehr freuen, also melde Dinge bitte auf <gh>GitHub</gh>",
+    "techStack1": "Nexum wird mit den feinsten Weltraummaterialien zusammengehalten, die Geld und Koffein kaufen können. Das Frontend ist <strong>React</strong> mit <strong>TypeScript</strong> — denn mit einem Compiler zu streiten ist immer noch produktiver, als mit einer Nullsec-Allianz zu streiten. Karten werden mit <strong>ReactFlow</strong> gerendert, das den ganzen Knoten-Zieh-Zirkus übernimmt, damit ich es nicht muss. Der State wird von <strong>Zustand</strong> verwaltet, das herrlich klein ist und mir nie gesagt hat, ich solle \"einfach Redux nehmen\".",
+    "techStack2": "Das Backend ist <strong>Node.js</strong> mit <strong>Express</strong> — bewährt, langweilig und es funktioniert. Die Daten liegen in <strong>PostgreSQL</strong>, befüllt mit CCPs Static Data Export, sodass Nexum tatsächlich weiß, was J213422 ist, ohne alle fünf Sekunden die ESI zu fragen. Die Authentifizierung übernimmt <strong>EVE Online SSO</strong> — deine Zugangsdaten berühren diesen Server nie, genau so, wie es sein sollte.",
+    "techStack3": "Live-System-Informationen kommen von der <strong>EVE ESI</strong> (CCPs offizielle API) und Kill-Daten von <strong>zKillboard</strong>. Das Ganze ist mit <strong>Docker</strong> containerisiert und über <strong>nginx</strong> geproxyt, weil jemand das Licht anlassen muss, während du aus deinem Wurmloch geräumt wirst.",
+    "faq": {
+      "whyNexum": {
+        "q": "Warum Nexum?",
+        "a": "Nexum ist das lateinische Wort für ein Band oder eine Verbindung — was für ein Tool passend wirkte, das rund um das Kartieren der Verbindungen zwischen Wurmlochsystemen gebaut ist. Es klingt außerdem vage nach etwas, das man in einem C6-Magnetar treiben sehen würde, was eigentlich der ausschlaggebende Faktor war."
+      },
+      "multipleAccounts": {
+        "q": "Kann ich mehrere Accounts nutzen?",
+        "a": "Ja — jeder EVE-Charakter erhält seinen eigenen Satz Karten. Melde dich einfach mit einem anderen Charakter über EVE SSO an, und Nexum hält ihre Karten vollständig getrennt. Keine Vermischung, kein versehentliches Teilen deiner streng geheimen Wurmlochkette mit deiner Alt-Corp."
+      },
+      "dataSafe": {
+        "q": "Sind meine Daten sicher?",
+        "a": "Nexum sieht dein EVE-Passwort nie — die Authentifizierung wird vollständig von CCPs EVE SSO abgewickelt. Gespeichert wird nur deine Charakteridentität und die Karten, die du baust. Deine Kartendaten liegen in einer privaten Datenbank und werden mit niemandem geteilt. Nutze Nexum dennoch nicht für die streng geheime Invasionsroute deiner Allianz — kein Tool im Internet ersetzt gute Operationssicherheit."
+      },
+      "reportBugs": {
+        "q": "Kann ich Bugs melden, Feedback geben und Features wünschen?",
+        "a": "Absolut. Das Projekt ist Open Source auf <gh>GitHub</gh> — eröffne ein Issue für Bugs oder Feature-Wünsche oder reiche einen Pull Request ein, wenn du dich traust. Feedback per In-Game-Mail an den mit diesem Account verbundenen Charakter funktioniert auch, falls GitHub nicht dein Ding ist."
+      },
+      "runYourself": {
+        "q": "Kann ich das selbst betreiben?",
+        "a": "Ja — Nexum ist vollständig selbst hostbar. Der Quellcode liegt auf <gh>GitHub</gh> und der gesamte Stack startet mit einem einzigen <code>docker compose up</code>. Du musst deine eigene EVE-Anwendung im <devportal>CCP-Entwicklerportal</devportal> registrieren, um SSO-Zugangsdaten zu erhalten, aber darüber hinaus deckt die README alles ab — einschließlich des Imports der EVE-Statikdaten und des Ausrichtens von Traefik darauf, falls das dein Ding ist. Wenn etwas kaputtgeht, eröffne ein Issue. Wenn du es behebst, eröffne bitte einen PR.<br></br><br></br>Es ist nicht das technischste, was man aufsetzen kann, aber ich würde empfehlen, dass du Grundkenntnisse über Docker und über den Server hast, auf dem du läufst (Linux?)"
+      },
+      "goonTrust": {
+        "q": "Aber du bist ein Goon, warum sollten wir dir vertrauen?",
+        "a": "Faire Frage, und ehrlich gesagt der richtige Instinkt für New Eden. Der Code ist vollständig Open Source — du darfst gern jede Zeile lesen, ihn selbst betreiben oder von jemandem, dem du vertraust, prüfen lassen. Nexum hat kein Interesse an deinen Scout-Routen, der Killboard-Schmach deiner Corp oder was auch immer du in diesem C5 geparkt hast. Das Schlimmste, was ein Goon je in einem Wurmloch getan hat, ist, aus einem geräumt zu werden, und ich würde dir gern helfen, diesem Schicksal zu entgehen."
+      },
+      "roadmap": {
+        "q": "Hast du eine Roadmap für neue Features?",
+        "a": "Lose. Derzeit funktioniert das System nur mit Solo-Spielern. Der nächste logische Schritt wäre, dies für Corporations und Allianzen umzusetzen. Sobald ich etwaige Bugs aus diesem ersten Launch ausgebügelt habe, beginne ich daran zu arbeiten.<br></br>Das setzt voraus, dass das echte Leben nicht dazwischenkommt!<br></br><br></br>Wenn du ein dringendes Feature möchtest, schreib mir im Spiel und wir können plaudern."
+      },
+      "donateIsk": {
+        "q": "Kann ich ISK spenden?",
+        "a": "Ich hätte es lieber, wenn du das nicht tust, nein. Ich mache das nicht für ISK, also behalte es und gib es für etwas aus, in dem du in die Luft fliegen oder jemand anderen in die Luft jagen kannst!"
+      }
+    },
+    "footer": "EVE Online und das EVE-Logo sind eingetragene Marken von CCP hf. Alle Rechte weltweit vorbehalten. Nexum ist ein Drittanbieter-Tool und steht in keiner Verbindung zu CCP hf und wird von ihnen nicht unterstützt. · <license>Lizenz- & EVE-IP-Hinweis</license>"
+  },
   "mapNode": {
     "unknown": "Unbekannt",
     "homeSystem": "Heimatsystem",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -778,6 +778,286 @@
       "closest": "Closest {{label}} system"
     }
   },
+  "landing": {
+    "tagline": "Wormhole chain mapping for EVE Online",
+    "demoNote": "◈ Interactive demo — a simplified preview. Sign in to access signatures, kill feeds, connection tracking, activity history, and more.",
+    "cta": {
+      "continueAs": "Continue as",
+      "sessionExpired": "Session expired — click your portrait to log back in via EVE SSO.",
+      "switchChar": "Log in as a different character",
+      "secureLogin": "Secure EVE SSO login — no passwords stored. Character identity only.",
+      "loginAlt": "Log in with EVE Online",
+      "joinDiscord": "Join the Nexum Discord"
+    },
+    "errors": {
+      "not_in_corp": "Your character is not a member of the corporation that runs this Nexum instance. Access is restricted to corp members only.",
+      "corp_check_failed": "Could not verify your corporation membership due to an ESI error. Please try again in a moment.",
+      "unknown": "An unknown error occurred. Please try again."
+    },
+    "sections": {
+      "mapping": "Mapping",
+      "personalCorp": "Personal & corp maps",
+      "sysIntel": "System intelligence",
+      "liveOps": "Live ops",
+      "productivity": "Productivity & UX",
+      "forCorps": "For Corporations",
+      "compare": "How does Nexum compare?",
+      "discordCta": "Got questions, ideas, or bugs?",
+      "about": "About Nexum",
+      "aboutMe": "About Me",
+      "techStack": "Tech Stack",
+      "faqs": "FAQs"
+    },
+    "features": {
+      "interactiveMap": {
+        "title": "Interactive map",
+        "desc": "Drag systems, draw connections, set wormhole class / type / status per connection. Snap-to-grid and an optional minimap."
+      },
+      "seedRegion": {
+        "title": "Seed a map from a region",
+        "desc": "Spin up a new map pre-populated with an entire EVE region — every system laid out from CCP's 2D star-map projection (a Dotlan-style layout) with all stargate connections drawn. Pick a region when creating a map, or leave it blank for an empty one."
+      },
+      "whIntel": {
+        "title": "Wormhole intel",
+        "desc": "Per-connection mass status (stable / destabilized / critical), end-of-life flag with countdown, K162-aware static identification, and frig-hole / gas-site auto-tagging from sig type."
+      },
+      "rollingCalc": {
+        "title": "Rolling calculator",
+        "desc": "Plan and track collapsing a hole from its connection panel. Models the ±10% mass variance and forecasts each pass safe / may-collapse / will-collapse against the worst case. Define a roller ship (cold + prop-on mass, or pull your flown ship from ESI), step through passes with side-tracking that warns before a pass strands you on the far side, and see an \"≈ N passes left\" estimate. Cumulative mass syncs live to everyone viewing the hole."
+      },
+      "whPicker": {
+        "title": "Wormhole type picker",
+        "desc": "Searchable popover for assigning the exact wormhole type to a connection. Statics quick-info on hover shows destination class, mass, and lifetime."
+      },
+      "multiSelect": {
+        "title": "Multi-select bulk operations",
+        "desc": "Shift-click to select multiple systems or signatures, then bulk-assign type, delete, or rename in a single action."
+      },
+      "pngExport": {
+        "title": "PNG export",
+        "desc": "Render the current map — with sig counts, connections, and status — to a PNG you can drop into a fleet ping or a corp Discord."
+      },
+      "sigAging": {
+        "title": "Wormhole sig aging",
+        "desc": "Wormhole sigs tint by their position in the WH type's known lifetime — yellow at 50%, orange at 90%, red past expected close. Catches forgotten chains before they collapse on someone."
+      },
+      "soloCorp": {
+        "title": "Solo / Corp split",
+        "desc": "Every user has personal maps that are always private; in corp mode each corp also gets shared corp maps. Cross-corp visibility is opt-in via a single env flag."
+      },
+      "multiMap": {
+        "title": "Multi-map support",
+        "desc": "Each character (or corp) can maintain multiple independent maps up to configured limits — separate chains for separate ops without losing context."
+      },
+      "mergeMaps": {
+        "title": "Merge maps",
+        "desc": "Fold one map into another. The destination is kept as the source of truth — only missing systems and connections are added, with signatures, structures, and notes merged in, and new systems slotted into the existing layout. Corp maps opt in per role as a merge source and/or destination."
+      },
+      "realtime": {
+        "title": "Real-time collaboration",
+        "desc": "Edits sync live to everyone viewing the same map — systems, connections, rename/lock, signatures, structures, and merges all appear for other viewers within moments, no refresh. Streamed per map (you only get events for maps you can see), with your own changes echo-suppressed and an auto-resync on reconnect."
+      },
+      "mapLocking": {
+        "title": "Map locking",
+        "desc": "Admins can freeze a corp map's topology. Systems and connections lock for non-admins, but signatures, structures, and per-system notes stay editable so ops continue while the layout is pinned."
+      },
+      "rbac": {
+        "title": "Role-based access",
+        "desc": "Four tiers — readonly, edit, full, admin — gating corp-map actions. Personal maps stay yours regardless of role."
+      },
+      "systemPanel": {
+        "title": "System panel",
+        "desc": "Per-system cards for signatures, structures, NPC stations, notes, killboard, and activity charts. Cards are reorderable via drag-and-drop and persist per-user."
+      },
+      "sigMgmt": {
+        "title": "Signature management",
+        "desc": "Paste straight from the probe scanner. Tracks created / updated age per signature, auto-deletes sigs missing from a re-paste, and supports bulk type assignment for multi-select."
+      },
+      "structImport": {
+        "title": "Structure import",
+        "desc": "Paste EVE overview data to import player-owned structures with names, types, owners, and notes in one operation."
+      },
+      "autoStruct": {
+        "title": "Auto-discovered structures",
+        "desc": "Your corp's citadels (via ESI when a member with the Station Manager role logs in) and any publicly-listed structures from a third-party feed appear automatically in the structures pane as read-only entries — already tinted by your standings toward the owner."
+      },
+      "activityCharts": {
+        "title": "Activity charts",
+        "desc": "24-hour rolling history of jumps, ship / pod kills, and NPC kills per system, polled from ESI hourly. The poller persists data for every k-space system — not just ones someone has opened — so charts populate the moment you view a new system."
+      },
+      "sovStation": {
+        "title": "Sovereignty & station data",
+        "desc": "Live alliance / corp / faction sov info and NPC station services, with in-game waypoint and destination actions."
+      },
+      "killboard": {
+        "title": "Killboard pane",
+        "desc": "Recent zKillboard activity per system, with NPC-only kills hidden by default (toggle to include). Rows tint red when a hostile actor is in the chain or a blue gets killed; blue when a friendly scores or a hostile dies. Recent kills also bubble up as highlights on the map."
+      },
+      "effectDigest": {
+        "title": "Chain-wide effect digest",
+        "desc": "A one-line summary at the top of the system info panel lists every Pulsar / Wolf-Rayet / Magnetar / etc. on the current chain. Hover for the modifier list; click to centre."
+      },
+      "standings": {
+        "title": "Standings overlay",
+        "desc": "Your EVE contact list (personal, corp, and alliance — fetched via ESI on login and re-pullable on demand) drives a chain-wide visual layer. Sov holders show inline P/C/A standing pills; structures resolved via their EVE structure ID tint by owner-corp standing; sov-holder system nodes get a coloured halo so hostile territory stands out on the map."
+      },
+      "scout": {
+        "title": "Scout connections",
+        "desc": "Thera and Turnur public Eve-Scout connections surfaced into the sidebar so you can jump straight to known holes."
+      },
+      "a0": {
+        "title": "A0 sun detection",
+        "desc": "Auto-flags systems with A0 (yellow) suns visible via ESI for capital-friendly skirmish planning."
+      },
+      "iceBelt": {
+        "title": "Ice belt systems",
+        "desc": "Flags Empire-space systems that spawn ice anomalies with a ❄ icon — handy when staging mining ops or looking for an alternate harvest spot. Static dataset committed in-repo and resolved to system IDs at startup."
+      },
+      "storms": {
+        "title": "Storm tracking",
+        "desc": "Active null-sec storms — Electric, Gamma, Exotic, Plasma — sourced from the community-maintained EveScout Rescue stormtrack feed surface as a colour-coded ⚡ on matching system nodes. Tooltip shows storm name, last report, and reporter. Refreshed every 30 minutes."
+      },
+      "proximity": {
+        "title": "Proximity alerts",
+        "desc": "Browser notification plus an audio ping when you're within a configurable number of jumps of an active incursion, pirate insurgency, or a sov-holding system whose corp / alliance you've set to red. Persistent toolbar chip shows the nearest threat at a glance."
+      },
+      "discordNotif": {
+        "title": "Discord notifications",
+        "desc": "Push corp chain intel to a Discord channel so alerts land even when nobody's watching the tab. Fires server-side on an inbound K162 or a new wormhole connection, scoped to corp maps. Admins filter which regions and maps notify from the admin panel. Best-effort and rate-limit-aware; bulk operations like region seeding never spam the channel."
+      },
+      "routePlanner": {
+        "title": "Route planner",
+        "desc": "Server-side BFS over stargates plus your live chain, so a route through a wormhole hop is a single click."
+      },
+      "locationTracking": {
+        "title": "Location tracking",
+        "desc": "Opt-in live character location dot in the toolbar, plus a per-map \"you are here\" indicator that updates every 10 seconds via ESI."
+      },
+      "presence": {
+        "title": "Pilot presence",
+        "desc": "See where everyone viewing the same map is right now — a blue dot (pilot name on hover) marks each other viewer's current system, live as they jump. Covers anyone with the map open, not just your fleet; opt-in and nothing is stored."
+      },
+      "onlineStatus": {
+        "title": "Online status",
+        "desc": "Toolbar dot shows whether each logged-in user is currently signed into EVE Online, so you can see at a glance who's actually on grid."
+      },
+      "commandPalette": {
+        "title": "Command palette",
+        "desc": "⌘ / Ctrl + K opens a fuzzy search across systems, sigs, and actions — jump to a system, set a waypoint, or toggle a pane without touching the mouse."
+      },
+      "homeHotkey": {
+        "title": "Home hotkey",
+        "desc": "Hit H to jump the viewport back to your home system from any panel. Right-click a system to set or change which one is home."
+      },
+      "killHighlights": {
+        "title": "Recent-kill highlights",
+        "desc": "Systems with kills in the last hour get a coloured halo so you can see fresh activity at a glance across the chain."
+      },
+      "userStats": {
+        "title": "User stats modal",
+        "desc": "Per-character totals: jumps, signatures by type, broken down by day / week / month / year / forever."
+      },
+      "serverStatus": {
+        "title": "Server status widget",
+        "desc": "Live Tranquility server status, player count, and ESI health in the toolbar. Cross-tab cached so all your open windows share a single ESI poll."
+      },
+      "demoMap": {
+        "title": "Demo map",
+        "desc": "The landing page mounts a non-editable demo map so visitors can see what the tool does before logging in."
+      },
+      "sidebar": {
+        "title": "Collapsible sidebar",
+        "desc": "Map Options, Connections, Proximity Alerts, Stale System Fade, and Shortcuts each expand or collapse independently. Per-section state persists per browser via localStorage."
+      }
+    },
+    "corpFeatures": {
+      "multiCorp": {
+        "title": "Multi-corp deployments",
+        "desc": "CORP_ID accepts a comma-separated list of corporation IDs. One Nexum instance can host several corps; each corp's maps stay scoped to its own members unless CORP_MAP_SHARED=true."
+      },
+      "adminDash": {
+        "title": "Admin dashboard",
+        "desc": "A dedicated /admin page with four tabs: Users, Maps, Reports, and Audit log. Admins reach it from the toolbar's Admin button."
+      },
+      "userMgmt": {
+        "title": "User management",
+        "desc": "Change roles, block / unblock, and force an ESI corp-membership re-check on demand. Self-block, self-demote, and changes to ADMIN_CHAR_ID are guarded against."
+      },
+      "mapMgmt": {
+        "title": "Map management",
+        "desc": "Admins see every corp map with owner avatar, corp ticker, system / connection counts, lock state, and last-active time. Force-lock, force-unlock, and force-delete are one-click each."
+      },
+      "usersReport": {
+        "title": "Users report",
+        "desc": "Per-character last login, systems added / deleted, structures added, signatures broken down by type, and last-corp-activity timestamps. Sortable, filterable by activity and time window, exportable as CSV."
+      },
+      "systemsReport": {
+        "title": "Systems report",
+        "desc": "Aggregate corp-map signatures with a sig-type donut, a daily / monthly activity line chart (bucketing adapts to the window), and a sortable wormhole-type breakdown."
+      },
+      "timeWindowed": {
+        "title": "Time-windowed reporting",
+        "desc": "Every report can be scoped to past 24 hours, week, month, year, or all time. Chart bucketing adapts automatically: hourly for 24h, daily for week / month, monthly for year and all-time."
+      },
+      "auditLog": {
+        "title": "Audit log",
+        "desc": "Every admin action — role change, block / unblock, force-lock, force-delete, ESI corp change, auto-block on corp departure — is recorded with actor, target, old → new value, and timestamp. Exportable as CSV."
+      },
+      "corpTicker": {
+        "title": "Corp ticker resolution",
+        "desc": "Corp IDs in the Users and Maps reports are resolved to in-game tickers via ESI, with a 1-hour in-memory cache to keep report loads cheap."
+      },
+      "perCharAttr": {
+        "title": "Per-character attribution",
+        "desc": "Sigs, structures, and system add / delete actions are recorded with the user who made them, so reports can answer \"who has been scanning what\" with no manual logging."
+      }
+    },
+    "forCorpsBody": "Run Nexum as a shared deployment for your corp or alliance. Members get visible-to-the-corp chain maps and private personal maps in one tool, with role-based permissions, admin tooling, and per-character activity reporting.",
+    "compareBody": "See how Nexum stacks up against Pathfinder, Tripwire and Wanderer — features, hosting and cost, side by side.",
+    "compareLink": "Compare Nexum vs Pathfinder, Tripwire & Wanderer →",
+    "discordCtaBody": "Drop into the Nexum Discord — feedback, feature requests, scanning chat and o7s all welcome.",
+    "aboutBody1": "Nexum is a wormhole and exploration tool. It can be used for mapping routes and logging signatures. It was heavily inspired by Pathfinder — but with Pathfinder no longer actively developed (no new release since 2020), rather than complain about it, Nexum was created.",
+    "aboutBody2": "Nexum is built by a single developer. I'm adding features as we go but get in contact if you want support or feature requests",
+    "aboutMe": "Nexum is written by Addelee as a solo project. I've played eve since Beta back in 2003. You might see me hanging out in the Help channels or the Scanning channel. I've played in all areas of space from living in wormholes and thera, running missions in High Sec, gate camping in lowsec and now, null life with Goonswarm.<br></br><br></br>As a day job, I am a programmer and run <area404>Area 404</area404>. Because of this, I decided I'd write this tool. I'm an avid explorer in Eve therefore I wanted a tool that worked for me.<br></br><br></br>Nexum is open source and I welcome anyone to contribute. I would definitely appreciate feedback and any bugs you encounter so please flag things on <gh>GitHub</gh>",
+    "techStack1": "Nexum is held together with the finest space-age materials money and caffeine can buy. The frontend is <strong>React</strong> with <strong>TypeScript</strong> — because arguing with a compiler is still more productive than arguing with a nullsec alliance. Maps are rendered with <strong>ReactFlow</strong>, which handles all the node-dragging shenanigans so I didn't have to. State is managed by <strong>Zustand</strong>, which is delightfully small and has never once told me to \"just use Redux\".",
+    "techStack2": "The backend is <strong>Node.js</strong> with <strong>Express</strong> — proven, boring, and it works. Data lives in <strong>PostgreSQL</strong>, seeded with CCP's Static Data Export so Nexum actually knows what J213422 is without asking the ESI every five seconds. Authentication is handled by <strong>EVE Online SSO</strong> — your credentials never touch this server, which is exactly how it should be.",
+    "techStack3": "Live system intelligence comes from the <strong>EVE ESI</strong> (CCP's official API) and kill data from <strong>zKillboard</strong>. The whole thing is containerised with <strong>Docker</strong> and proxied through <strong>nginx</strong>, because someone has to keep the lights on while you're getting evicted from your wormhole.",
+    "faq": {
+      "whyNexum": {
+        "q": "Why Nexum?",
+        "a": "Nexum is the Latin word for a bond or connection — which felt appropriate for a tool built around mapping the connections between wormhole systems. It also sounds vaguely like something you'd find floating in a C6 magnetar, which was really the deciding factor."
+      },
+      "multipleAccounts": {
+        "q": "Can I use multiple accounts?",
+        "a": "Yes — each EVE character gets their own set of maps. Just log in with a different character via EVE SSO and Nexum will keep their maps completely separate. No cross-contamination, no accidental sharing of your super-secret wormhole chain with your alt corp."
+      },
+      "dataSafe": {
+        "q": "Is my data safe?",
+        "a": "Nexum never sees your EVE password — authentication is handled entirely by CCP's EVE SSO. The only thing stored is your character identity and the maps you build. Your map data lives in a private database and is not shared with anyone. That said, don't use Nexum for your alliance's top-secret invasion route — no tool on the internet is a substitute for good operational security."
+      },
+      "reportBugs": {
+        "q": "Can I report bugs, add feedback and request features?",
+        "a": "Absolutely. The project is open source on <gh>GitHub</gh> — open an issue for bugs or feature requests, or submit a pull request if you're feeling brave. Feedback via in-game mail to the character tied to this account also works if GitHub isn't your thing."
+      },
+      "runYourself": {
+        "q": "Can I run this myself?",
+        "a": "Yes — Nexum is fully self-hostable. The source is on <gh>GitHub</gh> and the whole stack spins up with a single <code>docker compose up</code>. You'll need to register your own EVE application on the <devportal>CCP developer portal</devportal> to get SSO credentials, but beyond that the README covers everything — including importing the EVE static data and pointing Traefik at it if that's your thing. If something breaks, open an issue. If you fix it, please open a PR.<br></br><br></br>It isn't the most technical thing to run up but I'd recommend you have basic knownledge of docker and whatever server your running on (Linux?)"
+      },
+      "goonTrust": {
+        "q": "But you're a Goon, why would we trust you?",
+        "a": "Fair question, and honestly the correct instinct to have in New Eden. The code is fully open source — you're welcome to read every line, run it yourself, or have someone you trust audit it. Nexum has no interest in your scouting routes, your corp's killboard shame, or whatever you've got parked in that C5. The worst thing a Goon has ever done in a wormhole is get evicted from one, and I'd like to help you avoid that fate."
+      },
+      "roadmap": {
+        "q": "Do you have a roadmap for new features?",
+        "a": "Loosely. Currently the system only works with solo players. The next logical thing would be to implement this for Corporations and Alliances. Once I iron out any bugs from this initial launch, I'll start work on that.<br></br>This does assume real life work doesn't get in the way!<br></br><br></br>If you have any pressing feature you want, drop me a message ingame and we can chat."
+      },
+      "donateIsk": {
+        "q": "Can I donate ISK?",
+        "a": "I prefer it if you did not, no. I'm not doing this for ISK so keep it and spend it on something to blow up in or blow someone else up in!"
+      }
+    },
+    "footer": "EVE Online and the EVE logo are the registered trademarks of CCP hf. All rights reserved worldwide. Nexum is a third-party tool and is not affiliated with or endorsed by CCP hf. · <license>License & EVE IP notice</license>"
+  },
   "mapNode": {
     "unknown": "Unknown",
     "homeSystem": "Home system",


### PR DESCRIPTION
## Landing page i18n

Localises the entire marketing landing page — the last string-extraction piece of stage 3. Adds a comprehensive `landing` namespace to `en/common.json` and `de/common.json`.

### What's translated
- Header tagline and the interactive-demo note
- Login CTAs (continue-as / session-expired / switch-character / secure-login / EVE-SSO alt text) and the `?error=` login messages
- All five feature sections (~40 cards) and the **For Corporations** grid (10 cards)
- Compare CTA + link, Discord CTA
- About Nexum, About Me, Tech Stack prose
- The full FAQ list — including your new **"Can I donate ISK?"** entry, folded in and translated
- Footer (CCP trademark notice + licence link)

### Implementation notes
- Feature / corp-feature cards are now keyed by typed ids (`FeatureId` / `CorpFeatureId` / `SectionId`) so the dynamic `t(\`landing.features.${id}.title\`)` lookups type-check.
- Rich-text blocks render via `<Trans>`: About Me (Area 404 + GitHub links), Tech Stack (`<strong>`), the FAQ GitHub / dev-portal / inline `<code>` bits, the roadmap `<br>`s, and the footer licence link. Init already keeps `br`/`strong` as basic nodes; `<a>`/`<code>` are passed as components.

### Deliberately left untranslated
- SEO `<title>` / `<meta>` tags (kept canonical English)
- Brand name (Nexum), tech-stack product names (React, PostgreSQL, …), and EVE-canonical data

Verified with `yarn build`. Your App.css sidebar sizing tweak was left out of this PR. Based directly on `localization` (no stacking).

After this merges, all string extraction is done — next is stage 4 (a full second-language QA pass), then `localization` → `release`.
