### PR TITLE
i18n: translate map control tooltips

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -125,6 +125,17 @@ export function MapCanvas() {
   const [contextMenu, setContextMenu]         = useState<CtxMenu | null>(null);
   const [customIntel] = useCustomIntel();
 
+  // React Flow's <Controls> buttons read their hover title + aria-label from
+  // ariaLabelConfig (merged with the library defaults), so this translates the
+  // zoom / fit / lock tooltips without re-implementing the buttons.
+  const ariaLabelConfig = useMemo(() => ({
+    'controls.ariaLabel':            t('mapControls.panel'),
+    'controls.zoomIn.ariaLabel':     t('mapControls.zoomIn'),
+    'controls.zoomOut.ariaLabel':    t('mapControls.zoomOut'),
+    'controls.fitView.ariaLabel':    t('mapControls.fitView'),
+    'controls.interactive.ariaLabel': t('mapControls.interactive'),
+  }), [t]);
+
   // Empty initial — the `systems` effect below replaces this on the next
   // frame with the real node set. Starting empty avoids the dead useMemo that
   // only ever ran once before being overwritten.
@@ -789,6 +800,7 @@ export function MapCanvas() {
   return (
     <div className="map-canvas">
       <ReactFlow
+        ariaLabelConfig={ariaLabelConfig}
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}

--- a/web/src/components/ui/DemoMap.tsx
+++ b/web/src/components/ui/DemoMap.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   ReactFlow, ReactFlowProvider, Background, Controls, Panel,
   useNodesState, useEdgesState, addEdge, BackgroundVariant,
@@ -262,9 +263,18 @@ interface CtxMenu { x: number; y: number; nodeId?: string }
 interface AddFormState { flowX: number; flowY: number }
 
 function DemoMapInner() {
+  const { t } = useTranslation();
   const [nodes, setNodes, onNodesChange] = useNodesState(INITIAL_NODES);
   const [edges, setEdges, onEdgesChange] = useEdgesState(INITIAL_EDGES);
   const { screenToFlowPosition, getNodes } = useReactFlow();
+
+  // Translate the zoom / fit control tooltips (see MapCanvas for the same).
+  const ariaLabelConfig = useMemo(() => ({
+    'controls.ariaLabel':         t('mapControls.panel'),
+    'controls.zoomIn.ariaLabel':  t('mapControls.zoomIn'),
+    'controls.zoomOut.ariaLabel': t('mapControls.zoomOut'),
+    'controls.fitView.ariaLabel': t('mapControls.fitView'),
+  }), [t]);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [ctxMenu, setCtxMenu] = useState<CtxMenu | null>(null);
@@ -384,6 +394,7 @@ function DemoMapInner() {
 
       <div className="demo-canvas-wrap">
         <ReactFlow
+          ariaLabelConfig={ariaLabelConfig}
           nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -478,6 +478,13 @@
     "rollIt": "Durchrollen",
     "removeConnection": "Verbindung entfernen"
   },
+  "mapControls": {
+    "panel": "Steuerungsfeld",
+    "zoomIn": "Vergrößern",
+    "zoomOut": "Verkleinern",
+    "fitView": "Ansicht einpassen",
+    "interactive": "Interaktivität umschalten"
+  },
   "ctxMenu": {
     "disconnect": "Trennen",
     "jumpType": "Sprungtyp",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -478,6 +478,13 @@
     "rollIt": "Roll it",
     "removeConnection": "Remove Connection"
   },
+  "mapControls": {
+    "panel": "Control panel",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitView": "Fit view",
+    "interactive": "Toggle interactivity"
+  },
   "ctxMenu": {
     "disconnect": "Disconnect",
     "jumpType": "Jump Type",


### PR DESCRIPTION
## Translate the map control tooltips

The map's zoom/fit/lock control stack (React Flow's `<Controls>`) had hardcoded English hover tooltips: *Zoom in*, *Zoom out*, *Fit view*, *Toggle interactivity*.

React Flow 12 exposes an `ariaLabelConfig` prop that drives **both** the button `title` (the hover tooltip) and its `aria-label`, and it's merged with the library defaults — so passing a translated partial fixes the tooltips without re-implementing the buttons or their icons.

### Changes
- New `mapControls` namespace (en + de): `panel`, `zoomIn`, `zoomOut`, `fitView`, `interactive`.
- `MapCanvas` (main map) and `DemoMap` (landing demo) each pass a memoised `ariaLabelConfig` built from `t(...)`.

German: *Vergrößern · Verkleinern · Ansicht einpassen · Interaktivität umschalten*.

Verified with `yarn build`. Based directly on `localization` (independent of the open picker PR #71 — no file overlap).
