### PR TITLE
i18n: language picker on landing + comparison pages

### DIFF
--- a/web/public/compare/index.html
+++ b/web/public/compare/index.html
@@ -100,8 +100,12 @@
       }
       .wrap { max-width: 920px; margin: 0 auto; padding: 32px 20px 64px; }
       a { color: var(--accent); }
-      .topnav { font-size: 14px; }
+      .topnav { font-size: 14px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
       .topnav a { color: var(--muted); text-decoration: none; }
+      .lang-select {
+        background: var(--panel2); color: var(--text); border: 1px solid var(--border);
+        border-radius: 6px; padding: 4px 8px; font-size: 13px; font-family: inherit; cursor: pointer;
+      }
       header.hero { text-align: center; margin: 28px 0 8px; }
       .logo { font-size: 34px; color: var(--accent); line-height: 1; }
       h1 { color: var(--head); font-size: 30px; line-height: 1.25; margin: 12px 0 6px; }
@@ -135,7 +139,13 @@
   </head>
   <body>
     <div class="wrap">
-      <nav class="topnav"><a href="/" data-i18n="nav">&larr; Nexum home</a></nav>
+      <nav class="topnav">
+        <a href="/" data-i18n="nav">&larr; Nexum home</a>
+        <select id="lang-select" class="lang-select" aria-label="Language / Sprache">
+          <option value="en">English</option>
+          <option value="de">Deutsch</option>
+        </select>
+      </nav>
 
       <header class="hero">
         <div class="logo" aria-hidden="true">◈</div>
@@ -416,6 +426,19 @@
         try {
           var lang = localStorage.getItem('nexum.lang');
           if (!lang) lang = (navigator.language || '').slice(0, 2) === 'de' ? 'de' : 'en';
+
+          // Wire up the language picker regardless of the current language so
+          // a German visitor can switch back to English too. Persists to the
+          // same nexum.lang key the app uses, then reloads to re-run the swap.
+          var sel = document.getElementById('lang-select');
+          if (sel) {
+            sel.value = (lang === 'de') ? 'de' : 'en';
+            sel.addEventListener('change', function () {
+              try { localStorage.setItem('nexum.lang', sel.value); } catch (e) { /* ignore */ }
+              location.reload();
+            });
+          }
+
           if (lang !== 'de') return;
 
           var DE = {

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@phosphor-icons/react';
 import { apiUrl } from '../../api/client';
 import { DemoMap } from './DemoMap';
+import { LanguageSwitcher } from './LanguageSwitcher';
 import portraitImg from '../../assets/portrait.jpeg';
 interface LastCharacter { characterId: number; characterName: string; }
 
@@ -280,6 +281,9 @@ export function LandingPage() {
       <header className="landing__header">
         <canvas ref={canvasRef} className="landing__canvas" />
         <div className="landing__header-fade" />
+        <div style={{ position: 'absolute', top: 16, right: 16, zIndex: 3 }}>
+          <LanguageSwitcher />
+        </div>
         <div className="landing__logo">◈</div>
         <h1 className="landing__title">Nexum</h1>
         <p className="landing__tagline">{t('landing.tagline')}</p>
@@ -431,8 +435,8 @@ export function LandingPage() {
               <Trans
                 i18nKey="landing.aboutMe"
                 components={{
-                  area404: <a href="https://area404.org" target="_blank" className="landing__faq-link" />,
-                  gh: <a href="https://github.com/GQuantrill/eve-nexum/issues" target="_blank" className="landing__faq-link" />,
+                  area404: <a href="https://area404.org" target="_blank" rel="noopener noreferrer" className="landing__faq-link" />,
+                  gh: <a href="https://github.com/GQuantrill/eve-nexum/issues" target="_blank" rel="noopener noreferrer" className="landing__faq-link" />,
                 }}
               />
             </p>


### PR DESCRIPTION
## Language picker on the landing & comparison pages

Logged-out visitors had no way to change language — only the in-app toolbar exposed one. This adds a picker to both public pages.

### Landing page
Reuses the existing `<LanguageSwitcher />` component (so language persists to the same `nexum.lang` key and the option list stays single-sourced), positioned top-right of the hero header.

### Comparison page (static HTML)
A native `English / Deutsch` `<select>` in the top nav. On change it writes `nexum.lang` to localStorage and reloads, so the page's existing runtime swap re-applies. The picker is wired up **regardless of the current language**, so a German visitor can switch back to English too; the dropdown reflects the active language on load.

### Notes
- Landing switcher is positioned with an inline style to avoid touching `App.css` (which has an unrelated pending local change).
- Also added `rel="noopener noreferrer"` to the two About Me links (cleared a lint error).

Verified: `yarn build` clean, compare inline script passes `node --check`, `data-i18n` coverage still 83/83. Based directly on `localization`.
