### PR TITLE
i18n: auto-detect language from browser locale

### DIFF
--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -31,6 +31,13 @@ void i18n
     resources,
     fallbackLng: 'en',
     supportedLngs: SUPPORTED_LANGUAGES,
+    // Map regional browser locales to the base language we ship, so a visitor
+    // whose browser reports e.g. es-ES / es-MX / en-GB / fr-CA / de-AT is
+    // auto-detected as es / en / fr / de rather than missing and falling back
+    // to English. (`load` strips the region from the resolved language; the
+    // navigator detector still reads navigator.languages in priority order.)
+    load: 'languageOnly',
+    nonExplicitSupportedLngs: true,
     defaultNS: 'common',
     ns: ['common'],
     detection: {


### PR DESCRIPTION
Auto-switches a first-time visitor to a matching shipped language based on their browser locale.

### What changed
The `navigator` detector was already in the chain (`order: ['localStorage','navigator']`), so browser detection ran — but regional locales like `es-ES`, `es-MX`, `en-GB`, `fr-CA`, `de-AT` didn't match our base-code `supportedLngs` (`en/de/fr/es`) and fell back to English. Added:
- `load: 'languageOnly'` — resolves a regional locale down to its base language.
- `nonExplicitSupportedLngs: true` — treats a regional locale as supported when its base is.

### Behaviour
- **First visit, no saved choice:** reads `navigator.languages` in the browser's priority order, maps region → base, and switches to the first one we ship; no match → English.
- **Explicit choice** via the 🇬🇧/🇩🇪/🇫🇷/🇪🇸 switcher still wins and persists (`localStorage['nexum.lang']`).
- The static **compare page** already strips region client-side, so it's consistent.

One nuance: once a language is detected (or chosen) it's cached in localStorage, so later browser-language changes don't override it — the user switches manually. That's the standard i18next pattern. Build clean.