### PR TITLE
multi-account phase 5 (optional): background location poller

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -102,6 +102,11 @@ export const config = {
   corpMapExpireDays:   CORP_MAP_TIME,
   maxUserMaps:         parseInt(process.env.MAX_USER_MAPS ?? '5', 10),
   maxCorpMaps:         parseInt(process.env.MAX_CORP_MAPS ?? '5', 10),
+  // Background last-known-location poller (multi-account). 0 / unset = disabled
+  // (opt-in at the deployment level). When > 0, every linked character's
+  // last_known_system is refreshed from ESI on this cadence so positions stay
+  // current without anyone being logged into Nexum.
+  locationPollMinutes: Math.max(0, parseInt(process.env.LOCATION_POLL_MINUTES ?? '0', 10) || 0),
   discord:             DISCORD_WEBHOOKS,
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,7 @@ import routeRouter        from './routes/route.js';
 import wormholesRouter    from './routes/wormholes.js';
 import { loadRouteGraph } from './services/routeGraph.js';
 import { startSdeAutoUpdate } from './services/sdeUpdate.js';
+import { startLocationPoller } from './services/locationPoll.js';
 import { adminRouter, adminReadRouter, reportsRouter } from './routes/admin.js';
 import { standingsRouter } from './routes/standings.js';
 import { shareRouter } from './routes/share.js';
@@ -150,5 +151,6 @@ migrate()
     await loadRouteGraph();
     app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));
     startSdeAutoUpdate();
+    startLocationPoller();
   })
   .catch((err) => { console.error('Migration failed:', err); process.exit(1); });

--- a/server/src/services/locationPoll.ts
+++ b/server/src/services/locationPoll.ts
@@ -1,0 +1,85 @@
+import { db } from '../db.js';
+import { getValidToken } from '../utils/eveToken.js';
+import { config } from '../config.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('locationPoll');
+
+// Mirror of routes/character.ts isReallyOnline — ESI's `online` flag lags on
+// log-out, so cross-check last_login >= last_logout.
+interface OnlineResp { online?: boolean; last_login?: string; last_logout?: string }
+function reallyOnline(d: OnlineResp): boolean {
+  if (!d?.online) return false;
+  if (!d.last_login || !d.last_logout) return true;
+  const lin = new Date(d.last_login).getTime();
+  const lout = new Date(d.last_logout).getTime();
+  if (!Number.isFinite(lin) || !Number.isFinite(lout)) return true;
+  return lin >= lout;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Refresh one character's last_known_system from ESI (only when online — an
+// offline character keeps its existing last known system). No jump events:
+// background detection shouldn't inflate a pilot's activity stats.
+async function pollOne(userId: number, characterId: number): Promise<void> {
+  const token = await getValidToken(userId); // throws on a dead/revoked token
+  const onlineRes = await fetch(
+    `https://esi.evetech.net/latest/characters/${characterId}/online/`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!onlineRes.ok) return;
+  if (!reallyOnline(await onlineRes.json() as OnlineResp)) return;
+
+  const locRes = await fetch(
+    `https://esi.evetech.net/latest/characters/${characterId}/location/`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!locRes.ok) return;
+  const { solar_system_id } = await locRes.json() as { solar_system_id: number };
+  await db.query(
+    `UPDATE users SET last_known_system_id = $1, last_known_system_at = NOW()
+       WHERE id = $2 AND last_known_system_id IS DISTINCT FROM $1`,
+    [solar_system_id, userId],
+  );
+}
+
+let running = false;
+async function pollAll(): Promise<void> {
+  if (running) return; // never overlap cycles
+  running = true;
+  try {
+    // Only recently-active characters — avoids hammering ESI (and refreshing
+    // tokens) for long-dormant accounts whose tokens are probably dead anyway.
+    const { rows } = await db.query<{ id: number; character_id: number }>(
+      `SELECT id, character_id FROM users
+        WHERE refresh_token IS NOT NULL AND updated_at > NOW() - interval '30 days'
+        ORDER BY id`,
+    );
+    let ok = 0, skipped = 0;
+    for (const r of rows) {
+      try { await pollOne(r.id, r.character_id); ok++; }
+      catch { skipped++; } // dead token / ESI hiccup — skip quietly
+      await sleep(250);    // gentle on ESI between characters
+    }
+    if (rows.length) log.info(`location poll: ${ok} updated/ok, ${skipped} skipped of ${rows.length}`);
+  } catch (err) {
+    log.error('location poll cycle failed:', err);
+  } finally {
+    running = false;
+  }
+}
+
+/**
+ * Start the background last-known-location poller if LOCATION_POLL_MINUTES > 0.
+ * Opt-in at the deployment level — it reads the location of every recently
+ * active linked character (corp members, in corp mode), so it's only enabled
+ * where that's wanted.
+ */
+export function startLocationPoller(): void {
+  const mins = config.locationPollMinutes;
+  if (mins <= 0) return;
+  log.info(`background location poller enabled (every ${mins} min)`);
+  setTimeout(() => { void pollAll(); }, 30_000);      // first run shortly after boot
+  setInterval(() => { void pollAll(); }, mins * 60_000);
+}


### PR DESCRIPTION
The optional final phase. A deployment-gated background job that keeps every linked character's `last_known_system` fresh from ESI without anyone being logged into Nexum. Targets **`account-management`**. Server-only, **off by default**.

## What it does
- Enabled only when **`LOCATION_POLL_MINUTES > 0`** (unset/0 = disabled).
- Every cadence, refreshes `last_known_system` for characters **active within 30 days** that have a stored token.
- Only writes when the character is **actually online** (offline keeps the existing last known system). **No jump events** — background detection shouldn't inflate activity stats.
- Sequential with a 250 ms gap between characters and non-overlapping cycles, so it stays gentle on ESI; dead/revoked tokens skip quietly.

## Why
Keeps the toolbar last-known-system, the admin tables, and "centre/route from alt-N" data current for alts that aren't actively polled by a logged-in session — and is the basis for a future "where is everyone" view.

## Privacy / opt-in
It reads the location of every recently-active linked character (in corp mode, that's corp members), so it's **off unless a deployment opts in** by setting the interval. Documented as such.

Server `tsc` clean.

---

This completes all five phases of the multi-account epic on `account-management`:
1. owners schema + backfill · 2. add-character SSO + switcher · 3. owner-scoped maps + soft cap · 4. location/route-origin split + centre-on-alt-N · 5. background poller.

When you're happy with the epic end-to-end, `account-management` is ready to merge into `release`.