### PR TITLE
multi-account phase 1: owners schema + backfill

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -486,6 +486,35 @@ export async function migrate() {
         ALTER TABLE users ALTER COLUMN last_known_system_id TYPE INTEGER;
       END IF;
     END $$;
+
+    -- ── Multi-character (alt) support, phase 1 ───────────────────────────────
+    -- An "owner" is one human; each users row (an EVE character) links to an
+    -- owner. Personal maps will move to owner scope so a pilot's chain is
+    -- visible across all their alts. Phase 1 only adds the columns + a 1:1
+    -- backfill — nothing reads owner_id yet, so behaviour is unchanged.
+    CREATE TABLE IF NOT EXISTS owners (
+      id         SERIAL      PRIMARY KEY,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS owner_id INTEGER REFERENCES owners(id) ON DELETE SET NULL;
+    ALTER TABLE maps  ADD COLUMN IF NOT EXISTS owner_id INTEGER REFERENCES owners(id) ON DELETE SET NULL;
+
+    -- One-time 1:1 backfill: an owner per existing character, then point each
+    -- map at its character's owner. Idempotent — only touches NULL rows, so
+    -- re-runs are no-ops and characters linked later keep their owner.
+    DO $$
+    DECLARE r RECORD; oid INTEGER;
+    BEGIN
+      FOR r IN SELECT id FROM users WHERE owner_id IS NULL LOOP
+        INSERT INTO owners DEFAULT VALUES RETURNING id INTO oid;
+        UPDATE users SET owner_id = oid WHERE id = r.id;
+      END LOOP;
+      UPDATE maps m SET owner_id = u.owner_id
+        FROM users u WHERE m.user_id = u.id AND m.owner_id IS NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS idx_users_owner ON users (owner_id);
+    CREATE INDEX IF NOT EXISTS idx_maps_owner  ON maps  (owner_id);
   `);
 
   await encryptLegacyTokens();


### PR DESCRIPTION
First slice of multi-character (alt) support (see the design we agreed). **Server-only, zero behaviour change.**

## What it adds
- `owners` table — one row per human.
- `users.owner_id` + `maps.owner_id` (nullable, FK to `owners`, `ON DELETE SET NULL`).
- A one-time, **idempotent** backfill: one owner per existing character (1:1), then `maps.owner_id` set from each map's character's owner. Re-runs are no-ops (only touches NULL rows), and characters linked in later phases keep their owner.
- Indexes on `users(owner_id)` and `maps(owner_id)`.

## What it does NOT do
Nothing reads `owner_id` yet — maps/auth still resolve by `user_id`, so existing single-character users are completely unaffected. This ships alone specifically so the migration can be verified on real data before the next phases depend on it.

## Next phases (not in this PR)
2. Add-character SSO + session owner + character switcher.
3. Owner-scoped personal maps + per-owner soft cap.
4. Split active vs location/route-origin character + centre-on-alt-N.
5. (optional) background location poller.

Owner-level UI prefs deferred to a later phase (kept the `owners` table minimal). Server `tsc` clean. Base: `release`.