### PR TITLE
fix(landing): resolve three eslint errors

### DIFF
--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -206,7 +206,7 @@ function useShaderCanvas(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
     const resLoc  = gl.getUniformLocation(prog, 'resolution');
 
     let rafId = 0;
-    let startTime = performance.now();
+    const startTime = performance.now();
 
     const resize = () => {
       canvas.width  = canvas.clientWidth  * devicePixelRatio;
@@ -249,7 +249,19 @@ function loginErrorKey(param: string): 'landing.errors.not_in_corp' | 'landing.e
 
 export function LandingPage() {
   const { t } = useTranslation();
-  const [lastChar, setLastChar] = useState<LastCharacter | null>(null);
+  // Read the stored last-login chip eagerly so it paints on first render (no
+  // null -> value flash). Also reads the older colon-separated key so returning
+  // users don't lose their chip; that legacy key is cleaned up in the effect below.
+  const [lastChar] = useState<LastCharacter | null>(() => {
+    try {
+      const stored = localStorage.getItem('nexum.last_character')
+        ?? localStorage.getItem('nexum:last_character');
+      return stored ? (JSON.parse(stored) as LastCharacter) : null;
+    } catch {
+      // localStorage may be unavailable or hold malformed JSON — fall back to none.
+      return null;
+    }
+  });
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useShaderCanvas(canvasRef);
@@ -257,15 +269,14 @@ export function LandingPage() {
   const errorParam = new URLSearchParams(window.location.search).get('error');
   const errorMessage = errorParam ? t(loginErrorKey(errorParam)) : null;
 
+  // One-time migration: drop the older colon-separated key now that its value
+  // (if any) has been folded into state above.
   useEffect(() => {
     try {
-      // Migrate the older colon-separated key transparently so returning users
-      // don't lose their stored last-login chip.
-      const stored = localStorage.getItem('nexum.last_character')
-        ?? localStorage.getItem('nexum:last_character');
-      if (stored) setLastChar(JSON.parse(stored) as LastCharacter);
       localStorage.removeItem('nexum:last_character');
-    } catch {}
+    } catch {
+      // ignore — storage may be unavailable (private mode, etc.)
+    }
   }, []);
 
   return (


### PR DESCRIPTION
Fixes the three pre-existing eslint errors in `LandingPage.tsx` (flagged while working on the multi-lingual section).

- **prefer-const** (`startTime`): never reassigned in the shader-canvas effect → `const`.
- **react-hooks/set-state-in-effect**: the last-login chip was read from localStorage and pushed via `setState` inside a mount effect. Now read through a **lazy `useState` initializer**, so there's no synchronous setState in an effect (and no null→value first-paint flash). The legacy colon-separated-key cleanup stays in its own effect, since `removeItem` is an external-system update rather than a setState.
- **no-empty**: the two `catch` blocks now carry explanatory comments.

No behaviour change for users. Build + lint clean.

> Note: PR targets `release` per request. This puts the fix on `release` ahead of `main`/`localization`; happy to also land it on `main` and re-sync so the three branches stay byte-identical — just say the word.