### PR TITLE
i18n: style language picker + add flags

### DIFF
--- a/web/public/compare/index.html
+++ b/web/public/compare/index.html
@@ -104,8 +104,14 @@
       .topnav a { color: var(--muted); text-decoration: none; }
       .lang-select {
         background: var(--panel2); color: var(--text); border: 1px solid var(--border);
-        border-radius: 6px; padding: 4px 8px; font-size: 13px; font-family: inherit; cursor: pointer;
+        border-radius: 4px; padding: 4px 8px; font-size: 13px; font-family: inherit; cursor: pointer;
+        transition: border-color 0.15s ease;
       }
+      .lang-select:hover { border-color: var(--accent); }
+      .lang-select:focus-visible {
+        outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px rgba(91,155,255,0.25);
+      }
+      .lang-select option { background: var(--panel); color: var(--text); }
       header.hero { text-align: center; margin: 28px 0 8px; }
       .logo { font-size: 34px; color: var(--accent); line-height: 1; }
       h1 { color: var(--head); font-size: 30px; line-height: 1.25; margin: 12px 0 6px; }
@@ -142,8 +148,8 @@
       <nav class="topnav">
         <a href="/" data-i18n="nav">&larr; Nexum home</a>
         <select id="lang-select" class="lang-select" aria-label="Language / Sprache">
-          <option value="en">English</option>
-          <option value="de">Deutsch</option>
+          <option value="en">🇬🇧 English</option>
+          <option value="de">🇩🇪 Deutsch</option>
         </select>
       </nav>
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3439,6 +3439,33 @@ select.sig-toolbar-btn option {
   color: #c0ccde;
 }
 
+/* Language picker (toolbar + landing hero). Matches the site's dark
+   selects; native option rows forced dark so the dropdown panel isn't
+   light on a dark page. */
+.toolbar__lang-select {
+  background: #0a0e1a;
+  border: 1px solid #1e2740;
+  border-radius: 4px;
+  color: #c8d0e0;
+  font-family: inherit;
+  font-size: calc(13px * var(--font-scale, 1));
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+.toolbar__lang-select:hover {
+  border-color: #4d9de0;
+}
+.toolbar__lang-select:focus-visible {
+  outline: none;
+  border-color: #4d9de0;
+  box-shadow: 0 0 0 2px rgba(77, 157, 224, 0.25);
+}
+.toolbar__lang-select option {
+  background: #0d1117;
+  color: #c8d0e0;
+}
+
 .sig-notes-cell {
   vertical-align: top;
   padding: 2px 4px;

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -2,10 +2,11 @@ import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../../i18n';
 
 // Native language names — these read the same in every locale, so they're not
-// translated (English is always "English", German always "Deutsch").
+// translated (English is always "English", German always "Deutsch"). Prefixed
+// with a flag emoji; English uses the GB flag (the app's English is en-GB).
 const LANGUAGE_NAMES: Record<SupportedLanguage, string> = {
-  en: 'English',
-  de: 'Deutsch',
+  en: '🇬🇧 English',
+  de: '🇩🇪 Deutsch',
 };
 
 export function LanguageSwitcher() {

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -355,8 +355,6 @@ export function Toolbar() {
         <SlidersHorizontalIcon size={18} weight="regular" />
       </button>
 
-      <LanguageSwitcher />
-
       <div className="toolbar__server-status">
         <div className="toolbar__server-row">
           <span
@@ -446,6 +444,7 @@ export function Toolbar() {
             </span>
             {checkedAt && <CheckedAtLabel checkedAt={checkedAt} />}
           </div>
+          <LanguageSwitcher />
           <button
             className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
             onClick={logout}


### PR DESCRIPTION
## Style the language picker + add country flags

Follow-up to the language picker: theme it to match the site and add flags.

### Styling
- `.toolbar__lang-select` (used in the in-app toolbar **and** the landing hero) now matches the site's dark selects — panel background, themed border, accent hover + focus ring, and dark option rows — instead of the browser default.
- The comparison page's `.lang-select` gets the same hover/focus treatment and dark option rows.

### Flags
- 🇬🇧 **English** (the app's English is en-GB) and 🇩🇪 **Deutsch**, in both the React `LanguageSwitcher` and the static comparison page `<select>`.

### Notes
- My `App.css` change was committed in isolation (via `git stash`) so it does **not** include the unrelated pending sidebar-sizing tweak in your working tree — that's left untouched.
- Spotted a pre-existing unrelated bug nearby: `.wh-picker__group-hdr { color: #grey; }` (invalid CSS — the browser ignores it). Left as-is to keep this PR scoped; easy to fix separately if you want.

Verified: `yarn build` clean, compare inline script passes `node --check`. Based directly on `localization`.
