### PR TITLE
scout: age/closest sort dropdown for Thera & Turnur

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -208,6 +208,42 @@
   flex-direction: column;
 }
 
+.scout-pane__sort {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid #141c2e;
+}
+.scout-pane__sort-label {
+  font-size: calc(12px * var(--font-scale, 1));
+  color: #7a90a8;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.scout-pane__sort-select {
+  flex: 1;
+  background: #0a0e1a;
+  border: 1px solid #1e2740;
+  border-radius: 4px;
+  color: #c8d0e0;
+  font-family: inherit;
+  font-size: calc(13px * var(--font-scale, 1));
+  padding: 3px 6px;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+.scout-pane__sort-select:hover { border-color: #4d9de0; }
+.scout-pane__sort-select:focus-visible {
+  outline: none;
+  border-color: #4d9de0;
+  box-shadow: 0 0 0 2px rgba(77, 157, 224, 0.25);
+}
+.scout-pane__sort-select option {
+  background: #0d1117;
+  color: #c8d0e0;
+}
+
 .scout-row {
   display: flex;
   flex-direction: column;

--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -141,7 +141,9 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
           onChange={(e) => changeSort(e.target.value as ScoutSort)}
         >
           <option value="age">{t('scout.sortAge')}</option>
-          <option value="closest">{t('scout.sortClosest')}</option>
+          <option value="closest">
+            {t(routeMode === 'secure' ? 'scout.sortSecure' : 'scout.sortShortest')}
+          </option>
         </select>
       </div>
       {sorted.map(c => {

--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -13,6 +13,18 @@ interface Props {
   scoutSystem: 'Thera' | 'Turnur';
 }
 
+type ScoutSort = 'age' | 'closest';
+
+// Per-panel sort preference, remembered client-side. Thera and Turnur keep
+// independent choices under their own key.
+function readScoutSort(system: string): ScoutSort {
+  try {
+    return localStorage.getItem(`nexum.scoutSort.${system}`) === 'closest' ? 'closest' : 'age';
+  } catch {
+    return 'age';
+  }
+}
+
 const SIZE_LABELS: Record<string, string> = {
   small:  'S',
   medium: 'M',
@@ -53,6 +65,16 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
   const location = useCharacterLocation();
   const routeMode = useMapStore((s) => s.routeMode);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [sortBy, setSortBy] = useState<ScoutSort>(() => readScoutSort(scoutSystem));
+
+  function changeSort(v: ScoutSort) {
+    setSortBy(v);
+    try {
+      localStorage.setItem(`nexum.scoutSort.${scoutSystem}`, v);
+    } catch {
+      // storage may be unavailable (private mode, etc.) — keep the in-memory choice.
+    }
+  }
 
   const filtered = useMemo(
     () => all.filter(c => c.outSystemName === scoutSystem),
@@ -67,16 +89,31 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
   const targetIds = useMemo(() => filtered.map(c => c.inSystemId), [filtered]);
   const routes = useRoute(canRoute ? location.system!.eveSystemId : null, targetIds);
 
-  // Sort by remaining time descending — freshest holes at the top, the
-  // soon-to-collapse ones drop to the bottom. Name is a stable tiebreaker.
+  // Two sort modes:
+  //  - 'age'     : remaining time descending — freshest holes at the top, the
+  //                soon-to-collapse ones drop to the bottom.
+  //  - 'closest' : fewest jumps via the active route preference (shortest /
+  //                secure) ascending. Connections without a usable route (no
+  //                k-space location, or wormhole-class target) fall to the
+  //                bottom. Age then name break ties in both modes.
   const sorted = useMemo(() => {
-    const arr = [...filtered];
-    arr.sort((a, b) => {
+    const byAge = (a: typeof filtered[number], b: typeof filtered[number]) => {
       if (a.remainingHours !== b.remainingHours) return b.remainingHours - a.remainingHours;
       return a.inSystemName.localeCompare(b.inSystemName);
-    });
+    };
+    const arr = [...filtered];
+    if (sortBy === 'closest') {
+      arr.sort((a, b) => {
+        const ja = routes[String(a.inSystemId)]?.jumps ?? Infinity;
+        const jb = routes[String(b.inSystemId)]?.jumps ?? Infinity;
+        if (ja !== jb) return ja - jb;
+        return byAge(a, b);
+      });
+    } else {
+      arr.sort(byAge);
+    }
     return arr;
-  }, [filtered]);
+  }, [filtered, sortBy, routes]);
 
   function toggleExpanded(id: string) {
     setExpanded(prev => {
@@ -93,6 +130,20 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
 
   return (
     <div className="scout-pane">
+      <div className="scout-pane__sort">
+        <label className="scout-pane__sort-label" htmlFor={`scout-sort-${scoutSystem}`}>
+          {t('scout.sortLabel')}
+        </label>
+        <select
+          id={`scout-sort-${scoutSystem}`}
+          className="scout-pane__sort-select"
+          value={sortBy}
+          onChange={(e) => changeSort(e.target.value as ScoutSort)}
+        >
+          <option value="age">{t('scout.sortAge')}</option>
+          <option value="closest">{t('scout.sortClosest')}</option>
+        </select>
+      </div>
       {sorted.map(c => {
         const route   = canRoute ? routes[String(c.inSystemId)] : undefined;
         const isOpen  = expanded.has(c.id);

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "Keine {{system}}-Verbindungen.",
-    "expiring": "läuft ab"
+    "expiring": "läuft ab",
+    "sortLabel": "Sortieren",
+    "sortAge": "WH-Alter",
+    "sortClosest": "Nächste"
   },
   "activity": {
     "thisHour": "diese Stunde",

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -633,7 +633,8 @@
     "expiring": "läuft ab",
     "sortLabel": "Sortieren",
     "sortAge": "WH-Alter",
-    "sortClosest": "Nächste"
+    "sortShortest": "Kürzeste Route",
+    "sortSecure": "Sichere Route"
   },
   "activity": {
     "thisHour": "diese Stunde",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "No {{system}} connections.",
-    "expiring": "expiring"
+    "expiring": "expiring",
+    "sortLabel": "Sort",
+    "sortAge": "WH age",
+    "sortClosest": "Closest"
   },
   "activity": {
     "thisHour": "this hour",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -633,7 +633,8 @@
     "expiring": "expiring",
     "sortLabel": "Sort",
     "sortAge": "WH age",
-    "sortClosest": "Closest"
+    "sortShortest": "Shortest route",
+    "sortSecure": "Secure route"
   },
   "activity": {
     "thisHour": "this hour",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "No hay conexiones de {{system}}.",
-    "expiring": "caducando"
+    "expiring": "caducando",
+    "sortLabel": "Ordenar",
+    "sortAge": "Edad del WH",
+    "sortClosest": "Más cercano"
   },
   "activity": {
     "thisHour": "esta hora",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -633,7 +633,8 @@
     "expiring": "caducando",
     "sortLabel": "Ordenar",
     "sortAge": "Edad del WH",
-    "sortClosest": "Más cercano"
+    "sortShortest": "Ruta más corta",
+    "sortSecure": "Ruta segura"
   },
   "activity": {
     "thisHour": "esta hora",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -633,7 +633,8 @@
     "expiring": "expire",
     "sortLabel": "Trier",
     "sortAge": "Âge du WH",
-    "sortClosest": "Plus proche"
+    "sortShortest": "Route la plus courte",
+    "sortSecure": "Route sécurisée"
   },
   "activity": {
     "thisHour": "cette heure",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "Aucune connexion {{system}}.",
-    "expiring": "expire"
+    "expiring": "expire",
+    "sortLabel": "Trier",
+    "sortAge": "Âge du WH",
+    "sortClosest": "Plus proche"
   },
   "activity": {
     "thisHour": "cette heure",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -633,7 +633,8 @@
     "expiring": "まもなく期限切れ",
     "sortLabel": "並び替え",
     "sortAge": "WH 寿命",
-    "sortClosest": "最も近い"
+    "sortShortest": "最短ルート",
+    "sortSecure": "安全ルート"
   },
   "activity": {
     "thisHour": "今時間",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "{{system}} の接続はありません。",
-    "expiring": "まもなく期限切れ"
+    "expiring": "まもなく期限切れ",
+    "sortLabel": "並び替え",
+    "sortAge": "WH 寿命",
+    "sortClosest": "最も近い"
   },
   "activity": {
     "thisHour": "今時間",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -633,7 +633,8 @@
     "expiring": "만료 임박",
     "sortLabel": "정렬",
     "sortAge": "WH 수명",
-    "sortClosest": "가장 가까움"
+    "sortShortest": "최단 경로",
+    "sortSecure": "안전 경로"
   },
   "activity": {
     "thisHour": "이번 시간",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "{{system}} 연결이 없습니다.",
-    "expiring": "만료 임박"
+    "expiring": "만료 임박",
+    "sortLabel": "정렬",
+    "sortAge": "WH 수명",
+    "sortClosest": "가장 가까움"
   },
   "activity": {
     "thisHour": "이번 시간",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "Não há conexões de {{system}}.",
-    "expiring": "a expirar"
+    "expiring": "a expirar",
+    "sortLabel": "Ordenar",
+    "sortAge": "Idade do WH",
+    "sortClosest": "Mais próximo"
   },
   "activity": {
     "thisHour": "esta hora",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -633,7 +633,8 @@
     "expiring": "a expirar",
     "sortLabel": "Ordenar",
     "sortAge": "Idade do WH",
-    "sortClosest": "Mais próximo"
+    "sortShortest": "Rota mais curta",
+    "sortSecure": "Rota segura"
   },
   "activity": {
     "thisHour": "esta hora",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -656,7 +656,10 @@
   },
   "scout": {
     "noConnections": "Нет соединений {{system}}.",
-    "expiring": "истекает"
+    "expiring": "истекает",
+    "sortLabel": "Сортировка",
+    "sortAge": "Возраст ЧД",
+    "sortClosest": "Ближайшие"
   },
   "activity": {
     "thisHour": "за этот час",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -659,7 +659,8 @@
     "expiring": "истекает",
     "sortLabel": "Сортировка",
     "sortAge": "Возраст ЧД",
-    "sortClosest": "Ближайшие"
+    "sortShortest": "Кратчайший маршрут",
+    "sortSecure": "Безопасный маршрут"
   },
   "activity": {
     "thisHour": "за этот час",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -630,7 +630,10 @@
   },
   "scout": {
     "noConnections": "没有 {{system}} 连接。",
-    "expiring": "即将过期"
+    "expiring": "即将过期",
+    "sortLabel": "排序",
+    "sortAge": "WH 时长",
+    "sortClosest": "最近"
   },
   "activity": {
     "thisHour": "本小时",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -633,7 +633,8 @@
     "expiring": "即将过期",
     "sortLabel": "排序",
     "sortAge": "WH 时长",
-    "sortClosest": "最近"
+    "sortShortest": "最短路线",
+    "sortSecure": "安全路线"
   },
   "activity": {
     "thisHour": "本小时",


### PR DESCRIPTION
Adds a **Sort** dropdown at the top of each scout panel (Thera and Turnur) to switch the row order between:

- **WH age** (default, current behaviour) — freshest holes first, soon-to-collapse last.
- **Closest** — fewest jumps via the active route preference. Because route jumps already respect the shortest-vs-secure setting, this naturally orders by **shortest/safest route** as requested. Connections with no usable route (not docked in k-space, or a wormhole-class target that can't be a waypoint) fall to the bottom; age then name break ties.

The choice persists per panel in `localStorage` (Thera and Turnur are independent). New `scout.sortLabel`/`sortAge`/`sortClosest` keys are translated across all nine locales (full parity). Build + lint clean.

Base: `release` per current workflow.