### PR TITLE
i18n: translate remaining components (sweep)

### DIFF
--- a/web/src/components/ui/DraggableCard.tsx
+++ b/web/src/components/ui/DraggableCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useUserSetting } from '../../hooks/useUserSetting';
@@ -12,6 +13,7 @@ interface Props {
 function storageKey(id: string) { return `nexum.panel.collapsed.${id}`; }
 
 export function DraggableCard({ id, title, children }: Props) {
+  const { t } = useTranslation();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
 
   const [collapsed, setCollapsed] = useUserSetting<boolean>(storageKey(id), false);
@@ -33,7 +35,7 @@ export function DraggableCard({ id, title, children }: Props) {
           type="button"
           className="info-card__collapse-btn"
           onClick={(e) => { e.stopPropagation(); toggle(); }}
-          title={collapsed ? 'Expand' : 'Collapse'}
+          title={collapsed ? t('actions.expand') : t('actions.collapse')}
         >
           <span className={`info-card__chevron${collapsed ? ' info-card__chevron--collapsed' : ''}`}>▾</span>
         </button>
@@ -44,7 +46,7 @@ export function DraggableCard({ id, title, children }: Props) {
           {...listeners}
           {...attributes}
           onClick={(e) => e.stopPropagation()}
-          title="Drag to reorder"
+          title={t('closest.dragToReorder')}
         >
           ⠿
         </button>

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ArrowRightIcon, CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react';
 import type { MapSystem, SystemClass } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS } from '../../data/wormholes';
@@ -14,6 +15,7 @@ const J_SPACE: SystemClass[] = ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C13', 'Ther
 const K_SPACE: SystemClass[] = ['HS', 'LS', 'NS'];
 
 export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Props) {
+  const { t } = useTranslation();
   const { open, setOpen, pos, btnRef, dropdownRef, openAt } = usePopover();
   const [search, setSearch] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
@@ -63,7 +65,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
             )}
           </span>
         ) : (
-          <span className="wh-picker__placeholder">Unknown</span>
+          <span className="wh-picker__placeholder">{t('mapNode.unknown')}</span>
         )}
         <span className="wh-picker__chevron">
           {open ? <CaretUpIcon size={11} weight="bold" /> : <CaretDownIcon size={11} weight="bold" />}
@@ -81,7 +83,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
             className="wh-picker__search"
             value={search}
             onChange={e => setSearch(e.target.value)}
-            placeholder="Search..."
+            placeholder={t('whPicker.searchPlaceholder')}
             spellCheck={false}
           />
           <div className="wh-picker__list">
@@ -89,13 +91,13 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
               className={`wh-picker__option${!value ? ' wh-picker__option--active' : ''}`}
               onMouseDown={() => select('')}
             >
