### PR TITLE
multi-account phase 2: add-character SSO + character switcher

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -82,7 +82,14 @@ app.use(session({
 // catches the residual cases.
 app.use(originGuard(process.env.FRONTEND_URL ?? 'http://localhost:5174'));
 
-app.use('/auth', authLimiter, authRouter);
+// Tight limiter ONLY on the SSO brute-force surface (login spam, state
+// guessing). The rest of /auth — /me, /preferences, /settings,
+// /switch-character, /logout — is normal authenticated traffic (fires on every
+// load, character switch, map-option toggle and column-resize drag), so it gets
+// the higher app ceiling. Putting the tight 20/min cap on all of /auth made a
+// busy session (or rapid character switching) trip "too many requests".
+app.use(['/auth/login', '/auth/callback', '/auth/add-character'], authLimiter);
+app.use('/auth', appLimiter, authRouter);
 app.use('/api/systems', publicLimiter, systemsRouter);
 app.use('/api/regions', appLimiter, regionsRouter);
 app.use('/api/maps', appLimiter, mapsRouter);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { randomBytes } from 'node:crypto';
 import { db } from '../db.js';
 import { config } from '../config.js';
@@ -19,44 +19,76 @@ const FRONTEND_URL  = process.env.FRONTEND_URL ?? 'http://localhost:5174';
 const EVE_AUTH_URL  = 'https://login.eveonline.com/v2/oauth/authorize';
 const EVE_TOKEN_URL = 'https://login.eveonline.com/v2/oauth/token';
 
-// GET /auth/login  — redirect to EVE SSO
-authRouter.get('/login', (req, res) => {
+const SSO_SCOPES = [
+  'esi-location.read_location.v1',
+  'esi-location.read_ship_type.v1',
+  'esi-universe.read_structures.v1',
+  'esi-corporations.read_corporation_membership.v1',
+  'esi-ui.open_window.v1',
+  'esi-ui.write_waypoint.v1',
+  'esi-characters.read_corporation_roles.v1',
+  'esi-location.read_online.v1',
+  // Read player standings (contacts) so the UI can colour-tag structures /
+  // killboard / sov by your standing toward each entity. Corp / alliance reads
+  // only succeed for characters with the Contact Manager role; reads gracefully
+  // no-op otherwise.
+  'esi-characters.read_contacts.v1',
+  'esi-corporations.read_contacts.v1',
+  'esi-alliances.read_contacts.v1',
+  // Fleet member tracking — show fleet-mate locations on the map as purple
+  // dots. Requires the character to be the fleet boss or a wing/squad
+  // commander; ESI returns 403 to everyone else and the UI degrades silently.
+  'esi-fleets.read_fleet.v1',
+].join(' ');
+
+// Build the SSO authorize redirect with a fresh CSRF state and send the user.
+function beginSso(req: Request, res: Response): void {
   const state = randomBytes(32).toString('hex');
   req.session.oauthState = state;
-
   const params = new URLSearchParams({
     response_type: 'code',
     redirect_uri:  CALLBACK_URL,
     client_id:     CLIENT_ID,
-    scope: [
-          'esi-location.read_location.v1',
-          'esi-location.read_ship_type.v1',
-          'esi-universe.read_structures.v1',
-          'esi-corporations.read_corporation_membership.v1',
-          'esi-ui.open_window.v1',
-          'esi-ui.write_waypoint.v1',
-          'esi-characters.read_corporation_roles.v1',
-          'esi-location.read_online.v1',
-          // Read player standings (contacts) so the UI can colour-tag
-          // structures / killboard / sov by your standing toward each
-          // entity. Corp / alliance reads only succeed for characters with
-          // the Contact Manager role; reads gracefully no-op otherwise.
-          'esi-characters.read_contacts.v1',
-          'esi-corporations.read_contacts.v1',
-          'esi-alliances.read_contacts.v1',
-          // Fleet member tracking — show fleet-mate locations on the map as
-          // purple dots. Requires the character to be the fleet boss or a
-          // wing/squad commander; ESI returns 403 to everyone else and the
-          // UI degrades silently to "no fleet visibility".
-          'esi-fleets.read_fleet.v1',
-        ].join(' '),
+    scope:         SSO_SCOPES,
     state,
   });
-
   req.session.save((err) => {
     if (err) { res.status(500).json({ error: 'Session error' }); return; }
     res.redirect(`${EVE_AUTH_URL}?${params}`);
   });
+}
+
+// Resolve the session's owner (account) id, lazily backfilling it from the DB
+// for sessions created before multi-account support shipped.
+async function ensureOwnerId(req: Request): Promise<number | null> {
+  if (req.session.ownerId != null) return req.session.ownerId;
+  if (!req.session.userId) return null;
+  const { rows } = await db.query<{ owner_id: number | null }>(
+    `SELECT owner_id FROM users WHERE id = $1`, [req.session.userId],
+  );
+  const oid = rows[0]?.owner_id ?? null;
+  if (oid != null) req.session.ownerId = oid;
+  return oid;
+}
+
+// GET /auth/login  — redirect to EVE SSO for a fresh login
+authRouter.get('/login', (req, res) => {
+  // A normal login must never carry an add-character link from a stale session.
+  delete req.session.addCharacterOwnerId;
+  beginSso(req, res);
+});
+
+// GET /auth/add-character — link another character to the current account.
+// Only an authenticated session may do this; the callback reads
+// addCharacterOwnerId to attach the returning character to this owner.
+authRouter.get('/add-character', async (req, res) => {
+  const ownerId = await ensureOwnerId(req);
+  if (!req.session.userId || ownerId == null) {
+    res.redirect(`${FRONTEND_URL}?error=not_authenticated`);
+    return;
+  }
+  req.session.addCharacterOwnerId = ownerId;
+  beginSso(req, res);
 });
 
 // GET /auth/callback  — EVE SSO returns here
@@ -69,6 +101,10 @@ authRouter.get('/callback', async (req, res) => {
     return;
   }
   delete req.session.oauthState;
+  // Captured before any session.regenerate(): if set, this SSO round-trip is
+  // an authenticated "add character" link, not a fresh login.
+  const addCharacterOwnerId = req.session.addCharacterOwnerId;
+  delete req.session.addCharacterOwnerId;
 
   try {
     // Exchange code for tokens
@@ -187,6 +223,44 @@ authRouter.get('/callback', async (req, res) => {
       return;
     }
 
+    // Fire-and-forget standings refresh. Raw access token (not the
+    // encrypted-at-rest version) since it's already in memory; the service
+    // swallows its own errors so a bad ESI response never breaks the flow.
+    const kickStandings = () => refreshStandingsForUser({
+      userId, characterId, corpId: userCorpId, allianceId: userAllianceId,
+      accessToken: tokens.access_token,
+    }).catch((err) => log.error('standings refresh kickoff failed:', err));
+
+    // ── Add-character link ────────────────────────────────────────────────
+    // Authenticated "add character" flow: attach this character to the
+    // initiating account and return WITHOUT touching the active session — no
+    // regenerate, no active-character change. The character's maps follow it
+    // onto the owner (merge); the per-owner map cap is enforced at creation
+    // time (phase 3) so nothing is deleted here.
+    if (addCharacterOwnerId != null) {
+      if (!req.session.userId) { res.redirect(`${FRONTEND_URL}?error=not_authenticated`); return; }
+      await db.query(`UPDATE users SET owner_id = $1 WHERE id = $2`, [addCharacterOwnerId, userId]);
+      await db.query(`UPDATE maps  SET owner_id = $1 WHERE user_id = $2`, [addCharacterOwnerId, userId]);
+      req.session.ownerId = addCharacterOwnerId;
+      await new Promise<void>((resolve, reject) => { req.session.save((err) => err ? reject(err) : resolve()); });
+      kickStandings();
+      res.redirect(`${FRONTEND_URL}?added=${encodeURIComponent(jwtPayload.name)}`);
+      return;
+    }
+
+    // ── Fresh login ───────────────────────────────────────────────────────
+    // Ensure the character has an owner: the one backfilled in phase 1, or a
+    // brand-new account for a first-ever login.
+    const { rows: ownerRows } = await db.query<{ owner_id: number | null }>(
+      `SELECT owner_id FROM users WHERE id = $1`, [userId]);
+    let ownerId = ownerRows[0]?.owner_id ?? null;
+    if (ownerId == null) {
+      const { rows: created } = await db.query<{ id: number }>(`INSERT INTO owners DEFAULT VALUES RETURNING id`);
+      ownerId = created[0].id;
+      await db.query(`UPDATE users SET owner_id = $1 WHERE id = $2`, [ownerId, userId]);
+      await db.query(`UPDATE maps SET owner_id = $1 WHERE user_id = $2 AND owner_id IS NULL`, [ownerId, userId]);
+    }
+
     // First login: seed a starter "Demo Map" so the canvas isn't blank.
     // No-op when the user already has a map.
     await seedDemoMap(userId);
@@ -209,6 +283,7 @@ authRouter.get('/callback', async (req, res) => {
     req.session.characterName = jwtPayload.name;
     req.session.role          = role;
     req.session.userCorpId    = userCorpId;
+    req.session.ownerId       = ownerId;
     req.session.prefs         = {
       compactMode: p?.compact_mode ?? false,
       snapToGrid:  p?.snap_to_grid ?? false,
@@ -226,18 +301,7 @@ authRouter.get('/callback', async (req, res) => {
       req.session.save((err) => err ? reject(err) : resolve());
     });
 
-    // Fire-and-forget standings refresh. We pass the *raw* access token
-    // here (not the encrypted-at-rest version) since it's already in
-    // memory and avoids a decrypt round-trip. The service swallows its
-    // own errors so a bad ESI response doesn't break login.
-    refreshStandingsForUser({
-      userId,
-      characterId,
-      corpId:      userCorpId,
-      allianceId:  userAllianceId,
-      accessToken: tokens.access_token,
-    }).catch((err) => log.error('standings refresh kickoff failed:', err));
-
+    kickStandings();
     res.redirect(FRONTEND_URL);
   } catch (err) {
     log.error('Auth callback error:', err);
@@ -250,6 +314,54 @@ authRouter.post('/logout', (req, res) => {
   req.session.destroy(() => {
     res.json({ ok: true });
   });
+});
+
+// POST /auth/switch-character — make another character on the same account the
+// active one. No SSO: the target's tokens are already stored from when it was
+// added. Authorised strictly by owner ownership.
+authRouter.post('/switch-character', async (req, res) => {
+  const ownerId = await ensureOwnerId(req);
+  if (!req.session.userId || ownerId == null) { res.status(401).json({ error: 'Not authenticated' }); return; }
+  const targetId = Number((req.body as { userId?: unknown }).userId);
+  if (!Number.isInteger(targetId)) { res.status(400).json({ error: 'Invalid userId' }); return; }
+
+  const { rows } = await db.query<{
+    owner_id: number | null; character_id: number; character_name: string; role: string;
+    corp_id: number | null; blocked: boolean;
+    compact_mode: boolean; snap_to_grid: boolean; show_minimap: boolean; uniform_size: boolean;
+    show_statics: boolean; connection_thickness: string; route_mode: string; ui_zoom: string;
+    ui_settings: Record<string, unknown>; panel_order: string[];
+  }>(
+    `SELECT owner_id, character_id, character_name, role, corp_id, blocked,
+            compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics,
+            connection_thickness, route_mode, ui_zoom, ui_settings, panel_order
+     FROM users WHERE id = $1`,
+    [targetId],
+  );
+  const u = rows[0];
+  // Must belong to the same account, and you can't switch into a blocked char.
+  if (!u || u.owner_id !== ownerId) { res.status(403).json({ error: 'Not your character' }); return; }
+  if (u.blocked && u.character_id !== config.adminCharId) { res.status(403).json({ error: 'Character is blocked' }); return; }
+
+  req.session.userId        = targetId;
+  req.session.characterId   = u.character_id;
+  req.session.characterName = u.character_name;
+  req.session.role          = u.role as 'admin' | 'full' | 'edit' | 'readonly';
+  req.session.userCorpId    = u.corp_id;
+  req.session.prefs         = {
+    compactMode: u.compact_mode ?? false,
+    snapToGrid:  u.snap_to_grid ?? false,
+    showMinimap: u.show_minimap ?? true,
+    uniformSize: u.uniform_size ?? true,
+    showStatics: u.show_statics ?? true,
+    connectionThickness: u.connection_thickness ?? 'standard',
+    routeMode:   u.route_mode ?? 'shortest',
+    uiZoom:      u.ui_zoom != null ? Number(u.ui_zoom) : 1,
+    uiSettings:  u.ui_settings ?? {},
+    panelOrder:  u.panel_order  ?? ['notes', 'signatures'],
+  };
+  await new Promise<void>((resolve, reject) => { req.session.save((err) => err ? reject(err) : resolve()); });
+  res.json({ ok: true });
 });
 
 // GET /auth/me
@@ -302,12 +414,37 @@ authRouter.get('/me', async (req, res) => {
     ? { id: Number(lk.id), name: lk.name, systemClass: lk.systemClass, at: lk.at }
     : null;
 
+  // All characters linked to this account, for the character switcher.
+  const ownerId = await ensureOwnerId(req);
+  const { rows: charRows } = ownerId != null
+    ? await db.query<{ id: number; characterId: number; characterName: string; role: string; corpId: number | null; blocked: boolean; lksId: number | null; lksName: string | null }>(
+        `SELECT u.id, u.character_id AS "characterId", u.character_name AS "characterName", u.role,
+                u.corp_id AS "corpId", u.blocked,
+                u.last_known_system_id AS "lksId", s.name AS "lksName"
+         FROM users u LEFT JOIN solar_systems s ON s.id = u.last_known_system_id
+         WHERE u.owner_id = $1 ORDER BY u.character_name`,
+        [ownerId])
+    : { rows: [] };
+  const characters = charRows.map((c) => ({
+    id:                  c.id,
+    characterId:         c.characterId,
+    characterName:       c.characterName,
+    role:                c.role,
+    corpId:              c.corpId,
+    blocked:             c.blocked,
+    lastKnownSystemId:   c.lksId != null ? Number(c.lksId) : null,
+    lastKnownSystemName: c.lksName,
+    active:              c.id === req.session.userId,
+  }));
+
   res.json({
     user: {
       id:            req.session.userId,
       characterId:   req.session.characterId,
       characterName: req.session.characterName,
       role,
+      ownerId,
+      characters,
       lastKnownSystem,
       corpMode:      config.corpMode,
       compactMode:   prefs.compactMode,

--- a/server/src/session.d.ts
+++ b/server/src/session.d.ts
@@ -7,7 +7,14 @@ declare module 'express-session' {
     characterName: string;
     role: 'admin' | 'full' | 'edit' | 'readonly';
     userCorpId?: number | null;
+    // The account (human) this session belongs to. All of the owner's
+    // characters share it; the active character is `userId`.
+    ownerId?: number;
     oauthState: string;
+    // Set by GET /auth/add-character (only with an active session) so the
+    // OAuth callback links the returning character to this owner instead of
+    // starting a fresh login. Cleared once consumed.
+    addCharacterOwnerId?: number;
     // Cached UI preferences — kept in sync by PATCH /auth/preferences so
     // /auth/me doesn't have to hit the DB on every page load.
     prefs: {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -715,6 +715,72 @@
   cursor: default;
 }
 
+/* ── Character (account) switcher ─────────────────────────── */
+.character-switcher { position: relative; display: inline-flex; }
+.character-switcher__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: transparent;
+  border: 1px solid #1e2740;
+  border-radius: 4px;
+  color: #8a9ab5;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.character-switcher__trigger:hover { border-color: #4d9de0; color: #c8d0e0; }
+.character-switcher__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 1000;
+  min-width: 200px;
+  background: #0d1117;
+  border: 1px solid #1e2740;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.character-switcher__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: #c0ccde;
+  font-family: inherit;
+  font-size: calc(13px * var(--font-scale, 1));
+  cursor: pointer;
+  text-align: left;
+}
+.character-switcher__item:hover:not(:disabled) { background: #162032; }
+.character-switcher__item:disabled { cursor: default; }
+.character-switcher__item--active { color: #e8f0ff; }
+.character-switcher__avatar { width: 24px; height: 24px; border-radius: 50%; flex-shrink: 0; }
+.character-switcher__name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.character-switcher__blocked { margin-left: 6px; color: #e25a5a; font-size: 0.85em; }
+.character-switcher__add {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  margin-top: 2px;
+  border-top: 1px solid #1a2535;
+  color: #5a9af8;
+  font-size: calc(13px * var(--font-scale, 1));
+  text-decoration: none;
+  border-radius: 4px;
+}
+.character-switcher__add:hover { background: #162032; color: #7ab0ff; }
+
 
 .toolbar__online-dot {
   width: 8px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,8 @@ import { Sidebar } from './components/ui/Sidebar';
 import { ProximityOptInModal } from './components/ui/ProximityOptInModal';
 import { CommandPaletteModal } from './components/ui/CommandPaletteModal';
 import { LandingPage } from './components/ui/LandingPage';
-import { Toaster } from './components/ui/Toaster';
+import { Toaster, toast } from './components/ui/Toaster';
+import i18n from './i18n';
 import { TooltipLayer } from './components/ui/TooltipLayer';
 import { AdminPage } from './components/ui/AdminPage';
 import { SharedMapView } from './components/ui/SharedMapView';
@@ -104,6 +105,17 @@ function MapApp() {
 function AppShell() {
   const { user, loading } = useAuth();
   const [path] = useHashRoute();
+
+  // After the add-character SSO flow the server redirects with ?added=<name>.
+  // Confirm it once, then strip the param so a refresh doesn't re-toast.
+  useEffect(() => {
+    const added = new URLSearchParams(window.location.search).get('added');
+    if (!added) return;
+    toast.success(i18n.t('account.characterAdded', { name: added }));
+    const url = new URL(window.location.href);
+    url.searchParams.delete('added');
+    window.history.replaceState({}, '', url.toString());
+  }, []);
 
   // Share links bypass the entire auth gate — a guest with the URL should
   // be able to load the map without ever seeing the landing page. Match

--- a/web/src/components/ui/CharacterSwitcher.tsx
+++ b/web/src/components/ui/CharacterSwitcher.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CaretDownIcon, PlusIcon, CheckIcon } from '@phosphor-icons/react';
+import { useAuth } from '../../context/AuthContext';
+import { api, apiUrl } from '../../api/client';
+
+/**
+ * Account character switcher. Lists every character linked to the signed-in
+ * account; clicking one makes it active (no SSO — its token is already stored)
+ * and reloads so map/corp context re-initialises. "Add character" runs the
+ * authenticated add-character SSO flow on the server.
+ */
+export function CharacterSwitcher() {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  if (!user) return null;
+  const characters = user.characters ?? [];
+
+  async function switchTo(userId: number) {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await api('/auth/switch-character', { method: 'POST', body: JSON.stringify({ userId }) });
+      // Full reload so maps, corp access and all per-character context re-init.
+      window.location.reload();
+    } catch {
+      setBusy(false);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className="character-switcher" ref={wrapRef}>
+      <button
+        type="button"
+        className="character-switcher__trigger"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-tooltip={t('account.switchCharacter')}
+        aria-label={t('account.switchCharacter')}
+      >
+        <CaretDownIcon size={14} weight="bold" />
+      </button>
+      {open && (
+        <div className="character-switcher__menu" role="menu">
+          {characters.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              role="menuitem"
+              className={`character-switcher__item${c.active ? ' character-switcher__item--active' : ''}`}
+              disabled={busy || c.active || c.blocked}
+              onClick={() => switchTo(c.id)}
+            >
+              <img
+                className="character-switcher__avatar"
+                src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=32`}
+                alt=""
+              />
+              <span className="character-switcher__name">
+                {c.characterName}
+                {c.blocked && <span className="character-switcher__blocked">{t('account.blocked')}</span>}
+              </span>
+              {c.active && <CheckIcon size={13} weight="bold" />}
+            </button>
+          ))}
+          <a className="character-switcher__add" href={apiUrl('/auth/add-character')}>
+            <PlusIcon size={13} weight="bold" />
+            {t('account.addCharacter')}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -13,6 +13,7 @@ import { UserStatsModal } from './UserStatsModal';
 import { ConfirmModal } from './ConfirmModal';
 import { CreateMapModal } from './CreateMapModal';
 import { LanguageSwitcher } from './LanguageSwitcher';
+import { CharacterSwitcher } from './CharacterSwitcher';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
@@ -484,6 +485,7 @@ export function Toolbar() {
               {checkedAt && <CheckedAtIcon checkedAt={checkedAt} />}
             </div>
           </div>
+          <CharacterSwitcher />
           <LanguageSwitcher />
           <button
             className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -8,12 +8,29 @@ export interface LastKnownSystem {
   at: string | null;
 }
 
+// A character linked to the same account (owner), for the character switcher.
+export interface AccountCharacter {
+  id: number;                 // users.id
+  characterId: number;        // EVE character id (for the portrait)
+  characterName: string;
+  role: 'admin' | 'full' | 'edit' | 'readonly';
+  corpId: number | null;
+  blocked: boolean;
+  lastKnownSystemId: number | null;
+  lastKnownSystemName: string | null;
+  active: boolean;
+}
+
 export interface AuthUser {
   id: number;
   characterId: number;
   characterName: string;
   role: 'admin' | 'full' | 'edit' | 'readonly';
   corpMode: boolean;
+  /** Account (human) this character belongs to; groups all linked alts. */
+  ownerId: number | null;
+  /** Every character linked to this account, for the switcher. */
+  characters: AccountCharacter[];
   /** Where the pilot was last seen (updated as they jump). null until first ESI poll. */
   lastKnownSystem: LastKnownSystem | null;
   compactMode: boolean;

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "Sprache"
   },
+  "account": {
+    "switchCharacter": "Charakter wechseln",
+    "addCharacter": "Charakter hinzufügen",
+    "blocked": "blockiert",
+    "characterAdded": "{{name}} hinzugefügt"
+  },
   "actions": {
     "save": "Speichern",
     "cancel": "Abbrechen",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "Language"
   },
+  "account": {
+    "switchCharacter": "Switch character",
+    "addCharacter": "Add character",
+    "blocked": "blocked",
+    "characterAdded": "Added {{name}}"
+  },
   "actions": {
     "save": "Save",
     "cancel": "Cancel",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "Idioma"
   },
+  "account": {
+    "switchCharacter": "Cambiar de personaje",
+    "addCharacter": "Añadir personaje",
+    "blocked": "bloqueado",
+    "characterAdded": "{{name}} añadido"
+  },
   "actions": {
     "save": "Guardar",
     "cancel": "Cancelar",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "Langue"
   },
+  "account": {
+    "switchCharacter": "Changer de personnage",
+    "addCharacter": "Ajouter un personnage",
+    "blocked": "bloqué",
+    "characterAdded": "{{name}} ajouté"
+  },
   "actions": {
     "save": "Enregistrer",
     "cancel": "Annuler",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "言語"
   },
+  "account": {
+    "switchCharacter": "キャラクター切り替え",
+    "addCharacter": "キャラクターを追加",
+    "blocked": "ブロック中",
+    "characterAdded": "{{name}} を追加しました"
+  },
   "actions": {
     "save": "保存",
     "cancel": "キャンセル",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "언어"
   },
+  "account": {
+    "switchCharacter": "캐릭터 전환",
+    "addCharacter": "캐릭터 추가",
+    "blocked": "차단됨",
+    "characterAdded": "{{name}} 추가됨"
+  },
   "actions": {
     "save": "저장",
     "cancel": "취소",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "Idioma"
   },
+  "account": {
+    "switchCharacter": "Mudar de personagem",
+    "addCharacter": "Adicionar personagem",
+    "blocked": "bloqueado",
+    "characterAdded": "{{name}} adicionado"
+  },
   "actions": {
     "save": "Guardar",
     "cancel": "Cancelar",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "Язык"
   },
+  "account": {
+    "switchCharacter": "Сменить персонажа",
+    "addCharacter": "Добавить персонажа",
+    "blocked": "заблокирован",
+    "characterAdded": "{{name}} добавлен"
+  },
   "actions": {
     "save": "Сохранить",
     "cancel": "Отмена",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -2,6 +2,12 @@
   "language": {
     "label": "语言"
   },
+  "account": {
+    "switchCharacter": "切换角色",
+    "addCharacter": "添加角色",
+    "blocked": "已封禁",
+    "characterAdded": "已添加 {{name}}"
+  },
   "actions": {
     "save": "保存",
     "cancel": "取消",


### PR DESCRIPTION
Phase 2 of multi-character support. Builds on the phase-1 owners schema. Targets **`account-management`**.

## Server
- **Session** gains `ownerId` (+ a transient `addCharacterOwnerId`). `ensureOwnerId()` lazily backfills it for pre-existing sessions.
- **`GET /auth/add-character`** — authenticated-only; stashes the owner so the OAuth callback **links** the returning character to this account instead of starting a fresh login. No session regenerate, active character unchanged; the linked character's maps follow it onto the owner (merge — nothing deleted; per-owner cap lands in phase 3).
- **`/auth/callback`** resolves/creates the owner on fresh login and sets `session.ownerId`.
- **`POST /auth/switch-character`** — make another character on the same account active, **no SSO** (its token is already stored). Authorised strictly by owner ownership; blocked characters rejected.
- **`/auth/me`** now returns `ownerId` + `characters[]` (the account roster, each with last-known system + active flag).

## Client
- `AuthUser` gains `ownerId` + `characters[]`.
- **`CharacterSwitcher`** — a caret by the avatar opens a menu of the account's characters (portrait + name + active tick); click to switch (then full reload so maps/corp context re-init); **"Add character"** runs the add-character SSO flow.
- After add-character the server redirects with `?added=<name>`; `AppShell` shows a confirm toast and cleans the URL.
- New `account.*` strings across all nine locales (full parity).

## Safety
- Linking only via authenticated add-character SSO (never by claim); the active session is never wiped during a link.
- Switch/permission resolution strictly by **active** character + owner ownership; can't switch into a blocked character.
- Single-character accounts are unaffected (the switcher just shows one character + "Add character").

Web + server builds clean. No new eslint errors (the one in AuthContext is the pre-existing `useAuth` react-refresh rule).

Next: phase 3 (owner-scoped personal maps + per-owner soft cap).