### PR TITLE
i18n: translate the landing-page demo map

### DIFF
--- a/web/src/components/ui/DemoMap.tsx
+++ b/web/src/components/ui/DemoMap.tsx
@@ -122,6 +122,7 @@ function resolveOverlaps(
 // ── demo node ────────────────────────────────────────────────
 
 function DemoSystemNode({ data, selected }: NodeProps) {
+  const { t } = useTranslation();
   const sys = data as unknown as DemoSys;
   const color = CLASS_COLORS[sys.systemClass];
   const connection = useConnection();
@@ -147,11 +148,11 @@ function DemoSystemNode({ data, selected }: NodeProps) {
         )}
       </div>
 
-      <div className="system-node__name">{sys.name || 'Unknown'}</div>
+      <div className="system-node__name">{sys.name || t('mapNode.unknown')}</div>
 
       {sys.statics.length > 0 && (
         <div className="system-node__statics">
-          <div className="title">Statics</div>
+          <div className="title">{t('systemPanel.statics')}</div>
           {sys.statics.map(s => {
             const dest = WORMHOLE_DESTINATIONS[s];
             return (
@@ -174,6 +175,7 @@ function DemoSystemNode({ data, selected }: NodeProps) {
 // ── info panel ───────────────────────────────────────────────
 
 function DemoInfoPanel({ sys, onRemove }: { sys: DemoSys; onRemove: () => void }) {
+  const { t } = useTranslation();
   const color = CLASS_COLORS[sys.systemClass];
   const effectIcon = EFFECT_ICONS[sys.effect];
   const effectLabel = EFFECT_LABELS[sys.effect];
@@ -206,7 +208,7 @@ function DemoInfoPanel({ sys, onRemove }: { sys: DemoSys; onRemove: () => void }
 
       {sys.statics.length > 0 && (
         <div className="demo-info__statics">
-          <div className="demo-info__label">Statics</div>
+          <div className="demo-info__label">{t('systemPanel.statics')}</div>
           {sys.statics.map(s => {
             const dest = WORMHOLE_DESTINATIONS[s];
             return (
@@ -225,30 +227,31 @@ function DemoInfoPanel({ sys, onRemove }: { sys: DemoSys; onRemove: () => void }
 
       {sys.regionName && (
         <div className="demo-info__section">
-          <div className="demo-info__label">Region</div>
+          <div className="demo-info__label">{t('systemPanel.region')}</div>
           <div>{sys.regionName}</div>
         </div>
       )}
 
       <div className="demo-info__more">
         <div className="demo-info__more-icon">✦</div>
-        <p>Sign in to view kills, signatures, structures, activity, sovereignty, and more.</p>
+        <p>{t('demo.signInMore')}</p>
       </div>
 
       <button type="button" className="btn btn--ghost demo-info__remove" onClick={onRemove}>
-        Remove System
+        {t('ctxMenu.removeSystem')}
       </button>
     </div>
   );
 }
 
 function DemoInfoHint() {
+  const { t } = useTranslation();
   return (
     <div className="demo-info__hint">
-      <p>Click a system to view its details here.</p>
-      <p>Right-click the map to add a system.</p>
-      <p>Drag from a node handle to connect systems.</p>
-      <p className="demo-info__hint-limit">Demo limited to {DEMO_MAX_SYSTEMS} systems — no limit when signed in.</p>
+      <p>{t('demo.hintClick')}</p>
+      <p>{t('demo.hintAdd')}</p>
+      <p>{t('demo.hintConnect')}</p>
+      <p className="demo-info__hint-limit">{t('demo.hintLimit', { count: DEMO_MAX_SYSTEMS })}</p>
     </div>
   );
 }
@@ -380,8 +383,8 @@ function DemoMapInner() {
   }, [setNodes, setEdges, selectedId]);
 
   const ctxItems: ContextMenuItem[] = ctxMenu?.nodeId
-    ? [{ label: 'Remove System', icon: '✕', action: () => removeNode(ctxMenu.nodeId!) }]
-    : [{ label: atLimit ? `Add System (limit ${DEMO_MAX_SYSTEMS} reached)` : 'Add System here', icon: '+', action: openAddForm, disabled: atLimit }];
+    ? [{ label: t('ctxMenu.removeSystem'), icon: '✕', action: () => removeNode(ctxMenu.nodeId!) }]
+    : [{ label: atLimit ? t('demo.addSystemLimit', { max: DEMO_MAX_SYSTEMS }) : t('demo.addSystemHere'), icon: '+', action: openAddForm, disabled: atLimit }];
 
   return (
     <div className="demo-wrap">
@@ -418,11 +421,11 @@ function DemoMapInner() {
           <Controls showInteractive={false} />
           <Panel position="top-right">
             <div className="demo-map-actions">
-              <button type="button" className="map-sidebar__action" onClick={spreadNodes} disabled={nodes.length < 2} data-tooltip="Adjust system nodes to stop overlap">
-                ⊞ Spread Nodes
+              <button type="button" className="map-sidebar__action" onClick={spreadNodes} disabled={nodes.length < 2} data-tooltip={t('mapSidebar.spreadNodesTooltip')}>
+                {t('mapSidebar.spreadNodes')}
               </button>
               <span className={`demo-map-actions__count${atLimit ? ' demo-map-actions__count--limit' : ''}`}>
-                {nodes.length} / {DEMO_MAX_SYSTEMS} systems
+                {t('demo.systemsCount', { count: nodes.length, max: DEMO_MAX_SYSTEMS })}
               </span>
             </div>
           </Panel>

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -485,6 +485,16 @@
     "fitView": "Ansicht einpassen",
     "interactive": "Interaktivität umschalten"
   },
+  "demo": {
+    "hintClick": "Klicke auf ein System, um hier seine Details zu sehen.",
+    "hintAdd": "Rechtsklick auf die Karte, um ein System hinzuzufügen.",
+    "hintConnect": "Von einem Knotengriff ziehen, um Systeme zu verbinden.",
+    "hintLimit": "Demo auf {{count}} Systeme begrenzt — keine Begrenzung, wenn du angemeldet bist.",
+    "systemsCount": "{{count}} / {{max}} Systeme",
+    "signInMore": "Melde dich an, um Kills, Signaturen, Strukturen, Aktivität, Souveränität und mehr zu sehen.",
+    "addSystemHere": "System hier hinzufügen",
+    "addSystemLimit": "System hinzufügen (Limit {{max}} erreicht)"
+  },
   "ctxMenu": {
     "disconnect": "Trennen",
     "jumpType": "Sprungtyp",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -485,6 +485,16 @@
     "fitView": "Fit view",
     "interactive": "Toggle interactivity"
   },
+  "demo": {
+    "hintClick": "Click a system to view its details here.",
+    "hintAdd": "Right-click the map to add a system.",
+    "hintConnect": "Drag from a node handle to connect systems.",
+    "hintLimit": "Demo limited to {{count}} systems — no limit when signed in.",
+    "systemsCount": "{{count}} / {{max}} systems",
+    "signInMore": "Sign in to view kills, signatures, structures, activity, sovereignty, and more.",
+    "addSystemHere": "Add System here",
+    "addSystemLimit": "Add System (limit {{max}} reached)"
+  },
   "ctxMenu": {
     "disconnect": "Disconnect",
     "jumpType": "Jump Type",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -485,6 +485,16 @@
     "fitView": "Ajuster la vue",
     "interactive": "Basculer l'interactivité"
   },
+  "demo": {
+    "hintClick": "Cliquez sur un système pour voir ses détails ici.",
+    "hintAdd": "Clic droit sur la carte pour ajouter un système.",
+    "hintConnect": "Glissez depuis une poignée de nœud pour connecter des systèmes.",
+    "hintLimit": "Démo limitée à {{count}} systèmes — aucune limite une fois connecté.",
+    "systemsCount": "{{count}} / {{max}} systèmes",
+    "signInMore": "Connectez-vous pour voir les kills, signatures, structures, l'activité, la souveraineté et plus encore.",
+    "addSystemHere": "Ajouter un système ici",
+    "addSystemLimit": "Ajouter un système (limite de {{max}} atteinte)"
+  },
   "ctxMenu": {
     "disconnect": "Déconnecter",
     "jumpType": "Type de saut",


### PR DESCRIPTION
The landing page's interactive demo map (`DemoMap`) was never wired to i18n — its left-panel instructions, the **Spread Nodes** button, the **N / 10 systems** counter, the "Statics" labels, the clicked-system info panel (Region / Sign-in prompt / Remove System) and the right-click add-system labels were all hardcoded English.

### Changes
- New `demo` namespace (en/de/fr): the three hint lines + limit line, the systems counter, the sign-in prompt, and the add-system context labels (here / limit-reached).
- Reuses existing keys: `mapNode.unknown`, `systemPanel.statics`/`region`, `ctxMenu.removeSystem`, `mapSidebar.spreadNodes` (+ tooltip).
- Added `useTranslation` to the `DemoSystemNode`, `DemoInfoPanel`, and `DemoInfoHint` sub-components (the inner map already had it; the add-system form already uses the translated `AddSystemModal`).

EVE-canonical data (system names, class labels, effect names, Jita, HI-SEC) stays English.

All three locales at 861 keys, full parity; build clean.