### PR TITLE
docs: surface multi-lingual support (README + compare page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Open <http://localhost> and click **Log in with EVE Online**. That's it.
 - **Demo map** — the landing page mounts a non-editable demo map so visitors can see what the tool does before logging in.
 - **Collapsible sidebar** — Map Options, Connections, Proximity Alerts, Stale System Fade, and Shortcuts each expand or collapse independently. Per-section open/closed state persists per browser via `localStorage`.
 - **European date format** — DD-MM-YYYY everywhere a date is displayed (chart axes, relative-time fallbacks for events older than a month). ISO timestamps are still used in CSV exports for spreadsheet sortability.
+- **Multi-lingual** — the entire UI is translated into nine languages: English, Deutsch, Français, Español, Português, 简体中文, 한국어, 日本語, and Русский. The language is auto-detected from the browser (regional locales like `es-MX` or `en-GB` map to the base language) and can be changed any time from the in-app language switcher; the choice persists per browser. The public landing and comparison pages are localised too.
 
 ### For corporations
 

--- a/web/public/compare/index.html
+++ b/web/public/compare/index.html
@@ -247,6 +247,13 @@
               <td data-i18n="massStatus">Mass status tracking</td>
             </tr>
             <tr>
+              <th scope="row" data-i18n="gMultiLingual">Multi-lingual</th>
+              <td class="nexum" data-i18n="gMultiLingualN"><span class="yes">Yes</span> — currently 9 languages</td>
+              <td data-i18n="no"><span class="no">No</span></td>
+              <td data-i18n="no"><span class="no">No</span></td>
+              <td data-i18n="no"><span class="no">No</span></td>
+            </tr>
+            <tr>
               <th scope="row" data-i18n="gTech">Tech stack</th>
               <td class="nexum">TypeScript · React · Node · Postgres</td>
               <td>PHP · MySQL</td>
@@ -496,6 +503,9 @@
             gSync: 'Echtzeit-Mehrbenutzer-Sync',
             gSigPaste: 'Signatur-Einfügen &amp; -Verfolgung',
             gMass: 'Wurmloch-Masse / Rolling',
+            gMultiLingual: 'Mehrsprachig',
+            gMultiLingualN: '<span class="yes">Ja</span> — derzeit 9 Sprachen',
+            no: '<span class="no">Nein</span>',
             gTech: 'Tech-Stack',
             gCost: 'Kosten',
             yes: '<span class="yes">Ja</span>',
@@ -593,6 +603,9 @@
             gSync: 'Sync multi-utilisateur en temps réel',
             gSigPaste: 'Collage &amp; suivi des signatures',
             gMass: 'Masse / rolling de trou de ver',
+            gMultiLingual: 'Multilingue',
+            gMultiLingualN: '<span class="yes">Oui</span> — actuellement 9 langues',
+            no: '<span class="no">Non</span>',
             gTech: 'Stack technique',
             gCost: 'Coût',
             yes: '<span class="yes">Oui</span>',
@@ -690,6 +703,9 @@
             gSync: 'Sync multiusuario en tiempo real',
             gSigPaste: 'Pegado y seguimiento de firmas',
             gMass: 'Masa / rolling de agujeros de gusano',
+            gMultiLingual: 'Multilingüe',
+            gMultiLingualN: '<span class="yes">Sí</span> — actualmente 9 idiomas',
+            no: '<span class="no">No</span>',
             gTech: 'Stack tecnológico',
             gCost: 'Coste',
             yes: '<span class="yes">Sí</span>',
@@ -787,6 +803,9 @@
             gSync: 'Sync multiutilizador em tempo real',
             gSigPaste: 'Colagem e seguimento de assinaturas',
             gMass: 'Massa / rolling de buracos de minhoca',
+            gMultiLingual: 'Multilíngue',
+            gMultiLingualN: '<span class="yes">Sim</span> — atualmente 9 idiomas',
+            no: '<span class="no">Não</span>',
             gTech: 'Stack tecnológico',
             gCost: 'Custo',
             yes: '<span class="yes">Sim</span>',
@@ -883,6 +902,9 @@
             gSync: '实时多用户同步',
             gSigPaste: '信号粘贴与跟踪',
             gMass: '虫洞质量 / 关洞',
+            gMultiLingual: '多语言',
+            gMultiLingualN: '<span class="yes">是</span> — 目前支持 9 种语言',
+            no: '<span class="no">否</span>',
             gTech: '技术栈',
             gCost: '成本',
             yes: '<span class="yes">是</span>',
@@ -979,6 +1001,9 @@
             gSync: '실시간 다중 사용자 동기화',
             gSigPaste: '시그니처 붙여넣기 및 추적',
             gMass: '웜홀 질량 / 롤링',
+            gMultiLingual: '다국어 지원',
+            gMultiLingualN: '<span class="yes">예</span> — 현재 9개 언어',
+            no: '<span class="no">아니요</span>',
             gTech: '기술 스택',
             gCost: '비용',
             yes: '<span class="yes">예</span>',
@@ -1075,6 +1100,9 @@
             gSync: 'リアルタイムマルチユーザー同期',
             gSigPaste: 'シグネチャの貼り付けと追跡',
             gMass: 'ワームホール質量 / ロール',
+            gMultiLingual: '多言語対応',
+            gMultiLingualN: '<span class="yes">はい</span> — 現在9言語',
+            no: '<span class="no">いいえ</span>',
             gTech: '技術スタック',
             gCost: 'コスト',
             yes: '<span class="yes">はい</span>',
@@ -1171,6 +1199,9 @@
             gSync: 'Многопользовательская синхронизация в реальном времени',
             gSigPaste: 'Вставка и отслеживание сигнатур',
             gMass: 'Масса / роллинг червоточин',
+            gMultiLingual: 'Многоязычность',
+            gMultiLingualN: '<span class="yes">Да</span> — сейчас 9 языков',
+            no: '<span class="no">Нет</span>',
             gTech: 'Технологический стек',
             gCost: 'Стоимость',
             yes: '<span class="yes">Да</span>',


### PR DESCRIPTION
The README didn't mention language support at all. Adds a **Multi-lingual** bullet to *Key features → Productivity & UX* covering:

- The nine shipped UI languages: English, Deutsch, Français, Español, Português, 简体中文, 한국어, 日本語, Русский.
- Browser auto-detection (regional locales like `es-MX` / `en-GB` map to the base language).
- The in-app language switcher, with the choice persisted per browser.
- Localised public landing + comparison pages.

Docs only.