-              <span className="wh-picker__placeholder">Unknown</span>
+              <span className="wh-picker__placeholder">{t('mapNode.unknown')}</span>
             </div>
 
             {filteredConnected.length > 0 && (
               <>
                 <div className="wh-picker__group-hdr">
-                  Connected Systems
+                  {t('whPicker.connectedSystems')}
                   <span className="wh-picker__group-count">({connectedSystems.length})</span>
                 </div>
                 {filteredConnected.map(sys => (
@@ -105,7 +107,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
                     onMouseDown={() => select(sys.name || sys.id)}
                   >
                     <span className="wh-picker__code" style={{ color: '#c0d0e8', minWidth: 'auto', marginRight: 4 }}>
-                      {sys.name || 'Unknown'}
+                      {sys.name || t('mapNode.unknown')}
                     </span>
                     <span className="wh-picker__arrow"><ArrowRightIcon size={11} weight="bold" /></span>
                     <span className="wh-picker__dest" style={{ color: CLASS_COLORS[sys.systemClass] }}>

--- a/web/src/components/ui/NpcStationsPane.tsx
+++ b/web/src/components/ui/NpcStationsPane.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import type { NpcStation } from '../../types';
 import { ContextMenu } from './ContextMenu';
@@ -9,30 +10,39 @@ import { useShareMode } from '../../context/ShareModeContext';
 
 const ESI = 'https://esi.evetech.net/latest';
 
-const SERVICE_ICONS: Record<string, { icon: string; label: string }> = {
-  'market':              { icon: '◈', label: 'Market' },
-  'repair-facilities':   { icon: '⚙', label: 'Repair Facilities' },
-  'fitting':             { icon: '⊕', label: 'Fitting' },
-  'factory':             { icon: '⬡', label: 'Factory' },
-  'labratory':           { icon: '⌬', label: 'Laboratory' },
-  'reprocessing-plant':  { icon: '⟲', label: 'Reprocessing Plant' },
-  'cloning':             { icon: '◑', label: 'Cloning' },
-  'clones':              { icon: '◑', label: 'Clone Bay' },
-  'insurance':           { icon: '◎', label: 'Insurance' },
-  'loyalty-point-store': { icon: '✦', label: 'Loyalty Point Store' },
-  'navy-offices':        { icon: '⚔', label: 'Navy Offices' },
-  'security-offices':    { icon: '◉', label: 'Security Offices' },
-  'bounty-missions':     { icon: '⊛', label: 'Bounty Missions' },
-  'bounty-office':       { icon: '⊛', label: 'Bounty Office' },
-  'assay-offices':       { icon: '⌖', label: 'Assay Office' },
-  'office-rental':       { icon: '⊞', label: 'Office Rental' },
-  'stock-exchange':      { icon: '⇅', label: 'Stock Exchange' },
-  'commodity-trading':   { icon: '⇄', label: 'Commodity Trading' },
-  'news':                { icon: '◫', label: 'News' },
-  'docking':             { icon: '⬒', label: 'Docking' },
-  'exploration':         { icon: '⟁', label: 'Exploration' },
-  'black-market':        { icon: '◆', label: 'Black Market' },
-  'mentoring':           { icon: '⊙', label: 'Mentoring' },
+// `key` indexes into the npcStations.services.* i18n namespace; the union type
+// keeps the dynamic t(`npcStations.services.${key}`) lookup type-checked.
+type NpcServiceKey =
+  | 'market' | 'repairFacilities' | 'fitting' | 'factory' | 'laboratory'
+  | 'reprocessingPlant' | 'cloning' | 'cloneBay' | 'insurance' | 'loyaltyPointStore'
+  | 'navyOffices' | 'securityOffices' | 'bountyMissions' | 'bountyOffice' | 'assayOffice'
+  | 'officeRental' | 'stockExchange' | 'commodityTrading' | 'news' | 'docking'
+  | 'exploration' | 'blackMarket' | 'mentoring';
+
+const SERVICE_ICONS: Record<string, { icon: string; key: NpcServiceKey }> = {
+  'market':              { icon: '◈', key: 'market' },
+  'repair-facilities':   { icon: '⚙', key: 'repairFacilities' },
+  'fitting':             { icon: '⊕', key: 'fitting' },
+  'factory':             { icon: '⬡', key: 'factory' },
+  'labratory':           { icon: '⌬', key: 'laboratory' },
+  'reprocessing-plant':  { icon: '⟲', key: 'reprocessingPlant' },
+  'cloning':             { icon: '◑', key: 'cloning' },
+  'clones':              { icon: '◑', key: 'cloneBay' },
+  'insurance':           { icon: '◎', key: 'insurance' },
+  'loyalty-point-store': { icon: '✦', key: 'loyaltyPointStore' },
+  'navy-offices':        { icon: '⚔', key: 'navyOffices' },
+  'security-offices':    { icon: '◉', key: 'securityOffices' },
+  'bounty-missions':     { icon: '⊛', key: 'bountyMissions' },
+  'bounty-office':       { icon: '⊛', key: 'bountyOffice' },
+  'assay-offices':       { icon: '⌖', key: 'assayOffice' },
+  'office-rental':       { icon: '⊞', key: 'officeRental' },
+  'stock-exchange':      { icon: '⇅', key: 'stockExchange' },
+  'commodity-trading':   { icon: '⇄', key: 'commodityTrading' },
+  'news':                { icon: '◫', key: 'news' },
+  'docking':             { icon: '⬒', key: 'docking' },
+  'exploration':         { icon: '⟁', key: 'exploration' },
+  'black-market':        { icon: '◆', key: 'blackMarket' },
+  'mentoring':           { icon: '⊙', key: 'mentoring' },
 };
 
 const stationCache = new Map<number, NpcStation[]>();
@@ -63,6 +73,7 @@ async function fetchStations(eveSystemId: number): Promise<NpcStation[]> {
 interface CtxState { x: number; y: number; station: NpcStation }
 
 export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null }) {
+  const { t } = useTranslation();
   const [stations, setStations] = useState<NpcStation[]>([]);
   const [loading, setLoading]   = useState(false);
   const [ctx, setCtx]           = useState<CtxState | null>(null);
@@ -92,9 +103,9 @@ export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null })
     setCtx({ x: e.clientX, y: e.clientY, station });
   };
 
-  if (!eveSystemId) return <div className="sig-pane__empty">No EVE system linked</div>;
-  if (loading)      return <div className="sig-pane__empty">Loading stations…</div>;
-  if (stations.length === 0) return <div className="sig-pane__empty">No NPC stations in this system</div>;
+  if (!eveSystemId) return <div className="sig-pane__empty">{t('panes.noEveSystem')}</div>;
+  if (loading)      return <div className="sig-pane__empty">{t('npcStations.loading')}</div>;
+  if (stations.length === 0) return <div className="sig-pane__empty">{t('npcStations.none')}</div>;
 
   return (
     <>
@@ -113,7 +124,7 @@ export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null })
                     const def = SERVICE_ICONS[svc];
                     if (!def) return null;
                     return (
-                      <span key={svc} className="npc-svc-icon" data-tooltip={def.label}>
+                      <span key={svc} className="npc-svc-icon" data-tooltip={t(`npcStations.services.${def.key}`)}>
                         {def.icon}
                       </span>
                     );
@@ -127,14 +138,14 @@ export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null })
                     className="sys-btn"
                     onClick={(e) => { e.stopPropagation(); setDestination(s.id).catch(console.error); }}
                   >
