### PR TITLE
fix: keep tooltips inside the viewport

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -692,7 +692,7 @@
     opacity: 0;
     transition: opacity 0.1s;
   }
-  &:hover::after { opacity: 1; }
+  /* Reveal handled by the global TooltipLayer (viewport-clamped). */
 
   &.toolbar__status-dot--on  { background: #3ddc84; box-shadow: 0 0 4px #3ddc8466; }
   &.toolbar__status-dot--off { background: #e05a5a; box-shadow: 0 0 4px #e05a5a66; }
@@ -743,7 +743,11 @@
     transition: opacity 0.1s;
     z-index: 9999;
   }
-  &:hover::after { opacity: 1; }
+  /* Hover reveal is handled by the JS-positioned TooltipLayer (see
+     TooltipLayer.tsx), which clamps the chip inside the viewport so it can't
+     spill off-screen the way this centred pseudo-element does. The ::after
+     above is kept (invisible) so the legacy markup/variant classes are inert
+     rather than removed wholesale. */
 }
 
 /* Portal-rendered floating tooltip (see Tooltip.tsx). Anchored via
@@ -762,6 +766,16 @@
   white-space: nowrap;
   pointer-events: none;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+/* Variant used by the global TooltipLayer. Allows long labels to wrap within
+   a bounded width so that, combined with the layer's viewport clamping, the
+   chip always fits on-screen. Short labels still render on a single line. */
+.floating-tooltip--auto {
+  max-width: min(360px, calc(100vw - 12px));
+  white-space: normal;
+  text-align: center;
+  line-height: 1.35;
 }
 
 /* Right-side variant. Elements at the bottom of the System Panel (links,
@@ -3800,9 +3814,8 @@ select.sig-toolbar-btn option {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
 }
 
-.npc-svc-icon:hover::after {
-  opacity: 1;
-}
+/* Reveal handled by the global TooltipLayer (viewport-clamped) — the invisible
+   ::after above is kept only so this rule's plate styling stays documented. */
 
 
 .icon-btn--danger {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { ProximityOptInModal } from './components/ui/ProximityOptInModal';
 import { CommandPaletteModal } from './components/ui/CommandPaletteModal';
 import { LandingPage } from './components/ui/LandingPage';
 import { Toaster } from './components/ui/Toaster';
+import { TooltipLayer } from './components/ui/TooltipLayer';
 import { AdminPage } from './components/ui/AdminPage';
 import { SharedMapView } from './components/ui/SharedMapView';
 import { useMapStore } from './store/mapStore';
@@ -135,6 +136,7 @@ export default function App() {
     <AuthProvider>
       <AppShell />
       <Toaster />
+      <TooltipLayer />
     </AuthProvider>
   );
 }

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -154,7 +154,7 @@ function ProximityChip() {
     { label: t('toolbar.proximity.threat'), Icon: QuestionIcon };
   return (
     <span
-      className="toolbar__proximity toolbar__proximity--alert"
+      className="toolbar__proximity toolbar__proximity--alert tooltip-right"
       data-tooltip={t('toolbar.proximity.closest', { label: label.toLowerCase() })}
     >
       <span className="toolbar__proximity-icon"><Icon size={14} weight="bold" /></span>

--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 /**
@@ -11,9 +11,11 @@ import { createPortal } from 'react-dom';
  * Positioning is recomputed on each hover from the trigger's bounding
  * rect — no resize observer is needed because the tooltip is only visible
  * while the cursor is over the trigger, and triggers don't typically
- * reflow mid-hover.
+ * reflow mid-hover. After the chip is laid out at its natural size it is
+ * CLAMPED inside the viewport, so it can never spill off the display area
+ * even when the trigger sits close to an edge.
  *
- * `placement` picks the side the chip appears on:
+ * `placement` picks the preferred side the chip appears on:
  *   - 'right' = vertically centred on the trigger, to its right
  *   - 'above' = horizontally centred on the trigger, above it
  *   - 'below' = horizontally centred on the trigger, below it
@@ -28,41 +30,52 @@ interface Props {
 }
 
 const GAP = 8;
+const MARGIN = 6;
 
 export function Tooltip({ label, placement = 'right', className, children }: Props) {
   const wrapRef = useRef<HTMLSpanElement>(null);
-  const [coords, setCoords] = useState<{ top: number; left: number; transform: string } | null>(null);
+  const chipRef = useRef<HTMLSpanElement>(null);
+  // The trigger rect captured at hover time; positioning happens after the
+  // chip mounts so we know its measured size and can clamp to the viewport.
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 
   const show = useCallback(() => {
     const el = wrapRef.current;
     if (!el) return;
-    const r = el.getBoundingClientRect();
-    if (placement === 'right') {
-      setCoords({
-        top:       r.top + r.height / 2,
-        left:      r.right + GAP,
-        transform: 'translateY(-50%)',
-      });
-    } else if (placement === 'above') {
-      setCoords({
-        top:       r.top - GAP,
-        left:      r.left + r.width / 2,
-        transform: 'translate(-50%, -100%)',
-      });
-    } else {
-      setCoords({
-        top:       r.bottom + GAP,
-        left:      r.left + r.width / 2,
-        transform: 'translateX(-50%)',
-      });
-    }
-  }, [placement]);
+    setPos(null); // hide until measured at the new size/position
+    setRect(el.getBoundingClientRect());
+  }, []);
 
-  const hide = useCallback(() => setCoords(null), []);
+  const hide = useCallback(() => { setRect(null); setPos(null); }, []);
 
   // Tear down the floating chip if the trigger unmounts while hovered
   // (e.g. system panel closes mid-hover).
-  useEffect(() => () => setCoords(null), []);
+  useEffect(() => () => { setRect(null); setPos(null); }, []);
+
+  useLayoutEffect(() => {
+    if (!rect || !chipRef.current) return;
+    const tip = chipRef.current.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let top: number;
+    let left: number;
+    if (placement === 'right') {
+      top = rect.top + rect.height / 2 - tip.height / 2;
+      left = rect.right + GAP;
+    } else if (placement === 'above') {
+      top = rect.top - GAP - tip.height;
+      left = rect.left + rect.width / 2 - tip.width / 2;
+    } else {
+      top = rect.bottom + GAP;
+      left = rect.left + rect.width / 2 - tip.width / 2;
+    }
+
+    left = Math.max(MARGIN, Math.min(left, vw - tip.width - MARGIN));
+    top = Math.max(MARGIN, Math.min(top, vh - tip.height - MARGIN));
+    setPos({ top, left });
+  }, [rect, placement]);
 
   return (
     <>
@@ -76,13 +89,14 @@ export function Tooltip({ label, placement = 'right', className, children }: Pro
       >
         {children}
       </span>
-      {coords && createPortal(
+      {rect && createPortal(
         <span
+          ref={chipRef}
           className="floating-tooltip"
           style={{
-            top:       coords.top,
-            left:      coords.left,
-            transform: coords.transform,
+            top:        pos?.top ?? 0,
+            left:       pos?.left ?? 0,
+            visibility: pos ? 'visible' : 'hidden',
           }}
         >
           {label}

--- a/web/src/components/ui/TooltipLayer.tsx
+++ b/web/src/components/ui/TooltipLayer.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Global tooltip layer for every `[data-tooltip]` element in the app.
+ *
+ * The old approach was a pure-CSS `[data-tooltip]::after` pseudo-element
+ * centred below (or, via manual `.tooltip-right` / `.tooltip-above` opt-in
+ * classes, beside/above) the trigger. CSS can't measure the viewport, so a
+ * wide tooltip on a trigger near a screen edge — e.g. the waypoint buttons in
+ * a left-docked sidebar pane — would spill off-screen and get clipped.
+ *
+ * This mounts once at the app root and listens (via event delegation) for
+ * hover/focus on anything carrying `data-tooltip`. It renders a single portal
+ * chip positioned from the trigger's bounding rect and then CLAMPED inside the
+ * viewport, so a tooltip can never leave the display area regardless of where
+ * its trigger sits. The matching CSS hover-reveal is disabled so the two
+ * mechanisms don't double up (see App.css `[data-tooltip]`).
+ *
+ * Placement honours the same opt-in hints the CSS variants used:
+ *   - `.tooltip-right`  -> to the right of the trigger
+ *   - `.tooltip-above`  -> above the trigger
+ *   - (default)         -> below, auto-flipping above when there's no room
+ * After placement the chip is clamped on both axes with a viewport margin.
+ */
+
+const MARGIN = 6; // keep at least this far from every viewport edge
+const GAP = 6;     // distance between trigger and chip
+
+type Placement = 'below' | 'above' | 'right';
+type Trigger = { text: string; rect: DOMRect; placement: Placement };
+
+export function TooltipLayer() {
+  const [trigger, setTrigger] = useState<Trigger | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const chipRef = useRef<HTMLDivElement>(null);
+
+  // Delegate hover/focus tracking from the document so we cover every
+  // `[data-tooltip]` in the tree — current and future — without per-element wiring.
+  useEffect(() => {
+    let active: Element | null = null;
+
+    const placementFor = (el: Element): Placement =>
+      el.classList.contains('tooltip-right') ? 'right'
+        : el.classList.contains('tooltip-above') ? 'above'
+          : 'below';
+
+    const open = (el: Element) => {
+      const text = el.getAttribute('data-tooltip');
+      if (!text) return;
+      active = el;
+      setPos(null); // hide until measured at the new size
+      setTrigger({ text, rect: el.getBoundingClientRect(), placement: placementFor(el) });
+    };
+
+    const close = () => {
+      if (!active) return;
+      active = null;
+      setTrigger(null);
+      setPos(null);
+    };
+
+    const onOver = (e: Event) => {
+      const el = (e.target as Element | null)?.closest?.('[data-tooltip]') ?? null;
+      if (el && el !== active) open(el);
+      else if (!el && active) close();
+    };
+    const onOut = (e: MouseEvent) => {
+      if (!active) return;
+      const to = e.relatedTarget as Node | null;
+      // Only dismiss once the pointer has actually left the active trigger.
+      if (!to || !active.contains(to)) close();
+    };
+    const onFocusIn = (e: Event) => {
+      const el = (e.target as Element | null)?.closest?.('[data-tooltip]') ?? null;
+      if (el) open(el); else close();
+    };
+
+    document.addEventListener('mouseover', onOver, true);
+    document.addEventListener('mouseout', onOut, true);
+    document.addEventListener('focusin', onFocusIn, true);
+    document.addEventListener('focusout', close, true);
+    // Any layout shift invalidates the cached trigger rect — just hide.
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close, true);
+
+    return () => {
+      document.removeEventListener('mouseover', onOver, true);
+      document.removeEventListener('mouseout', onOut, true);
+      document.removeEventListener('focusin', onFocusIn, true);
+      document.removeEventListener('focusout', close, true);
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close, true);
+    };
+  }, []);
+
+  // Once the chip is in the DOM at its natural size, position it from the
+  // trigger rect and clamp inside the viewport.
+  useLayoutEffect(() => {
+    if (!trigger || !chipRef.current) return;
+    const tip = chipRef.current.getBoundingClientRect();
+    const { rect, placement } = trigger;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let top: number;
+    let left: number;
+    if (placement === 'right') {
+      top = rect.top + rect.height / 2 - tip.height / 2;
+      left = rect.right + GAP;
+    } else if (placement === 'above') {
+      top = rect.top - GAP - tip.height;
+      left = rect.left + rect.width / 2 - tip.width / 2;
+    } else {
+      top = rect.bottom + GAP;
+      left = rect.left + rect.width / 2 - tip.width / 2;
+      // Flip above when there isn't room below.
+      if (top + tip.height > vh - MARGIN && rect.top - GAP - tip.height >= MARGIN) {
+        top = rect.top - GAP - tip.height;
+      }
+    }
+
+    left = Math.max(MARGIN, Math.min(left, vw - tip.width - MARGIN));
+    top = Math.max(MARGIN, Math.min(top, vh - tip.height - MARGIN));
+    setPos({ top, left });
+  }, [trigger]);
+
+  if (!trigger) return null;
+
+  return createPortal(
+    <div
+      ref={chipRef}
+      className="floating-tooltip floating-tooltip--auto"
+      role="tooltip"
+      style={{
+        top: pos?.top ?? 0,
+        left: pos?.left ?? 0,
+        // Render offscreen-invisible for the measuring pass so the user never
+        // sees an unclamped flash at the wrong position.
+        visibility: pos ? 'visible' : 'hidden',
+      }}
+    >
+      {trigger.text}
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## Problem
The generic `[data-tooltip]` tooltip is a pure-CSS `::after` centred below its trigger. CSS can't measure the viewport, so a wide label on a trigger near a screen edge — e.g. the waypoint buttons in a left-docked sidebar pane (screenshot: "Задать пункт назначения") — spills off the edge and gets clipped.

## Fix
- **New `TooltipLayer`** mounted once at the app root. Event-delegates hover/focus on any `[data-tooltip]`, renders one portal chip from the trigger rect, and **clamps it inside the viewport** (edge margins, auto-flip below↔above when no room, wrapping for long labels). Works for every `data-tooltip` in the app — current and future — with no per-element wiring.
- CSS hover-reveal disabled (pseudo-element kept invisible) so the two paths don't double up; same for the two selectors with their own `data-tooltip` pseudo (`.toolbar__status-dot`, `.npc-svc-icon` station-service icons).
- Proximity chip keeps its right-side placement via the existing `tooltip-right` hint class (the layer honours `tooltip-right`/`tooltip-above`).
- Portal `Tooltip` component (System Panel) gets the same measure-and-clamp positioning, replacing transform-only placement.

Build + lint clean.