### PR TITLE
signatures: keep the delete column always visible

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3250,7 +3250,33 @@ div.system-node__easy-handle {
 
 .sig-col--check   { width: 24px; }
 .sig-col--whtype  { overflow: visible; }
-.sig-col--actions { width: 24px; }
+.sig-col--actions { width: 28px; }
+
+/* When the resizable columns sum wider than the pane, let the table scroll
+   horizontally inside its card instead of being clipped by the card's
+   overflow:hidden. */
+.sig-table-wrap {
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+/* Pin the per-row delete (and its header) to the right edge so it's always
+   reachable no matter how narrow the pane is or how the columns are sized.
+   The cell needs an opaque background per row state, otherwise scrolled
+   columns would show through the pinned column. Scoped under .sig-table so
+   these win over the semi-transparent .sig-row--* td tints. */
+.sig-table th.sig-cell--actions,
+.sig-table td.sig-cell--actions {
+  position: sticky;
+  right: 0;
+  z-index: 1;
+  box-shadow: -6px 0 8px -6px rgba(0, 0, 0, 0.55);
+}
+.sig-table th.sig-cell--actions             { background: #080e1a; }          /* card backdrop */
+.sig-table tbody td.sig-cell--actions        { background: #0b0f18; }          /* odd rows */
+.sig-table tbody tr:nth-child(even) td.sig-cell--actions { background: #0d1220; }
+.sig-table tbody tr:hover td.sig-cell--actions           { background: #111a28; }
+.sig-table tbody tr.sig-row--selected td.sig-cell--actions { background: #0a1525; }
 
 .sig-th {
   position: relative;

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -510,6 +510,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
           {isShareMode ? t('signatures.emptyShared') : t('signatures.empty')}
         </div>
       ) : (
+        <div className="sig-table-wrap">
         <table className="sig-table">
           <colgroup>
             {/* In share mode the checkbox and per-row delete cells are
@@ -572,7 +573,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 {t('signatures.colUpdated')}{sortInd('updatedAt')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
               </th>
-              {!isShareMode && <th />}
+              {!isShareMode && <th className="sig-cell--actions" />}
             </tr>
           </thead>
           <tbody>
@@ -674,7 +675,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 />
                 <ElapsedCell iso={sig.updatedAt} className="sig-td--time sig-td--updated" />
                 {!isShareMode && (
-                  <td>
+                  <td className="sig-cell--actions">
                     {canEdit && (
                       <button
                         className="icon-btn icon-btn--danger"
@@ -688,6 +689,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
     </>


### PR DESCRIPTION
## Problem
When the resizable signature columns are sized (or the pane is narrow) such that their total width exceeds the pane, the table overflows its card — which is `overflow: hidden` — and the rightmost **delete (✕)** column gets clipped off-screen, as in the screenshot.

## Fix
- Wrap the table in a `.sig-table-wrap` with `overflow-x: auto`, so an oversized table **scrolls horizontally inside the card** instead of being clipped.
- Pin the actions column (header cell + per-row delete) **`position: sticky; right: 0`**, so it's always visible at the right edge no matter the pane width or column sizing.
- Give the pinned cell an opaque per-row background (odd/even/hover/selected) plus a soft left shadow, so scrolled columns slide cleanly underneath it rather than bleeding through.

No behaviour change to the button itself. Build clean; no new eslint errors (4 pre-existing in the file unchanged).

Base: `release` per current workflow.