-                    Set Destination
+                    {t('waypoint.setDestination')}
                   </button>
                   <button
                     type="button"
                     className="sys-btn"
                     onClick={(e) => { e.stopPropagation(); addWaypoint(s.id).catch(console.error); }}
                   >
-                    + Waypoint
+                    {t('systemPanel.addWaypointBtn')}
                   </button>
                 </span>
               )}
@@ -150,12 +161,12 @@ export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null })
           onClose={() => setCtx(null)}
           items={[
             {
-              label: 'Set Destination',
+              label: t('waypoint.setDestination'),
               icon: <MapPinSimpleIcon size={16} weight="regular" color="#3ddc84" />,
               action: () => setDestination(ctx.station.id).catch(console.error),
             },
             {
-              label: 'Add Waypoint',
+              label: t('waypoint.addWaypoint'),
               icon: <PathIcon size={16} weight="regular" color="#5a9af8" />,
               action: () => addWaypoint(ctx.station.id).catch(console.error),
             },

--- a/web/src/components/ui/SharedMapView.tsx
+++ b/web/src/components/ui/SharedMapView.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { ReactFlowProvider } from '@xyflow/react';
 import { useMapStore } from '../../store/mapStore';
 import { MapCanvas } from '../map/MapCanvas';
@@ -41,16 +43,17 @@ function formatLocal(iso: string): string {
   } catch { return iso; }
 }
 
-function formatRemaining(iso: string): string {
+function formatRemaining(t: TFunction, iso: string): string {
   const ms = new Date(iso).getTime() - Date.now();
-  if (ms <= 0) return 'expired';
+  if (ms <= 0) return t('share.expired');
   const h = Math.floor(ms / 3_600_000);
   const m = Math.floor((ms % 3_600_000) / 60_000);
-  if (h > 0) return `${h}h ${m}m left`;
-  return `${m}m left`;
+  if (h > 0) return t('share.expiresInHM', { hours: h, minutes: m });
+  return t('share.expiresInM', { minutes: m });
 }
 
 export function SharedMapView({ token }: { token: string }) {
+  const { t } = useTranslation();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
 
   // Hydrate the map store directly from the share payload. The store's
@@ -114,14 +117,19 @@ export function SharedMapView({ token }: { token: string }) {
     return (
       <div className="share-error">
         <div className="share-error__card">
-          <div className="share-error__title">Share link expired</div>
+          <div className="share-error__title">{t('shareView.expiredTitle')}</div>
           <p className="share-error__body">
-            This shared view of <strong>{state.payload.mapName}</strong> was
-            published by <strong>{state.payload.ownerName}</strong> and expired
-            on <strong>{formatLocal(state.payload.expiredAt)}</strong>.
+            <Trans
+              i18nKey="shareView.expiredBody"
+              values={{
+                map: state.payload.mapName,
+                owner: state.payload.ownerName,
+                date: formatLocal(state.payload.expiredAt),
+              }}
+            />
           </p>
           <p className="share-error__hint">
-            Ask {state.payload.ownerName} for a fresh link.
+            {t('shareView.expiredHint', { owner: state.payload.ownerName })}
           </p>
         </div>
       </div>
@@ -132,10 +140,9 @@ export function SharedMapView({ token }: { token: string }) {
     return (
       <div className="share-error">
         <div className="share-error__card">
-          <div className="share-error__title">Share link not found</div>
+          <div className="share-error__title">{t('shareView.notFoundTitle')}</div>
           <p className="share-error__body">
-            This link doesn't match a known shared map. It may have been
-            revoked, or the URL may be incorrect.
+            {t('shareView.notFoundBody')}
           </p>
         </div>
       </div>
@@ -153,6 +160,7 @@ export function SharedMapView({ token }: { token: string }) {
 }
 
 function SharedMapLayout({ payload }: { payload: SharePayload }) {
+  const { t } = useTranslation();
   // Subscribed via the hook so the system panel opens/closes reactively
   // when the viewer clicks a system on the canvas.
   const selectedSystemId = useMapStore((s) => s.selectedSystemId);
@@ -161,13 +169,13 @@ function SharedMapLayout({ payload }: { payload: SharePayload }) {
       <div className="share-header">
         <span className="share-header__title">{payload.mapName}</span>
         <span className="share-header__sep">·</span>
-        <span className="share-header__meta">shared by <strong>{payload.ownerName}</strong></span>
+        <span className="share-header__meta"><Trans i18nKey="shareView.sharedBy" values={{ owner: payload.ownerName }} /></span>
         <span className="share-header__sep">·</span>
-        <span className="share-header__meta">{formatRemaining(payload.expiresAt)}</span>
+        <span className="share-header__meta">{formatRemaining(t, payload.expiresAt)}</span>
         {/* CTA — sits in the top right, recruits the viewer back to the
             landing page. Strips the share hash so the SPA lands on the
             normal app shell instead of bouncing straight back here. */}
-        <a className="share-header__cta" href="/">Create maps with Nexum today!</a>
+        <a className="share-header__cta" href="/">{t('shareView.cta')}</a>
       </div>
       <div className="layout__body">
         <div className="layout__main">

--- a/web/src/components/ui/WHTypeInfo.tsx
+++ b/web/src/components/ui/WHTypeInfo.tsx
@@ -55,7 +55,7 @@ export function WHTypeInfo({ code, children }: Props) {
     <div className="wh-type-info__popover" role="dialog">
       <div className="wh-type-info__header">{code.toUpperCase()}</div>
       <div className="wh-type-info__row">
-        <span className="wh-type-info__label">Leads to</span>
+        <span className="wh-type-info__label">{t('whInfo.leadsTo')}</span>
         <span
           className="wh-type-info__value"
           style={dest ? { color: CLASS_COLORS[dest] } : undefined}
@@ -64,15 +64,15 @@ export function WHTypeInfo({ code, children }: Props) {
         </span>
       </div>
       <div className="wh-type-info__row">
-        <span className="wh-type-info__label">Lifetime</span>
+        <span className="wh-type-info__label">{t('whInfo.lifetime')}</span>
         <span className="wh-type-info__value">{spec.lifetimeHours}h</span>
       </div>
       <div className="wh-type-info__row">
-        <span className="wh-type-info__label">Total mass</span>
+        <span className="wh-type-info__label">{t('whInfo.totalMass')}</span>
         <span className="wh-type-info__value">{mass(t, spec.totalMass)}</span>
       </div>
       <div className="wh-type-info__row">
-        <span className="wh-type-info__label">Max jump</span>
+        <span className="wh-type-info__label">{t('whInfo.maxJump')}</span>
         <span className="wh-type-info__value">{mass(t, spec.maxJumpMass)}</span>
       </div>
     </div>
@@ -98,8 +98,8 @@ export function WHTypeInfo({ code, children }: Props) {
         type="button"
         className="wh-type-info__btn"
         onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
-        aria-label={`${code} info`}
-        data-tooltip={`${code} spec`}
+        aria-label={t('whInfo.infoAria', { code })}
+        data-tooltip={t('whInfo.specTooltip', { code })}
       >
         ⓘ
       </button>

--- a/web/src/components/ui/WormholeTypePicker.tsx
+++ b/web/src/components/ui/WormholeTypePicker.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ArrowRightIcon, CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react';
 import { CLASS_COLORS, CLASS_LABELS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
@@ -59,6 +60,7 @@ function DestBadge({ code, types }: { code: string; types: ReturnType<typeof use
 }
 
 export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
+  const { t } = useTranslation();
   const types = useWormholeTypes();
   const { open, setOpen, pos, btnRef, dropdownRef, openAt } = usePopover();
   const [search, setSearch] = useState('');
@@ -142,7 +144,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
             <DestBadge code={value} types={types} />
           </span>
         ) : (
-          <span className="wh-picker__placeholder">Unknown</span>
+          <span className="wh-picker__placeholder">{t('mapNode.unknown')}</span>
         )}
         <span className="wh-picker__chevron">
           {open ? <CaretUpIcon size={11} weight="bold" /> : <CaretDownIcon size={11} weight="bold" />}
@@ -160,7 +162,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
             className="wh-picker__search"
             value={search}
             onChange={e => setSearch(e.target.value)}
-            placeholder="Search..."
+            placeholder={t('whPicker.searchPlaceholder')}
             spellCheck={false}
           />
           <div className="wh-picker__list">
@@ -168,12 +170,12 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
               className={`wh-picker__option${!value ? ' wh-picker__option--active' : ''}`}
               onMouseDown={() => { onChange('', ''); setOpen(false); }}
             >
-              <span className="wh-picker__placeholder">Unknown</span>
+              <span className="wh-picker__placeholder">{t('mapNode.unknown')}</span>
             </div>
             {groups.map(group => (
               <div key={group.key}>
                 <div className="wh-picker__group-hdr">
-                  {group.label}
+                  {group.key === '__other' ? t('whPicker.other') : group.label}
                   <span className="wh-picker__group-count">({group.totalCount})</span>
                 </div>
                 {group.types.map(code => (
@@ -185,7 +187,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
                     <span className="wh-picker__code">{code}</span>
                     <DestBadge code={code} types={types} />
                     {code === 'K162' && (
-                      <span className="wh-picker__inbound">inbound</span>
+                      <span className="wh-picker__inbound">{t('whPicker.inbound')}</span>
                     )}
                   </div>
                 ))}

--- a/web/src/components/ui/routeUi.tsx
+++ b/web/src/components/ui/routeUi.tsx
@@ -1,5 +1,6 @@
 import { api } from '../../api/client';
 import { toast } from './Toaster';
+import i18n from '../../i18n';
 import { truesecColor } from '../../utils/truesec';
 import type { RouteEntry } from '../../hooks/useRoute';
 
@@ -9,8 +10,10 @@ export function setWaypoint(systemId: number, systemName: string, clear: boolean
     method: 'POST',
     body:   JSON.stringify({ destinationId: systemId, clearOtherWaypoints: clear }),
   })
-    .then(() => toast.success(clear ? `Destination set to ${systemName}` : `Waypoint added: ${systemName}`))
-    .catch(() => toast.error('Failed to set waypoint — is your character online?'));
+    .then(() => toast.success(clear
+      ? i18n.t('routeToast.destinationSet', { system: systemName })
+      : i18n.t('routeToast.waypointAdded', { system: systemName })))
+    .catch(() => toast.error(i18n.t('routeToast.failed')));
 }
 
 /** Wrap-friendly row of coloured squares, one per system on the path. */

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -10,7 +10,9 @@
     "close": "Schließen",
     "ok": "OK",
     "on": "An",
-    "off": "Aus"
+    "off": "Aus",
+    "expand": "Erweitern",
+    "collapse": "Einklappen"
   },
   "confirm": {
     "title": "Bist du sicher?",
@@ -1078,6 +1080,63 @@
       }
     },
     "footer": "EVE Online und das EVE-Logo sind eingetragene Marken von CCP hf. Alle Rechte weltweit vorbehalten. Nexum ist ein Drittanbieter-Tool und steht in keiner Verbindung zu CCP hf und wird von ihnen nicht unterstützt. · <license>Lizenz- & EVE-IP-Hinweis</license>"
+  },
+  "whInfo": {
+    "leadsTo": "Führt zu",
+    "lifetime": "Lebensdauer",
+    "totalMass": "Gesamtmasse",
+    "maxJump": "Max. Sprung",
+    "infoAria": "{{code}} Info",
+    "specTooltip": "{{code}} Spezifikation"
+  },
+  "whPicker": {
+    "searchPlaceholder": "Suchen…",
+    "connectedSystems": "Verbundene Systeme",
+    "other": "Andere",
+    "inbound": "eingehend"
+  },
+  "npcStations": {
+    "loading": "Lade Stationen…",
+    "none": "Keine NPC-Stationen in diesem System",
+    "services": {
+      "market": "Markt",
+      "repairFacilities": "Reparatureinrichtungen",
+      "fitting": "Fitting",
+      "factory": "Fabrik",
+      "laboratory": "Labor",
+      "reprocessingPlant": "Wiederaufbereitungsanlage",
+      "cloning": "Klonen",
+      "cloneBay": "Klonanlage",
+      "insurance": "Versicherung",
+      "loyaltyPointStore": "Treuepunkt-Shop",
+      "navyOffices": "Marinebüros",
+      "securityOffices": "Sicherheitsbüros",
+      "bountyMissions": "Kopfgeld-Missionen",
+      "bountyOffice": "Kopfgeldbüro",
+      "assayOffice": "Prüfbüro",
+      "officeRental": "Büromiete",
+      "stockExchange": "Börse",
+      "commodityTrading": "Warenhandel",
+      "news": "Nachrichten",
+      "docking": "Andocken",
+      "exploration": "Erkundung",
+      "blackMarket": "Schwarzmarkt",
+      "mentoring": "Mentoring"
+    }
+  },
+  "shareView": {
+    "expiredTitle": "Freigabe-Link abgelaufen",
+    "expiredBody": "Diese geteilte Ansicht von <strong>{{map}}</strong> wurde von <strong>{{owner}}</strong> veröffentlicht und ist am <strong>{{date}}</strong> abgelaufen.",
+    "expiredHint": "Bitte {{owner}} um einen neuen Link.",
+    "notFoundTitle": "Freigabe-Link nicht gefunden",
+    "notFoundBody": "Dieser Link passt zu keiner bekannten geteilten Karte. Er wurde möglicherweise widerrufen oder die URL ist falsch.",
+    "sharedBy": "geteilt von <strong>{{owner}}</strong>",
+    "cta": "Erstelle noch heute Karten mit Nexum!"
+  },
+  "routeToast": {
+    "destinationSet": "Ziel festgelegt auf {{system}}",
+    "waypointAdded": "Wegpunkt hinzugefügt: {{system}}",
+    "failed": "Wegpunkt konnte nicht gesetzt werden — ist dein Charakter online?"
   },
   "mapNode": {
     "unknown": "Unbekannt",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -10,7 +10,9 @@
     "close": "Close",
     "ok": "OK",
     "on": "On",
-    "off": "Off"
+    "off": "Off",
+    "expand": "Expand",
+    "collapse": "Collapse"
   },
   "confirm": {
     "title": "Are you sure?",
@@ -1078,6 +1080,63 @@
       }
     },
     "footer": "EVE Online and the EVE logo are the registered trademarks of CCP hf. All rights reserved worldwide. Nexum is a third-party tool and is not affiliated with or endorsed by CCP hf. · <license>License & EVE IP notice</license>"
+  },
+  "whInfo": {
+    "leadsTo": "Leads to",
+    "lifetime": "Lifetime",
+    "totalMass": "Total mass",
+    "maxJump": "Max jump",
+    "infoAria": "{{code}} info",
+    "specTooltip": "{{code}} spec"
+  },
+  "whPicker": {
+    "searchPlaceholder": "Search…",
+    "connectedSystems": "Connected Systems",
+    "other": "Other",
+    "inbound": "inbound"
+  },
+  "npcStations": {
+    "loading": "Loading stations…",
+    "none": "No NPC stations in this system",
+    "services": {
+      "market": "Market",
+      "repairFacilities": "Repair Facilities",
+      "fitting": "Fitting",
+      "factory": "Factory",
+      "laboratory": "Laboratory",
+      "reprocessingPlant": "Reprocessing Plant",
+      "cloning": "Cloning",
+      "cloneBay": "Clone Bay",
+      "insurance": "Insurance",
+      "loyaltyPointStore": "Loyalty Point Store",
+      "navyOffices": "Navy Offices",
+      "securityOffices": "Security Offices",
+      "bountyMissions": "Bounty Missions",
+      "bountyOffice": "Bounty Office",
+      "assayOffice": "Assay Office",
+      "officeRental": "Office Rental",
+      "stockExchange": "Stock Exchange",
+      "commodityTrading": "Commodity Trading",
+      "news": "News",
+      "docking": "Docking",
+      "exploration": "Exploration",
+      "blackMarket": "Black Market",
+      "mentoring": "Mentoring"
+    }
+  },
+  "shareView": {
+    "expiredTitle": "Share link expired",
+    "expiredBody": "This shared view of <strong>{{map}}</strong> was published by <strong>{{owner}}</strong> and expired on <strong>{{date}}</strong>.",
+    "expiredHint": "Ask {{owner}} for a fresh link.",
+    "notFoundTitle": "Share link not found",
+    "notFoundBody": "This link doesn't match a known shared map. It may have been revoked, or the URL may be incorrect.",
+    "sharedBy": "shared by <strong>{{owner}}</strong>",
+    "cta": "Create maps with Nexum today!"
+  },
+  "routeToast": {
+    "destinationSet": "Destination set to {{system}}",
+    "waypointAdded": "Waypoint added: {{system}}",
+    "failed": "Failed to set waypoint — is your character online?"
   },
   "mapNode": {
     "unknown": "Unknown",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -10,7 +10,9 @@
     "close": "Fermer",
     "ok": "OK",
     "on": "Activé",
-    "off": "Désactivé"
+    "off": "Désactivé",
+    "expand": "Développer",
+    "collapse": "Réduire"
   },
   "confirm": {
     "title": "Êtes-vous sûr ?",
@@ -1078,6 +1080,63 @@
       }
     },
     "footer": "EVE Online et le logo EVE sont des marques déposées de CCP hf. Tous droits réservés dans le monde entier. Nexum est un outil tiers et n'est ni affilié à CCP hf ni approuvé par lui. · <license>Mention de licence & PI EVE</license>"
+  },
+  "whInfo": {
+    "leadsTo": "Mène à",
+    "lifetime": "Durée de vie",
+    "totalMass": "Masse totale",
+    "maxJump": "Saut max",
+    "infoAria": "Infos {{code}}",
+    "specTooltip": "Spéc. {{code}}"
+  },
+  "whPicker": {
+    "searchPlaceholder": "Rechercher…",
+    "connectedSystems": "Systèmes connectés",
+    "other": "Autre",
+    "inbound": "entrant"
+  },
+  "npcStations": {
+    "loading": "Chargement des stations…",
+    "none": "Aucune station PNJ dans ce système",
+    "services": {
+      "market": "Marché",
+      "repairFacilities": "Installations de réparation",
+      "fitting": "Équipement",
+      "factory": "Usine",
+      "laboratory": "Laboratoire",
+      "reprocessingPlant": "Usine de retraitement",
+      "cloning": "Clonage",
+      "cloneBay": "Baie de clonage",
+      "insurance": "Assurance",
+      "loyaltyPointStore": "Boutique de points de fidélité",
+      "navyOffices": "Bureaux de la marine",
+      "securityOffices": "Bureaux de sécurité",
+      "bountyMissions": "Missions de prime",
+      "bountyOffice": "Bureau des primes",
+      "assayOffice": "Bureau d'analyse",
+      "officeRental": "Location de bureau",
+      "stockExchange": "Bourse",
+      "commodityTrading": "Négoce de marchandises",
+      "news": "Actualités",
+      "docking": "Amarrage",
+      "exploration": "Exploration",
+      "blackMarket": "Marché noir",
+      "mentoring": "Mentorat"
+    }
+  },
+  "shareView": {
+    "expiredTitle": "Lien de partage expiré",
+    "expiredBody": "Cette vue partagée de <strong>{{map}}</strong> a été publiée par <strong>{{owner}}</strong> et a expiré le <strong>{{date}}</strong>.",
+    "expiredHint": "Demandez un nouveau lien à {{owner}}.",
+    "notFoundTitle": "Lien de partage introuvable",
+    "notFoundBody": "Ce lien ne correspond à aucune carte partagée connue. Il a peut-être été révoqué, ou l'URL est incorrecte.",
+    "sharedBy": "partagé par <strong>{{owner}}</strong>",
+    "cta": "Créez des cartes avec Nexum dès aujourd'hui !"
+  },
+  "routeToast": {
+    "destinationSet": "Destination définie sur {{system}}",
+    "waypointAdded": "Point de cheminement ajouté : {{system}}",
+    "failed": "Échec de la définition du point de cheminement — votre personnage est-il en ligne ?"
   },
   "mapNode": {
     "unknown": "Inconnu",


### PR DESCRIPTION
Pre-fourth-language sweep. Caught several components never wired to i18n:

- **WHTypeInfo** — wormhole-spec popover (Leads to / Lifetime / Total mass / Max jump) + info button aria/tooltip.
- **NpcStationsPane** — empty/loading states, Set Destination / Waypoint buttons + context menu, and all 23 station-service tooltips.
- **SharedMapView** — the public shared-map page: expired / not-found cards, header (shared-by + time remaining), CTA.
- **WormholeTypePicker** & **LeadsToDropdown** — Search placeholder, Unknown, Connected Systems, Other, inbound. (EVE-jargon group headers K162/Hi-Sec/Class N/Thera/J-Space/K-Space left as-is.)
- **DraggableCard** — Expand/Collapse + Drag-to-reorder titles.
- **routeUi** (non-React util) — waypoint toasts via the `i18n` instance.

New namespaces `whInfo`/`whPicker`/`npcStations`/`shareView`/`routeToast` + `actions.expand`/`collapse`. en/de/fr at **908 keys each, full parity**. EVE-canonical data and tech names stay English. Build clean; re-sweep confirms no remaining hardcoded UI strings.