### PR TITLE
Fix: language flags render on all platforms (bundled SVGs)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "@uiw/react-md-editor": "^4.1.0",
     "@xyflow/react": "^12.10.2",
     "chart.js": "^4.5.1",
+    "country-flag-icons": "^1.6.17",
     "html-to-image": "^1.11.13",
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/web/public/compare/index.html
+++ b/web/public/compare/index.html
@@ -151,15 +151,15 @@
       <nav class="topnav">
         <a href="/" data-i18n="nav">&larr; Nexum home</a>
         <select id="lang-select" class="lang-select" aria-label="Language / Sprache / Langue">
-          <option value="en">🇬🇧 English</option>
-          <option value="de">🇩🇪 Deutsch</option>
-          <option value="fr">🇫🇷 Français</option>
-          <option value="es">🇪🇸 Español</option>
-          <option value="pt">🇵🇹 Português</option>
-          <option value="zh">🇨🇳 简体中文</option>
-          <option value="ko">🇰🇷 한국어</option>
-          <option value="ja">🇯🇵 日本語</option>
-          <option value="ru">🇷🇺 Русский</option>
+          <option value="en">English</option>
+          <option value="de">Deutsch</option>
+          <option value="fr">Français</option>
+          <option value="es">Español</option>
+          <option value="pt">Português</option>
+          <option value="zh">简体中文</option>
+          <option value="ko">한국어</option>
+          <option value="ja">日本語</option>
+          <option value="ru">Русский</option>
         </select>
       </nav>
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3788,7 +3788,11 @@ select.sig-toolbar-btn option {
 /* Language picker (toolbar + landing hero). Matches the site's dark
    selects; native option rows forced dark so the dropdown panel isn't
    light on a dark page. */
-.toolbar__lang-select {
+.lang-switcher { position: relative; display: inline-flex; }
+.lang-switcher__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   background: #0a0e1a;
   border: 1px solid #1e2740;
   border-radius: 4px;
@@ -3799,18 +3803,54 @@ select.sig-toolbar-btn option {
   cursor: pointer;
   transition: border-color 0.15s ease;
 }
-.toolbar__lang-select:hover {
-  border-color: #4d9de0;
-}
-.toolbar__lang-select:focus-visible {
+.lang-switcher__trigger:hover { border-color: #4d9de0; }
+.lang-switcher__trigger:focus-visible {
   outline: none;
   border-color: #4d9de0;
   box-shadow: 0 0 0 2px rgba(77, 157, 224, 0.25);
 }
-.toolbar__lang-select option {
-  background: #0d1117;
-  color: #c8d0e0;
+.lang-switcher__flag {
+  width: 18px;
+  height: 12px;
+  flex-shrink: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
+.lang-switcher__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 1000;
+  min-width: 170px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: #0d1117;
+  border: 1px solid #1e2740;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.lang-switcher__option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: #c0ccde;
+  font-family: inherit;
+  font-size: calc(13px * var(--font-scale, 1));
+  text-align: left;
+  cursor: pointer;
+}
+.lang-switcher__option:hover { background: #162032; }
+.lang-switcher__option-name { flex: 1; white-space: nowrap; }
+.lang-switcher__option--active { color: #e8f0ff; }
 
 .sig-notes-cell {
   vertical-align: top;
@@ -5748,6 +5788,9 @@ select.sig-toolbar-btn option {
   max-width: 680px;
 }
 .landing__lang-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   padding: 7px 14px;
   background: rgba(91, 155, 255, 0.08);
   border: 1px solid rgba(91, 155, 255, 0.28);
@@ -5756,6 +5799,13 @@ select.sig-toolbar-btn option {
   font-size: calc(14px * var(--font-scale, 1));
   font-weight: 600;
   white-space: nowrap;
+}
+.landing__lang-flag {
+  width: 20px;
+  height: 13px;
+  flex-shrink: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
 }
 
 .landing__portrait {

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -13,6 +13,7 @@ import { apiUrl } from '../../api/client';
 import { SUPPORTED_LANGUAGES, LANGUAGE_NAMES } from '../../i18n';
 import { DemoMap } from './DemoMap';
 import { LanguageSwitcher } from './LanguageSwitcher';
+import { LangFlag } from './LangFlag';
 import portraitImg from '../../assets/portrait.jpeg';
 interface LastCharacter { characterId: number; characterName: string; }
 
@@ -409,7 +410,10 @@ export function LandingPage() {
           </p>
           <ul className="landing__lang-list">
             {SUPPORTED_LANGUAGES.map((lng) => (
-              <li key={lng} className="landing__lang-chip">{LANGUAGE_NAMES[lng]}</li>
+              <li key={lng} className="landing__lang-chip">
+                <LangFlag lang={lng} className="landing__lang-flag" />
+                {LANGUAGE_NAMES[lng]}
+              </li>
             ))}
           </ul>
         </section>

--- a/web/src/components/ui/LangFlag.tsx
+++ b/web/src/components/ui/LangFlag.tsx
@@ -1,0 +1,22 @@
+import type { SupportedLanguage } from '../../i18n';
+// Bundled SVG flags (no OS emoji font, no CDN) so flags render identically on
+// Windows/Linux too — country flag emoji are absent from the Windows emoji font.
+import GB from 'country-flag-icons/react/3x2/GB';
+import DE from 'country-flag-icons/react/3x2/DE';
+import FR from 'country-flag-icons/react/3x2/FR';
+import ES from 'country-flag-icons/react/3x2/ES';
+import PT from 'country-flag-icons/react/3x2/PT';
+import CN from 'country-flag-icons/react/3x2/CN';
+import KR from 'country-flag-icons/react/3x2/KR';
+import JP from 'country-flag-icons/react/3x2/JP';
+import RU from 'country-flag-icons/react/3x2/RU';
+
+// Map each UI language to the flag that best represents it.
+const FLAGS: Record<SupportedLanguage, typeof GB> = {
+  en: GB, de: DE, fr: FR, es: ES, pt: PT, zh: CN, ko: KR, ja: JP, ru: RU,
+};
+
+export function LangFlag({ lang, className }: { lang: SupportedLanguage; className?: string }) {
+  const Flag = FLAGS[lang];
+  return <Flag className={className} aria-hidden="true" />;
+}

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -1,21 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { CaretDownIcon, CheckIcon } from '@phosphor-icons/react';
 import { SUPPORTED_LANGUAGES, LANGUAGE_NAMES, type SupportedLanguage } from '../../i18n';
+import { LangFlag } from './LangFlag';
 
+// Custom dropdown (not a native <select>) because native <option>s can't render
+// the bundled SVG flags — only plain text. Mirrors the CharacterSwitcher menu.
 export function LanguageSwitcher() {
   const { t, i18n } = useTranslation();
   const current = (i18n.resolvedLanguage ?? 'en') as SupportedLanguage;
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const choose = (lng: SupportedLanguage) => {
+    void i18n.changeLanguage(lng);
+    setOpen(false);
+  };
 
   return (
-    <select
-      className="toolbar__lang-select"
-      value={current}
-      onChange={(e) => { void i18n.changeLanguage(e.target.value); }}
-      data-tooltip={t('language.label')}
-      aria-label={t('language.label')}
-    >
-      {SUPPORTED_LANGUAGES.map((lng) => (
-        <option key={lng} value={lng}>{LANGUAGE_NAMES[lng]}</option>
-      ))}
-    </select>
+    <div className="lang-switcher" ref={wrapRef}>
+      <button
+        type="button"
+        className="lang-switcher__trigger"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        data-tooltip={t('language.label')}
+        aria-label={t('language.label')}
+      >
+        <LangFlag lang={current} className="lang-switcher__flag" />
+        <span className="lang-switcher__current">{LANGUAGE_NAMES[current]}</span>
+        <CaretDownIcon size={12} weight="bold" />
+      </button>
+      {open && (
+        <div className="lang-switcher__menu" role="listbox" aria-label={t('language.label')}>
+          {SUPPORTED_LANGUAGES.map((lng) => (
+            <button
+              key={lng}
+              type="button"
+              role="option"
+              aria-selected={lng === current}
+              className={`lang-switcher__option${lng === current ? ' lang-switcher__option--active' : ''}`}
+              onClick={() => choose(lng)}
+            >
+              <LangFlag lang={lng} className="lang-switcher__flag" />
+              <span className="lang-switcher__option-name">{LANGUAGE_NAMES[lng]}</span>
+              {lng === current && <CheckIcon size={13} weight="bold" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -22,16 +22,18 @@ export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 // in every locale (English is always "English", Deutsch always "Deutsch") so
 // they are NOT translated. English uses the GB flag (the app's English is
 // en-GB). Used by the LanguageSwitcher and the landing-page language section.
+// Native language names. Flags are rendered separately as bundled SVGs (see
+// LangFlag) rather than emoji, since Windows has no country-flag glyphs.
 export const LANGUAGE_NAMES: Record<SupportedLanguage, string> = {
-  en: '🇬🇧 English',
-  de: '🇩🇪 Deutsch',
-  fr: '🇫🇷 Français',
-  es: '🇪🇸 Español',
-  pt: '🇵🇹 Português',
-  zh: '🇨🇳 简体中文',
-  ko: '🇰🇷 한국어',
-  ja: '🇯🇵 日本語',
-  ru: '🇷🇺 Русский',
+  en: 'English',
+  de: 'Deutsch',
+  fr: 'Français',
+  es: 'Español',
+  pt: 'Português',
+  zh: '简体中文',
+  ko: '한국어',
+  ja: '日本語',
+  ru: 'Русский',
 };
 
 // One namespace ('common') for now. Split into feature namespaces

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -847,6 +847,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+country-flag-icons@^1.6.17:
+  version "1.6.17"
+  resolved "https://registry.yarnpkg.com/country-flag-icons/-/country-flag-icons-1.6.17.tgz#875cf35eb2a0d7fcb0f07166fed9fc65863e03f8"
+  integrity sha512-Nmik0289ZVZSI3c7mJR/amg6DyY7Z59b0sTFSKayeX72mHfPzCPJygwJs2pYgQULzuAyWeCUgwAJ+Dq8OR+JFw==
+
 cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"


### PR DESCRIPTION
Promotes the language-flag fix (#115) to `main`.

## What
Language flags were Unicode country-flag emoji, which **Windows doesn't render** (its emoji font ships no flag glyphs) — so flags vanished on Windows/some Linux while working on macOS. Replaced with **bundled SVG flags** (`country-flag-icons`, no CDN):

- New `LangFlag` component; emoji removed from `LANGUAGE_NAMES`.
- Toolbar `LanguageSwitcher` is now a small custom dropdown (native `<select>` can't hold SVGs).
- Landing-page language chips show SVG flags.
- Static comparison page `<select>` uses clean text (emoji removed).

Renders identically on Windows, Linux, and macOS. 8 files, +164 / −37.