### PR TITLE
multi-account phase 4: centre/route from another character (eyes-on-the-exit)

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -417,10 +417,10 @@ authRouter.get('/me', async (req, res) => {
   // All characters linked to this account, for the character switcher.
   const ownerId = await ensureOwnerId(req);
   const { rows: charRows } = ownerId != null
-    ? await db.query<{ id: number; characterId: number; characterName: string; role: string; corpId: number | null; blocked: boolean; lksId: number | null; lksName: string | null }>(
+    ? await db.query<{ id: number; characterId: number; characterName: string; role: string; corpId: number | null; blocked: boolean; lksId: number | null; lksName: string | null; lksClass: string | null }>(
         `SELECT u.id, u.character_id AS "characterId", u.character_name AS "characterName", u.role,
                 u.corp_id AS "corpId", u.blocked,
-                u.last_known_system_id AS "lksId", s.name AS "lksName"
+                u.last_known_system_id AS "lksId", s.name AS "lksName", s.class AS "lksClass"
          FROM users u LEFT JOIN solar_systems s ON s.id = u.last_known_system_id
          WHERE u.owner_id = $1 ORDER BY u.character_name`,
         [ownerId])
@@ -434,6 +434,7 @@ authRouter.get('/me', async (req, res) => {
     blocked:             c.blocked,
     lastKnownSystemId:   c.lksId != null ? Number(c.lksId) : null,
     lastKnownSystemName: c.lksName,
+    lastKnownSystemClass: c.lksClass,
     active:              c.id === req.session.userId,
   }));
 

--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -5,6 +5,7 @@ import { getValidToken } from '../utils/eveToken.js';
 import { createLogger } from '../utils/logger.js';
 import { TtlCache } from '../utils/cache.js';
 import { resolveEntityNames } from '../services/entityNames.js';
+import { resolveOwnerId } from '../utils/owner.js';
 
 export const characterRouter = Router();
 characterRouter.use(requireAuth);
@@ -39,104 +40,107 @@ function isReallyOnline(data: EsiOnlineResponse): boolean {
   return login >= logout;
 }
 
-// GET /api/character/location
-// Returns the character's current system if online, or { online: false }
+// Read a character's live location (online + current system + ship) by Nexum
+// user id, using that character's own stored token. Records a jump + persists
+// last_known_system keyed by userId, so reading any of an account's characters
+// keeps its profile fresh. Returns the wire payload; throws on token/ESI errors.
+type LocationPayload =
+  | { online: false }
+  | { online: true; system: Record<string, unknown> | null; ship: { typeId: number; typeName: string; shipName: string; mass: number | null } | null };
+
+async function getLocationPayload(userId: number): Promise<LocationPayload> {
+  const { rows: userRows } = await db.query<{ character_id: number }>(
+    `SELECT character_id FROM users WHERE id = $1`, [userId]);
+  if (!userRows.length) return { online: false };
+
+  const token       = await getValidToken(userId);
+  const characterId = userRows[0].character_id;
+
+  const onlineRes = await fetch(
+    `https://esi.evetech.net/latest/characters/${characterId}/online/`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!onlineRes.ok || onlineRes.status === 401 || onlineRes.status === 403) return { online: false };
+  const onlineData = await onlineRes.json() as EsiOnlineResponse;
+  if (!isReallyOnline(onlineData)) { lastSeenSystem.delete(userId); return { online: false }; }
+
+  const [locRes, shipRes] = await Promise.all([
+    fetch(`https://esi.evetech.net/latest/characters/${characterId}/location/`,
+      { headers: { Authorization: `Bearer ${token}` } }),
+    fetch(`https://esi.evetech.net/latest/characters/${characterId}/ship/`,
+      { headers: { Authorization: `Bearer ${token}` } }),
+  ]);
+  if (!locRes.ok) return { online: true, system: null, ship: null };
+
+  const loc = await locRes.json() as { solar_system_id: number };
+
+  // Ship is best-effort — a transient ESI hiccup on /ship/ shouldn't hide the
+  // rest of the payload. Type name comes from SDE-seeded item_types.
+  let ship: { typeId: number; typeName: string; shipName: string; mass: number | null } | null = null;
+  if (shipRes.ok) {
+    const shipData = await shipRes.json() as { ship_type_id: number; ship_name: string };
+    const { rows: typeRows } = await db.query<{ name: string; mass: string | null }>(
+      `SELECT name, mass FROM item_types WHERE id = $1`, [shipData.ship_type_id]);
+    const massRaw = typeRows[0]?.mass;
+    const massNum = massRaw == null ? null : Number(massRaw);
+    ship = {
+      typeId:   shipData.ship_type_id,
+      typeName: typeRows[0]?.name ?? `Type ${shipData.ship_type_id}`,
+      shipName: shipData.ship_name,
+      mass:     massNum != null && Number.isFinite(massNum) ? massNum : null,
+    };
+  }
+
+  // Jump event + last-known persistence, keyed per character.
+  const prevSys = lastSeenSystem.get(userId);
+  if (prevSys !== undefined && prevSys !== loc.solar_system_id) {
+    db.query(`INSERT INTO user_events (user_id, event_type) VALUES ($1, 'jump')`, [userId]).catch(console.error);
+  }
+  if (prevSys !== loc.solar_system_id) {
+    db.query(`UPDATE users SET last_known_system_id = $1, last_known_system_at = NOW() WHERE id = $2`,
+      [loc.solar_system_id, userId]).catch(console.error);
+  }
+  lastSeenSystem.set(userId, loc.solar_system_id);
+
+  const { rows } = await db.query(
+    `SELECT s.id AS "eveSystemId", s.name, s.class AS "systemClass",
+            COALESCE(s.effect, 'none') AS effect, s.statics,
+            r.name AS "regionName", r.npc_type AS "npcType"
+     FROM solar_systems s
+     LEFT JOIN map_regions r ON r.id = s.region_id
+     WHERE s.id = $1`,
+    [loc.solar_system_id],
+  );
+  return { online: true, system: rows.length ? rows[0] : null, ship };
+}
+
+// GET /api/character/location — the active character's location.
 characterRouter.get('/location', async (req, res) => {
   try {
-    const { rows: userRows } = await db.query<{ character_id: number }>(
-      `SELECT character_id FROM users WHERE id = $1`,
-      [req.session.userId],
-    );
-    if (!userRows.length) { res.status(404).json({ error: 'User not found' }); return; }
-
-    const token       = await getValidToken(req.session.userId!);
-    const characterId = userRows[0].character_id;
-
-    // Check online status first
-    const onlineRes = await fetch(
-      `https://esi.evetech.net/latest/characters/${characterId}/online/`,
-      { headers: { Authorization: `Bearer ${token}` } },
-    );
-    if (!onlineRes.ok || onlineRes.status === 401 || onlineRes.status === 403) {
-      res.json({ online: false }); return;
-    }
-    const onlineData = await onlineRes.json() as EsiOnlineResponse;
-    if (!isReallyOnline(onlineData)) {
-      lastSeenSystem.delete(req.session.userId!);
-      res.json({ online: false }); return;
-    }
-
-    // Fetch current location + ship in parallel — both gated on the same
-    // token and online check, no point serialising them.
-    const [locRes, shipRes] = await Promise.all([
-      fetch(`https://esi.evetech.net/latest/characters/${characterId}/location/`,
-        { headers: { Authorization: `Bearer ${token}` } }),
-      fetch(`https://esi.evetech.net/latest/characters/${characterId}/ship/`,
-        { headers: { Authorization: `Bearer ${token}` } }),
-    ]);
-    if (!locRes.ok) { res.json({ online: true, system: null, ship: null }); return; }
-
-    const loc = await locRes.json() as { solar_system_id: number };
-
-    // Ship is best-effort — a transient ESI hiccup on /ship/ shouldn't
-    // hide the rest of the location payload. Look up the type name from
-    // the SDE-seeded item_types so the client gets a ready-to-render label.
-    let ship: { typeId: number; typeName: string; shipName: string; mass: number | null } | null = null;
-    if (shipRes.ok) {
-      const shipData = await shipRes.json() as { ship_type_id: number; ship_name: string };
-      const { rows: typeRows } = await db.query<{ name: string; mass: string | null }>(
-        `SELECT name, mass FROM item_types WHERE id = $1`,
-        [shipData.ship_type_id],
-      );
-      // item_types.mass is NUMERIC (parsed back as string by node-pg). Cast to
-      // number for the wire; null when the SDE row is missing or massless
-      // (capsule has 32k kg, so it'll have a value).
-      const massRaw = typeRows[0]?.mass;
-      const massNum = massRaw == null ? null : Number(massRaw);
-      ship = {
-        typeId:   shipData.ship_type_id,
-        typeName: typeRows[0]?.name ?? `Type ${shipData.ship_type_id}`,
-        shipName: shipData.ship_name,
-        mass:     massNum != null && Number.isFinite(massNum) ? massNum : null,
-      };
-    }
-
-    // Record a jump when the system changes
-    const userId  = req.session.userId!;
-    const prevSys = lastSeenSystem.get(userId);
-    if (prevSys !== undefined && prevSys !== loc.solar_system_id) {
-      db.query(
-        `INSERT INTO user_events (user_id, event_type) VALUES ($1, 'jump')`,
-        [userId],
-      ).catch(console.error);
-    }
-    // Persist the last known system to the user profile whenever it's new or
-    // changed (first poll of the session, or after a jump). Steady-state polls
-    // in the same system don't write. Best-effort — never blocks the response.
-    if (prevSys !== loc.solar_system_id) {
-      db.query(
-        `UPDATE users SET last_known_system_id = $1, last_known_system_at = NOW() WHERE id = $2`,
-        [loc.solar_system_id, userId],
-      ).catch(console.error);
-    }
-    lastSeenSystem.set(userId, loc.solar_system_id);
-
-    // Look up system details in our DB
-    const { rows } = await db.query(
-      `SELECT s.id AS "eveSystemId", s.name, s.class AS "systemClass",
-              COALESCE(s.effect, 'none') AS effect, s.statics,
-              r.name AS "regionName", r.npc_type AS "npcType"
-       FROM solar_systems s
-       LEFT JOIN map_regions r ON r.id = s.region_id
-       WHERE s.id = $1`,
-      [loc.solar_system_id],
-    );
-
-    if (!rows.length) { res.json({ online: true, system: null, ship }); return; }
-    res.json({ online: true, system: rows[0], ship });
+    res.json(await getLocationPayload(req.session.userId!));
   } catch (err) {
     log.error('Location check failed:', err);
     res.status(500).json({ error: 'Failed to get location' });
+  }
+});
+
+// GET /api/character/:userId/location — location of another character on the
+// SAME account. Used to centre/route from an alt that isn't logged into Nexum
+// (e.g. a scout sitting on the chain exit). Authorised by owner ownership; a
+// revoked/expired alt token degrades to { online: false } rather than erroring.
+characterRouter.get('/:targetUserId/location', async (req, res) => {
+  const targetUserId = Number(req.params.targetUserId);
+  if (!Number.isInteger(targetUserId)) { res.status(400).json({ error: 'Invalid user id' }); return; }
+  const ownerId = await resolveOwnerId(req);
+  if (ownerId == null) { res.status(401).json({ error: 'Not authenticated' }); return; }
+  const { rows } = await db.query<{ owner_id: number | null }>(
+    `SELECT owner_id FROM users WHERE id = $1`, [targetUserId]);
+  if (!rows.length || rows[0].owner_id !== ownerId) { res.status(403).json({ error: 'Not your character' }); return; }
+  try {
+    res.json(await getLocationPayload(targetUserId));
+  } catch (err) {
+    log.error(`Location check failed for character ${targetUserId}:`, err);
+    res.json({ online: false });
   }
 });
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -746,11 +746,15 @@
   flex-direction: column;
   gap: 2px;
 }
-.character-switcher__item {
+.character-switcher__row { display: flex; align-items: center; border-radius: 4px; }
+.character-switcher__row:hover { background: #162032; }
+.character-switcher__row--active .character-switcher__name { color: #e8f0ff; }
+.character-switcher__switch {
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 5px 8px;
   background: transparent;
   border: none;
@@ -761,12 +765,27 @@
   cursor: pointer;
   text-align: left;
 }
-.character-switcher__item:hover:not(:disabled) { background: #162032; }
-.character-switcher__item:disabled { cursor: default; }
-.character-switcher__item--active { color: #e8f0ff; }
+.character-switcher__switch:disabled { cursor: default; }
 .character-switcher__avatar { width: 24px; height: 24px; border-radius: 50%; flex-shrink: 0; }
 .character-switcher__name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .character-switcher__blocked { margin-left: 6px; color: #e25a5a; font-size: 0.85em; }
+.character-switcher__focus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  margin-right: 4px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: #7a90a8;
+  cursor: pointer;
+}
+.character-switcher__focus:hover:not(:disabled) { color: #5a9af8; background: #1c2940; }
+.character-switcher__focus:disabled { opacity: 0.4; cursor: default; }
+.character-switcher__focus--on { color: #5a9af8; }
 .character-switcher__add {
   display: flex;
   align-items: center;

--- a/web/src/components/ui/A0Pane.tsx
+++ b/web/src/components/ui/A0Pane.tsx
@@ -57,9 +57,11 @@ export function A0Pane() {
 
   return (
     <div className="scout-pane">
-      {origin.fromLastKnown && origin.name && (
+      {origin.characterName && origin.name ? (
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: origin.name })}</div>
+      ) : origin.fromLastKnown && origin.name ? (
         <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: origin.name })}</div>
-      )}
+      ) : null}
       <div className="scout-pane__note">{t('a0.showing', { count: TOP_N })}</div>
       {closest.map(s => {
         const route   = routes[String(s.id)];

--- a/web/src/components/ui/CharacterSwitcher.tsx
+++ b/web/src/components/ui/CharacterSwitcher.tsx
@@ -1,18 +1,30 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CaretDownIcon, PlusIcon, CheckIcon } from '@phosphor-icons/react';
+import { CaretDownIcon, PlusIcon, CheckIcon, MapPinIcon } from '@phosphor-icons/react';
 import { useAuth } from '../../context/AuthContext';
+import { useMapStore } from '../../store/mapStore';
 import { api, apiUrl } from '../../api/client';
+import { toast } from './Toaster';
+
+interface CharLocationResponse {
+  online: boolean;
+  system: { eveSystemId: number; name: string; systemClass: string | null } | null;
+}
 
 /**
  * Account character switcher. Lists every character linked to the signed-in
- * account; clicking one makes it active (no SSO — its token is already stored)
- * and reloads so map/corp context re-initialises. "Add character" runs the
- * authenticated add-character SSO flow on the server.
+ * account. Clicking a row makes it active (no SSO — its token is already
+ * stored) and reloads so map/corp context re-inits. The 📍 button focuses the
+ * map + jump calcs on that character's location WITHOUT switching active — e.g.
+ * route from a scout sitting on the chain exit while you fly your main out.
+ * "Add character" runs the authenticated add-character SSO flow.
  */
 export function CharacterSwitcher() {
   const { t } = useTranslation();
   const { user } = useAuth();
+  const routeOrigin = useMapStore((s) => s.routeOrigin);
+  const setRouteOrigin = useMapStore((s) => s.setRouteOrigin);
+  const requestCenter = useMapStore((s) => s.requestCenterOnEveSystem);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -42,6 +54,36 @@ export function CharacterSwitcher() {
     }
   }
 
+  // Point centring + jump calcs at this character's location (live if online,
+  // else its last known system). The active character clears the override and
+  // reverts to live routing.
+  async function focusOn(c: typeof characters[number]) {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const loc = await api<CharLocationResponse>(`/api/character/${c.id}/location`).catch(() => null);
+      let eveSystemId: number | null = null;
+      let systemName = '';
+      let systemClass: string | null = null;
+      if (loc?.online && loc.system) {
+        eveSystemId = loc.system.eveSystemId; systemName = loc.system.name; systemClass = loc.system.systemClass;
+      } else if (c.lastKnownSystemId != null) {
+        eveSystemId = c.lastKnownSystemId; systemName = c.lastKnownSystemName ?? ''; systemClass = c.lastKnownSystemClass;
+      }
+      if (eveSystemId == null) {
+        toast.error(t('account.noLocation', { name: c.characterName }));
+        return;
+      }
+      setRouteOrigin(c.active
+        ? null
+        : { charId: c.id, characterName: c.characterName, eveSystemId, systemName, systemClass });
+      requestCenter(eveSystemId);
+    } finally {
+      setBusy(false);
+      setOpen(false);
+    }
+  }
+
   return (
     <div className="character-switcher" ref={wrapRef}>
       <button
@@ -57,27 +99,42 @@ export function CharacterSwitcher() {
       </button>
       {open && (
         <div className="character-switcher__menu" role="menu">
-          {characters.map((c) => (
-            <button
-              key={c.id}
-              type="button"
-              role="menuitem"
-              className={`character-switcher__item${c.active ? ' character-switcher__item--active' : ''}`}
-              disabled={busy || c.active || c.blocked}
-              onClick={() => switchTo(c.id)}
-            >
-              <img
-                className="character-switcher__avatar"
-                src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=32`}
-                alt=""
-              />
-              <span className="character-switcher__name">
-                {c.characterName}
-                {c.blocked && <span className="character-switcher__blocked">{t('account.blocked')}</span>}
-              </span>
-              {c.active && <CheckIcon size={13} weight="bold" />}
-            </button>
-          ))}
+          {characters.map((c) => {
+            const isOrigin = routeOrigin ? routeOrigin.charId === c.id : c.active;
+            return (
+              <div key={c.id} className={`character-switcher__row${c.active ? ' character-switcher__row--active' : ''}`}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="character-switcher__switch"
+                  disabled={busy || c.active || c.blocked}
+                  onClick={() => switchTo(c.id)}
+                  data-tooltip={c.active ? undefined : t('account.switchTo', { name: c.characterName })}
+                >
+                  <img
+                    className="character-switcher__avatar"
+                    src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=32`}
+                    alt=""
+                  />
+                  <span className="character-switcher__name">
+                    {c.characterName}
+                    {c.blocked && <span className="character-switcher__blocked">{t('account.blocked')}</span>}
+                  </span>
+                  {c.active && <CheckIcon size={13} weight="bold" />}
+                </button>
+                <button
+                  type="button"
+                  className={`character-switcher__focus${isOrigin ? ' character-switcher__focus--on' : ''}`}
+                  disabled={busy || c.blocked}
+                  onClick={() => focusOn(c)}
+                  data-tooltip={t('account.focusLocation', { name: c.characterName })}
+                  aria-label={t('account.focusLocation', { name: c.characterName })}
+                >
+                  <MapPinIcon size={14} weight={isOrigin ? 'fill' : 'regular'} />
+                </button>
+              </div>
+            );
+          })}
           <a className="character-switcher__add" href={apiUrl('/auth/add-character')}>
             <PlusIcon size={13} weight="bold" />
             {t('account.addCharacter')}

--- a/web/src/components/ui/ClosestSystemsPane.tsx
+++ b/web/src/components/ui/ClosestSystemsPane.tsx
@@ -309,9 +309,11 @@ export function ClosestSystemsPane() {
 
   return (
     <div className="scout-pane">
-      {origin.fromLastKnown && origin.name && (
+      {origin.characterName && origin.name ? (
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: origin.name })}</div>
+      ) : origin.fromLastKnown && origin.name ? (
         <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: origin.name })}</div>
-      )}
+      ) : null}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <SortableContext items={items.map((i) => String(i.id))} strategy={verticalListSortingStrategy}>
           {items.map((i) => (

--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -127,9 +127,11 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
 
   return (
     <div className="scout-pane">
-      {origin.fromLastKnown && origin.name && (
+      {origin.characterName && origin.name ? (
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: origin.name })}</div>
+      ) : origin.fromLastKnown && origin.name ? (
         <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: origin.name })}</div>
-      )}
+      ) : null}
       <div className="scout-pane__sort">
         <label className="scout-pane__sort-label" htmlFor={`scout-sort-${scoutSystem}`}>
           {t('scout.sortLabel')}

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -18,6 +18,7 @@ export interface AccountCharacter {
   blocked: boolean;
   lastKnownSystemId: number | null;
   lastKnownSystemName: string | null;
+  lastKnownSystemClass: string | null;
   active: boolean;
 }
 

--- a/web/src/hooks/useRouteOrigin.ts
+++ b/web/src/hooks/useRouteOrigin.ts
@@ -1,35 +1,48 @@
 import { useCharacterLocation } from './useCharacterLocation';
 import { useAuth } from '../context/AuthContext';
+import { useMapStore } from '../store/mapStore';
 import { KSPACE_CLASSES } from '../components/ui/routeUi';
 
 export interface RouteOrigin {
   /** EVE system id to route FROM, or null when there's no usable origin. */
   systemId: number | null;
-  /** True when the origin is the pilot's last known system (offline) rather than live. */
+  /** True when the origin is a last known system (offline) rather than live. */
   fromLastKnown: boolean;
   /** Origin system name when known — for "jumps from X" labels. */
   name: string | null;
+  /** Set when the origin is another of the account's characters (not the active one). */
+  characterName: string | null;
 }
 
 /**
- * Resolves the system to calculate gate routes FROM, with a graceful offline
- * fallback. When the pilot is online and docked/floating in k-space we use
- * their live ESI location; otherwise we fall back to their last known system
- * (from /auth/me) so jump counts still work while they're logged out of EVE.
+ * Resolves the system to calculate gate routes FROM, with graceful fallbacks:
  *
- * Either way the origin must be k-space — gate routing can't start inside a
- * wormhole — so a last known WH system yields no origin (callers show the
- * usual sign-in/dock prompt).
+ *  1. An explicit route-origin override — another of the account's characters
+ *     (e.g. a scout sitting on the chain exit) selected as the reference.
+ *  2. Otherwise the active character's live ESI location when online in k-space.
+ *  3. Otherwise the active character's last known system (so jumps still work
+ *     while logged out of EVE).
+ *
+ * The origin must be k-space — gate routing can't start inside a wormhole — so a
+ * WH origin yields none (callers show the usual sign-in/dock prompt).
  */
 export function useRouteOrigin(): RouteOrigin {
+  const override  = useMapStore((s) => s.routeOrigin);
   const location  = useCharacterLocation();
   const lastKnown = useAuth().user?.lastKnownSystem ?? null;
 
+  if (override) {
+    if (override.systemClass && KSPACE_CLASSES.has(override.systemClass)) {
+      return { systemId: override.eveSystemId, fromLastKnown: false, name: override.systemName, characterName: override.characterName };
+    }
+    return { systemId: null, fromLastKnown: false, name: override.systemName, characterName: override.characterName };
+  }
+
   if (location.online && location.system && KSPACE_CLASSES.has(location.system.systemClass)) {
-    return { systemId: location.system.eveSystemId, fromLastKnown: false, name: location.system.name };
+    return { systemId: location.system.eveSystemId, fromLastKnown: false, name: location.system.name, characterName: null };
   }
   if (lastKnown?.id != null && lastKnown.systemClass && KSPACE_CLASSES.has(lastKnown.systemClass)) {
-    return { systemId: lastKnown.id, fromLastKnown: true, name: lastKnown.name };
+    return { systemId: lastKnown.id, fromLastKnown: true, name: lastKnown.name, characterName: null };
   }
-  return { systemId: null, fromLastKnown: false, name: null };
+  return { systemId: null, fromLastKnown: false, name: null, characterName: null };
 }

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "Charakter wechseln",
     "addCharacter": "Charakter hinzufügen",
     "blocked": "blockiert",
-    "characterAdded": "{{name}} hinzugefügt"
+    "characterAdded": "{{name}} hinzugefügt",
+    "switchTo": "Zu {{name}} wechseln",
+    "focusLocation": "Karte auf {{name}} zentrieren und von dort routen",
+    "noLocation": "Kein bekannter Standort für {{name}}"
   },
   "actions": {
     "save": "Speichern",
@@ -646,7 +649,8 @@
     "sortSecure": "Sichere Route"
   },
   "route": {
-    "fromLastKnown": "Sprünge ab {{system}} (letzter bekannter Standort)"
+    "fromLastKnown": "Sprünge ab {{system}} (letzter bekannter Standort)",
+    "fromCharacter": "Sprünge von {{character}} — {{system}}"
   },
   "activity": {
     "thisHour": "diese Stunde",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "Switch character",
     "addCharacter": "Add character",
     "blocked": "blocked",
-    "characterAdded": "Added {{name}}"
+    "characterAdded": "Added {{name}}",
+    "switchTo": "Switch to {{name}}",
+    "focusLocation": "Centre & route from {{name}}",
+    "noLocation": "No known location for {{name}}"
   },
   "actions": {
     "save": "Save",
@@ -646,7 +649,8 @@
     "sortSecure": "Secure route"
   },
   "route": {
-    "fromLastKnown": "Jumps from {{system}} (last known location)"
+    "fromLastKnown": "Jumps from {{system}} (last known location)",
+    "fromCharacter": "Jumps from {{character}} — {{system}}"
   },
   "activity": {
     "thisHour": "this hour",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "Cambiar de personaje",
     "addCharacter": "Añadir personaje",
     "blocked": "bloqueado",
-    "characterAdded": "{{name}} añadido"
+    "characterAdded": "{{name}} añadido",
+    "switchTo": "Cambiar a {{name}}",
+    "focusLocation": "Centrar y rutar desde {{name}}",
+    "noLocation": "No hay ubicación conocida de {{name}}"
   },
   "actions": {
     "save": "Guardar",
@@ -646,7 +649,8 @@
     "sortSecure": "Ruta segura"
   },
   "route": {
-    "fromLastKnown": "Saltos desde {{system}} (última ubicación conocida)"
+    "fromLastKnown": "Saltos desde {{system}} (última ubicación conocida)",
+    "fromCharacter": "Saltos desde {{character}} — {{system}}"
   },
   "activity": {
     "thisHour": "esta hora",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "Changer de personnage",
     "addCharacter": "Ajouter un personnage",
     "blocked": "bloqué",
-    "characterAdded": "{{name}} ajouté"
+    "characterAdded": "{{name}} ajouté",
+    "switchTo": "Basculer vers {{name}}",
+    "focusLocation": "Centrer et router depuis {{name}}",
+    "noLocation": "Aucune position connue pour {{name}}"
   },
   "actions": {
     "save": "Enregistrer",
@@ -646,7 +649,8 @@
     "sortSecure": "Route sécurisée"
   },
   "route": {
-    "fromLastKnown": "Sauts depuis {{system}} (dernière position connue)"
+    "fromLastKnown": "Sauts depuis {{system}} (dernière position connue)",
+    "fromCharacter": "Sauts depuis {{character}} — {{system}}"
   },
   "activity": {
     "thisHour": "cette heure",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "キャラクター切り替え",
     "addCharacter": "キャラクターを追加",
     "blocked": "ブロック中",
-    "characterAdded": "{{name}} を追加しました"
+    "characterAdded": "{{name}} を追加しました",
+    "switchTo": "{{name}} に切り替え",
+    "focusLocation": "{{name}} を中心に表示し、そこからルート計算",
+    "noLocation": "{{name}} の既知の位置がありません"
   },
   "actions": {
     "save": "保存",
@@ -646,7 +649,8 @@
     "sortSecure": "安全ルート"
   },
   "route": {
-    "fromLastKnown": "{{system}} からのジャンプ数（最後に確認された位置）"
+    "fromLastKnown": "{{system}} からのジャンプ数（最後に確認された位置）",
+    "fromCharacter": "{{character}} からのジャンプ数 — {{system}}"
   },
   "activity": {
     "thisHour": "今時間",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "캐릭터 전환",
     "addCharacter": "캐릭터 추가",
     "blocked": "차단됨",
-    "characterAdded": "{{name}} 추가됨"
+    "characterAdded": "{{name}} 추가됨",
+    "switchTo": "{{name}}(으)로 전환",
+    "focusLocation": "{{name}} 위치로 이동하고 경로 계산",
+    "noLocation": "{{name}}의 알려진 위치 없음"
   },
   "actions": {
     "save": "저장",
@@ -646,7 +649,8 @@
     "sortSecure": "안전 경로"
   },
   "route": {
-    "fromLastKnown": "{{system}}에서의 점프 (마지막으로 확인된 위치)"
+    "fromLastKnown": "{{system}}에서의 점프 (마지막으로 확인된 위치)",
+    "fromCharacter": "{{character}}에서의 점프 — {{system}}"
   },
   "activity": {
     "thisHour": "이번 시간",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "Mudar de personagem",
     "addCharacter": "Adicionar personagem",
     "blocked": "bloqueado",
-    "characterAdded": "{{name}} adicionado"
+    "characterAdded": "{{name}} adicionado",
+    "switchTo": "Mudar para {{name}}",
+    "focusLocation": "Centrar e traçar rota a partir de {{name}}",
+    "noLocation": "Nenhuma localização conhecida de {{name}}"
   },
   "actions": {
     "save": "Guardar",
@@ -646,7 +649,8 @@
     "sortSecure": "Rota segura"
   },
   "route": {
-    "fromLastKnown": "Saltos a partir de {{system}} (última localização conhecida)"
+    "fromLastKnown": "Saltos a partir de {{system}} (última localização conhecida)",
+    "fromCharacter": "Saltos a partir de {{character}} — {{system}}"
   },
   "activity": {
     "thisHour": "esta hora",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "Сменить персонажа",
     "addCharacter": "Добавить персонажа",
     "blocked": "заблокирован",
-    "characterAdded": "{{name}} добавлен"
+    "characterAdded": "{{name}} добавлен",
+    "switchTo": "Переключиться на {{name}}",
+    "focusLocation": "Центрировать и строить маршрут от {{name}}",
+    "noLocation": "Нет известного местоположения {{name}}"
   },
   "actions": {
     "save": "Сохранить",
@@ -672,7 +675,8 @@
     "sortSecure": "Безопасный маршрут"
   },
   "route": {
-    "fromLastKnown": "Прыжки от {{system}} (последнее известное местоположение)"
+    "fromLastKnown": "Прыжки от {{system}} (последнее известное местоположение)",
+    "fromCharacter": "Прыжки от {{character}} — {{system}}"
   },
   "activity": {
     "thisHour": "за этот час",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -6,7 +6,10 @@
     "switchCharacter": "切换角色",
     "addCharacter": "添加角色",
     "blocked": "已封禁",
-    "characterAdded": "已添加 {{name}}"
+    "characterAdded": "已添加 {{name}}",
+    "switchTo": "切换到 {{name}}",
+    "focusLocation": "以 {{name}} 为中心并从其位置规划路线",
+    "noLocation": "没有 {{name}} 的已知位置"
   },
   "actions": {
     "save": "保存",
@@ -646,7 +649,8 @@
     "sortSecure": "安全路线"
   },
   "route": {
-    "fromLastKnown": "从 {{system}} 起的跳跃数（最后已知位置）"
+    "fromLastKnown": "从 {{system}} 起的跳跃数（最后已知位置）",
+    "fromCharacter": "从 {{character}} 起的跳跃数 — {{system}}"
   },
   "activity": {
     "thisHour": "本小时",

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -7,6 +7,15 @@ import { toast } from '../components/ui/Toaster';
 import type { WormholeMap, MapSystem, MapConnection, SystemClass, WormholeEffect } from '../types';
 import { pickHandles } from '../components/map/edgeUtils';
 
+// Another of the account's characters chosen as the route/centre origin.
+export interface RouteOriginOverride {
+  charId:        number;          // users.id of the reference character
+  characterName: string;
+  eveSystemId:   number;          // the system to route from / centre on
+  systemName:    string;
+  systemClass:   string | null;   // for the k-space gate in useRouteOrigin
+}
+
 // Debounce position saves — fires max once per 500 ms per system
 const moveTimers = new Map<string, ReturnType<typeof setTimeout>>();
 // Per-node measured dimensions, kept out of reactive state so individual
@@ -135,6 +144,12 @@ interface MapStore {
   centerRequestEveId: number | null;
   requestCenterOnEveSystem: (eveSystemId: number) => void;
   clearCenterRequest: () => void;
+
+  // Route/centre origin override: point jump calcs + centring at another of
+  // the account's characters (e.g. a scout on the chain exit) instead of the
+  // active character. null = use the active character's live location.
+  routeOrigin: RouteOriginOverride | null;
+  setRouteOrigin: (o: RouteOriginOverride | null) => void;
 
   // Undo
   undoStack: UndoCommand[];
@@ -383,6 +398,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
     autoLayoutPending: false,
     fitViewPending: false,
     centerRequestEveId: null,
+    routeOrigin: null,
     sigRev: {},
     structRev: {},
     panelOrder: ['activity', 'killboard', 'notes', 'signatures', 'structures', 'npcStations'],
@@ -631,6 +647,8 @@ export const useMapStore = create<MapStore>()((set, get) => {
 
     requestCenterOnEveSystem: (eveSystemId) => set({ centerRequestEveId: eveSystemId }),
     clearCenterRequest: () => set({ centerRequestEveId: null }),
+
+    setRouteOrigin: (o) => set({ routeOrigin: o }),
 
     // ── Systems ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Final build phase of multi-character support. Splits the **active** character (identity, edits, in-game waypoints) from the **location/route-origin** character (what the map centres on and computes jumps from) — the "fly alt1 out while routing from alt5 on the exit" scenario. Targets **`account-management`**.

## Server
- Refactored `/api/character/location` into `getLocationPayload(userId)`.
- New **`GET /api/character/:userId/location`** — reads another of the account's characters' live location via *its own* stored token (works when that alt isn't logged into Nexum). Owner-authorised; a revoked/expired token degrades to `{ online: false }`.
- `/auth/me` characters now include `lastKnownSystemClass` (for the offline k-space gate).

## Client
- `mapStore.routeOrigin` override + `setRouteOrigin`.
- `useRouteOrigin()` now resolves: **override → active live (k-space) → active last-known**.
- **CharacterSwitcher**: each character gets a 📍 **focus** button that centres the map on that character and routes jump calcs from it, *without* switching active. Clicking your active character's 📍 clears the override (back to live). Reuses the `centerRequestEveId` centring mechanism from earlier.
- Closest Systems / A0 / Thera-Turnur show **"Jumps from {char} — {system}"** when an override is active.
- New `route.fromCharacter` + `account.switchTo`/`focusLocation`/`noLocation` strings across all nine locales (full parity).

Web + server build clean. No new eslint errors (the 2 in ClosestSystemsPane are pre-existing dropdown effects).

This completes the planned phases (1 schema → 2 add/switch → 3 owner-scoped maps → 4 location/route origin). Phase 5 (background location poller) remains optional.