### PR TITLE
SDE: version endpoint, auto-update hardening, and zip cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,22 @@ Each tab is also reachable at its own hash route (`#/admin/maps`, `#/admin/audit
 
 Some pre-computed lookups live in `server/data/` as plain JSON, derived once from the EVE Static Data Export (SDE). They're committed to the repo so a fresh install works without an extra step. You only need to regenerate them when CCP releases an SDE drop that adds or changes the underlying data.
 
+**Checking the SDE build** — `GET /api/sde/version` (public, browser-callable) reports the SDE build this instance is running against the latest CCP offers:
+
+```jsonc
+// GET /api/sde/version
+{
+  "installed":   "3365090",                 // build imported into this DB (null if never seeded)
+  "installedAt": "2026-05-29T11:29:00.000Z", // when that build was imported
+  "latest":      "3368760",                 // latest build CCP currently offers (null if unreachable)
+  "latestCheckedAt": "2026-06-02T11:30:00.000Z",
+  "upToDate":    false,                      // true | false | null (unknown)
+  "autoUpdate":  true                        // daily auto-update enabled?
+}
+```
+
+The remote `latest` lookup is a single cached HEAD to CCP (hourly), so the endpoint is cheap to poll. The daily auto-update keeps `installed` current on its own; this endpoint just lets you see where things stand.
+
 > **A0 sun systems** (`typeID 3801`, "Sun A0 (Blue Small)") used to live here as `data/a0-systems.json`. They're now flagged on `solar_systems.is_a0` directly by the SDE importer (from `mapStars.jsonl`) and served via `GET /api/systems/a0`, so they refresh automatically on every SDE re-seed — no committed file, no manual regen. Note this is the in-game A0 classification (`typeID 3801`), not the SDE's `statistics.spectralClass` field; the two don't agree.
 
 ### `data/wormholes.json`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   - [Docker (recommended)](#option-1--docker-recommended)
   - [Local development](#option-2--local-development)
   - [EVE developer app scopes](#eve-developer-app-scopes)
+  - [Updating the SDE](#updating-the-sde)
   - [Refreshing wormhole types](#refreshing-wormhole-types)
   - [Upgrading an existing deployment](#upgrading-an-existing-deployment)
 - [Corp mode](#corp-mode)
@@ -232,7 +233,7 @@ docker compose up -d
 
 The app will be available on port `${WEB_PORT:-80}` (defaults to `80`).
 
-The import is self-skipping: on every later `up` or restart the importer sees the static tables are already populated and exits in a second without re-downloading. So the two commands above are also your update flow. To force a re-import (e.g. after a CCP SDE drop), see [Updating the SDE](#installation) below.
+The import is self-skipping: on every later `up` or restart the importer sees the static tables are already populated and exits in a second without re-downloading. So the two commands above are also your update flow. To force a re-import (e.g. after a CCP SDE drop), see [Updating the SDE](#updating-the-sde) below.
 
 The importer also stores each system's universe coordinates and CCP's 2D star-map projection (`position` / `position2D`), which power the [Seed a map from a region](#features) feature.
 
@@ -252,9 +253,11 @@ Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-comp
 
 App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automatically the first time the server boots — no manual step.
 
-**4. Updating the SDE (after a CCP data drop)**
+#### Updating the SDE
 
-This is automatic — you don't normally do anything. The server checks once a day (default **11:30 UTC**, just after the 11:00 downtime when CCP publishes the new export) whether a newer SDE build exists. The check is cheap: a single `HEAD` request reads the build number from CCP's "latest" redirect (`…/eve-online-static-data-<build>-jsonl.zip`) and compares it to the build recorded in the `sde_meta` table. If — and only if — the build changed, the server downloads the new export, re-seeds the static tables, and reloads its in-memory route graph in place. No new build, no download; a re-seed needs no restart.
+The static data (systems, stargates, item types, dogma — everything CCP ships in the Static Data Export) is imported into Postgres at first boot and kept current from there. Here's how it stays up to date, how to force it, and how to check which build you're on.
+
+**Automatic (the default — you normally do nothing).** The server checks once a day (default **11:30 UTC**, just after the 11:00 downtime when CCP publishes the new export) whether a newer SDE build exists. The check is cheap: a single `HEAD` request reads the build number from CCP's "latest" redirect (`…/eve-online-static-data-<build>-jsonl.zip`) and compares it to the build recorded in the `sde_meta` table. If — and only if — the build changed, the server downloads the new export, re-seeds the static tables, and reloads its in-memory route graph in place. No new build, no download; a re-seed needs no restart.
 
 The re-seed is upsert-only (`ON CONFLICT DO UPDATE` on every table), so it's safe — your user data (maps, signatures, structures, sessions, etc.) lives in other tables and is never touched.
 
@@ -265,11 +268,33 @@ Tune it via `.env`:
 | `SDE_AUTO_UPDATE` | `1` (on) | Set to `0` to disable the daily check entirely. |
 | `SDE_CHECK_UTC` | `11:30` | Time of day (HH:MM, UTC) to run the check. |
 
-To force a re-import immediately (e.g. to test, or if you disabled the daily check), run the importer with `FORCE_SDE_IMPORT=1`:
+**Forcing an update now** (e.g. to test, right after a known CCP drop, or if you disabled the daily check). Run the importer with `FORCE_SDE_IMPORT=1` — it downloads the latest export and re-seeds regardless of the recorded build:
 
 ```bash
+# Docker
 docker compose run --rm -e FORCE_SDE_IMPORT=1 importer
 ```
+
+```bash
+# Local development (Postgres on localhost)
+cd server && FORCE_SDE_IMPORT=1 yarn setup-db
+```
+
+**Checking which build you're on.** `GET /api/sde/version` is public and browser-callable — it reports the build this instance is running against the latest CCP currently offers, so you can confirm an update landed (or see that one is pending):
+
+```jsonc
+// GET /api/sde/version
+{
+  "installed":   "3365090",                  // build imported into this DB (null if never seeded)
+  "installedAt": "2026-05-29T11:29:00.000Z", // when that build was imported
+  "latest":      "3368760",                  // latest build CCP offers (null if CCP unreachable)
+  "latestCheckedAt": "2026-06-02T11:30:00.000Z",
+  "upToDate":    false,                       // true | false | null (unknown)
+  "autoUpdate":  true                         // is the daily auto-update enabled?
+}
+```
+
+`installed` vs `latest` are directly comparable — both are CCP build numbers from the same source the importer uses. `upToDate` is `null` ("unknown") rather than a misleading `false` when either build can't be determined (CCP unreachable, or a never-seeded DB). The remote `latest` lookup is a single cached `HEAD` to CCP (1 h on success, 5 min after a failure), so the endpoint is cheap to poll.
 
 #### Refreshing wormhole types
 
@@ -497,21 +522,7 @@ Each tab is also reachable at its own hash route (`#/admin/maps`, `#/admin/audit
 
 Some pre-computed lookups live in `server/data/` as plain JSON, derived once from the EVE Static Data Export (SDE). They're committed to the repo so a fresh install works without an extra step. You only need to regenerate them when CCP releases an SDE drop that adds or changes the underlying data.
 
-**Checking the SDE build** — `GET /api/sde/version` (public, browser-callable) reports the SDE build this instance is running against the latest CCP offers:
-
-```jsonc
-// GET /api/sde/version
-{
-  "installed":   "3365090",                 // build imported into this DB (null if never seeded)
-  "installedAt": "2026-05-29T11:29:00.000Z", // when that build was imported
-  "latest":      "3368760",                 // latest build CCP currently offers (null if unreachable)
-  "latestCheckedAt": "2026-06-02T11:30:00.000Z",
-  "upToDate":    false,                      // true | false | null (unknown)
-  "autoUpdate":  true                        // daily auto-update enabled?
-}
-```
-
-The remote `latest` lookup is a single cached HEAD to CCP (hourly), so the endpoint is cheap to poll. The daily auto-update keeps `installed` current on its own; this endpoint just lets you see where things stand.
+The SDE tables themselves (systems, stargates, dogma, …) are imported into Postgres separately and kept current automatically — see [Updating the SDE](#updating-the-sde) for how that works, how to force it, and the `GET /api/sde/version` endpoint for checking which build you're on.
 
 > **A0 sun systems** (`typeID 3801`, "Sun A0 (Blue Small)") used to live here as `data/a0-systems.json`. They're now flagged on `solar_systems.is_a0` directly by the SDE importer (from `mapStars.jsonl`) and served via `GET /api/systems/a0`, so they refresh automatically on every SDE re-seed — no committed file, no manual regen. Note this is the in-game A0 classification (`typeID 3801`), not the SDE's `statistics.spectralClass` field; the two don't agree.
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automat
 
 The static data (systems, stargates, item types, dogma — everything CCP ships in the Static Data Export) is imported into Postgres at first boot and kept current from there. Here's how it stays up to date, how to force it, and how to check which build you're on.
 
-**Automatic (the default — you normally do nothing).** The server checks once a day (default **11:30 UTC**, just after the 11:00 downtime when CCP publishes the new export) whether a newer SDE build exists. The check is cheap: a single `HEAD` request reads the build number from CCP's "latest" redirect (`…/eve-online-static-data-<build>-jsonl.zip`) and compares it to the build recorded in the `sde_meta` table. If — and only if — the build changed, the server downloads the new export, re-seeds the static tables, and reloads its in-memory route graph in place. No new build, no download; a re-seed needs no restart.
+**Automatic (the default — you normally do nothing).** The server checks once a day (default **11:30 UTC**, just after the 11:00 downtime when CCP publishes the new export) — plus a catch-up a few minutes after every restart, so a deploy that missed the daily slot, or a build CCP publishes off-cycle, doesn't leave you stale for ~24h. The check is cheap: a single `HEAD` request reads the build number from CCP's "latest" redirect (`…/eve-online-static-data-<build>-jsonl.zip`) and compares it to the build recorded in the `sde_meta` table. If — and only if — the build changed, the server downloads the new export, re-seeds the static tables, reloads its in-memory route graph in place, then **deletes the downloaded zip** so it doesn't sit on disk. No new build, no download; a re-seed needs no restart.
 
 The re-seed is upsert-only (`ON CONFLICT DO UPDATE` on every table), so it's safe — your user data (maps, signatures, structures, sessions, etc.) lives in other tables and is never touched.
 
@@ -288,13 +288,16 @@ cd server && FORCE_SDE_IMPORT=1 yarn setup-db
   "installed":   "3365090",                  // build imported into this DB (null if never seeded)
   "installedAt": "2026-05-29T11:29:00.000Z", // when that build was imported
   "latest":      "3368760",                  // latest build CCP offers (null if CCP unreachable)
-  "latestCheckedAt": "2026-06-02T11:30:00.000Z",
+  "latestCheckedAt": "2026-06-02T11:30:00.000Z", // when THIS endpoint last queried CCP (cached)
   "upToDate":    false,                       // true | false | null (unknown)
-  "autoUpdate":  true                         // is the daily auto-update enabled?
+  "autoUpdate":  true,                        // is the daily auto-update enabled?
+  "autoCheck": { "at": "2026-06-02T11:30:12.000Z", "result": "updated" } // last auto-update run (null until one fires)
 }
 ```
 
-`installed` vs `latest` are directly comparable — both are CCP build numbers from the same source the importer uses. `upToDate` is `null` ("unknown") rather than a misleading `false` when either build can't be determined (CCP unreachable, or a never-seeded DB). The remote `latest` lookup is a single cached `HEAD` to CCP (1 h on success, 5 min after a failure), so the endpoint is cheap to poll.
+`installed` vs `latest` are directly comparable — both are CCP build numbers from the same source the importer uses. `upToDate` is `null` ("unknown") rather than a misleading `false` when either build can't be determined (CCP unreachable, or a never-seeded DB).
+
+Two timestamps that are easy to confuse: **`latestCheckedAt`** is when *this endpoint* last asked CCP for the latest build (cached — a single `HEAD`, 1 h on success / 5 min after a failure, so the endpoint is cheap to poll). **`autoCheck`** is when the *auto-updater* itself last ran and what it did (`updated` / `unchanged` / `error` / `skipped`) — that's the field to watch to confirm the daily check is actually firing. It's `null` until the first check runs in the current process. For the full picture, the server also logs each run under the `sde-update` tag (`docker compose logs server | grep sde-update`).
 
 #### Refreshing wormhole types
 

--- a/server/scripts/setup-db.ts
+++ b/server/scripts/setup-db.ts
@@ -17,7 +17,7 @@
 
 import 'dotenv/config';
 import { createWriteStream, existsSync, readdirSync, readFileSync } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Readable, Transform } from 'node:stream';
@@ -110,6 +110,16 @@ async function main() {
   await seedRegionNpcTypes();
 
   if (importedVer) await setStoredSdeVersion(importedVer);
+
+  // Reclaim disk: drop the downloaded zip now that it's imported. The re-import
+  // path always re-downloads a fresh copy, so the cached zip is never reused
+  // between runs — keeping it just wastes ~80 MB. Only the runtime download is
+  // removed; the versioned zip baked into the image under data/ is left alone.
+  if (resolved.path === SDE_ZIP) {
+    await rm(SDE_ZIP, { force: true }).catch((err) => {
+      console.warn(`Could not remove cached SDE zip: ${(err as Error).message}`);
+    });
+  }
 
   await db.end();
   console.log(`\nSetup complete${importedVer ? ` (SDE build ${importedVer})` : ''}.`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,6 +9,7 @@ import { db } from './db.js';
 import { config } from './config.js';
 import { migrate } from './migrate.js';
 import { systemsRouter } from './routes/systems.js';
+import { sdeRouter } from './routes/sde.js';
 import { regionsRouter } from './routes/regions.js';
 import { authRouter } from './routes/auth.js';
 import { mapsRouter } from './routes/maps.js';
@@ -92,6 +93,7 @@ app.use(originGuard(process.env.FRONTEND_URL ?? 'http://localhost:5174'));
 app.use(['/auth/login', '/auth/callback', '/auth/add-character'], authLimiter);
 app.use('/auth', appLimiter, authRouter);
 app.use('/api/systems', publicLimiter, systemsRouter);
+app.use('/api/sde', publicLimiter, sdeRouter);
 app.use('/api/regions', appLimiter, regionsRouter);
 app.use('/api/maps', appLimiter, mapsRouter);
 // Public read-only share endpoint — no auth, validates the share_token

--- a/server/src/routes/sde.ts
+++ b/server/src/routes/sde.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { config } from '../config.js';
+import { getInstalledSde, fetchLatestSdeBuild } from '../services/sdeUpdate.js';
+
+// Public, browser-callable: report the EVE Static Data Export (SDE) build this
+// instance is running vs. the latest CCP currently offers. No auth — the SDE
+// version isn't sensitive — and the remote check is cached in the service so
+// this can't be used to hammer CCP.
+const router = Router();
+
+// GET /api/sde/version
+router.get('/version', async (_req, res) => {
+  const [installed, latest] = await Promise.all([getInstalledSde(), fetchLatestSdeBuild()]);
+
+  // upToDate is null ("unknown") when we couldn't determine either build —
+  // e.g. CCP unreachable, or a never-seeded DB — rather than a misleading false.
+  const upToDate = installed.version != null && latest.build != null
+    ? installed.version === latest.build
+    : null;
+
+  res.json({
+    installed:   installed.version,             // build running now, e.g. "3365090" (null if never seeded)
+    installedAt: installed.updatedAt,           // when that build was imported (ISO)
+    latest:      latest.build,                  // latest build CCP offers (null if unreachable)
+    latestCheckedAt: new Date(latest.at).toISOString(),
+    upToDate,                                   // true | false | null (unknown)
+    autoUpdate:  config.sdeAutoUpdate,          // whether the daily auto-update is on
+  });
+});
+
+export const sdeRouter = router;

--- a/server/src/routes/sde.ts
+++ b/server/src/routes/sde.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { config } from '../config.js';
-import { getInstalledSde, fetchLatestSdeBuild } from '../services/sdeUpdate.js';
+import { getInstalledSde, fetchLatestSdeBuild, getLastSdeCheck } from '../services/sdeUpdate.js';
 
 // Public, browser-callable: report the EVE Static Data Export (SDE) build this
 // instance is running vs. the latest CCP currently offers. No auth — the SDE
@@ -11,6 +11,7 @@ const router = Router();
 // GET /api/sde/version
 router.get('/version', async (_req, res) => {
   const [installed, latest] = await Promise.all([getInstalledSde(), fetchLatestSdeBuild()]);
+  const lastCheck = getLastSdeCheck();
 
   // upToDate is null ("unknown") when we couldn't determine either build —
   // e.g. CCP unreachable, or a never-seeded DB — rather than a misleading false.
@@ -22,9 +23,14 @@ router.get('/version', async (_req, res) => {
     installed:   installed.version,             // build running now, e.g. "3365090" (null if never seeded)
     installedAt: installed.updatedAt,           // when that build was imported (ISO)
     latest:      latest.build,                  // latest build CCP offers (null if unreachable)
-    latestCheckedAt: new Date(latest.at).toISOString(),
+    latestCheckedAt: new Date(latest.at).toISOString(), // when THIS endpoint last queried CCP (cached)
     upToDate,                                   // true | false | null (unknown)
     autoUpdate:  config.sdeAutoUpdate,          // whether the daily auto-update is on
+    // When the auto-updater itself last ran, and its outcome — distinct from
+    // latestCheckedAt above. null until the first check fires this process.
+    autoCheck: lastCheck
+      ? { at: new Date(lastCheck.at).toISOString(), result: lastCheck.result }
+      : null,
   });
 });
 

--- a/server/src/services/sdeUpdate.ts
+++ b/server/src/services/sdeUpdate.ts
@@ -13,6 +13,9 @@ const log = createLogger('sde-update');
 // We check once a day a little later (default 11:30 UTC, override via
 // SDE_CHECK_UTC) so the export is up by the time we look.
 const DAY_MS = 24 * 60 * 60 * 1000;
+// Delay before the post-boot catch-up check, so it doesn't compete with the
+// rest of startup (route graph, standings, etc.).
+const BOOT_CHECK_DELAY_MS = 3 * 60 * 1000;
 
 // CCP's "latest" SDE URL 302-redirects to a versioned filename embedding the
 // build number, e.g. `…/eve-online-static-data-3365090-jsonl.zip`. Same URL the
@@ -86,16 +89,37 @@ export async function fetchLatestSdeBuild(): Promise<{ build: string | null; at:
 // own pg pool — its `db.end()` at finish won't touch the server's pool — and
 // isolates the import's memory from the long-lived server. The importer does
 // its own HEAD/build-number check, so on a no-change day this is a cheap no-op.
+// Hard cap on a single import. A stalled download (no socket timeout) would
+// otherwise leave the child running forever, so runImporter would never resolve
+// and the `running` guard would stay stuck — wedging every future check. Kill
+// it past this and treat as a failed run.
+const IMPORT_TIMEOUT_MS = 30 * 60 * 1000;
+
 function runImporter(): Promise<number> {
   return new Promise((resolve) => {
     const script = join(process.cwd(), 'dist/scripts/setup-db.js');
     const child = spawn(process.execPath, [script], { stdio: 'inherit', env: process.env });
-    child.on('exit', (code) => resolve(code ?? 1));
+    const timer = setTimeout(() => {
+      log.error(`importer exceeded ${IMPORT_TIMEOUT_MS / 60000} min; killing it`);
+      child.kill('SIGKILL');
+    }, IMPORT_TIMEOUT_MS);
+    child.on('exit', (code) => { clearTimeout(timer); resolve(code ?? 1); });
     child.on('error', (err) => {
+      clearTimeout(timer);
       log.error(`importer failed to start: ${err.message}`);
       resolve(1);
     });
   });
+}
+
+// Outcome of the most recent auto-update check, surfaced via getLastSdeCheck()
+// so /api/sde/version can show whether the updater is actually firing — the
+// thing you can't tell from installed/latest alone.
+export type SdeCheckResult = 'updated' | 'unchanged' | 'error' | 'skipped';
+let lastCheck: { at: number; result: SdeCheckResult } | null = null;
+
+export function getLastSdeCheck(): { at: number; result: SdeCheckResult } | null {
+  return lastCheck;
 }
 
 /**
@@ -105,12 +129,14 @@ function runImporter(): Promise<number> {
 export async function checkSde(): Promise<void> {
   if (running) {
     log.warn('previous SDE check still running; skipping this tick');
+    lastCheck = { at: Date.now(), result: 'skipped' };
     return;
   }
   running = true;
+  let result: SdeCheckResult = 'error';
   try {
     const before = await storedVersion();
-    log.info(`daily SDE check (current build ${before ?? 'unknown'})`);
+    log.info(`SDE check (current build ${before ?? 'unknown'})`);
     const code = await runImporter();
     if (code !== 0) {
       log.error(`importer exited with code ${code}`);
@@ -122,12 +148,15 @@ export async function checkSde(): Promise<void> {
       await loadRouteGraph();
       resetA0Cache();
       resetWormholeCache();
+      result = 'updated';
     } else {
       log.info('SDE unchanged');
+      result = 'unchanged';
     }
   } catch (err) {
     log.error(`SDE check failed: ${(err as Error).message}`);
   } finally {
+    lastCheck = { at: Date.now(), result };
     running = false;
   }
 }
@@ -156,7 +185,13 @@ export function startSdeAutoUpdate(): void {
   const minute = parseInt(mm, 10);
   const delay  = msUntilNextUtc(hour, minute);
 
-  log.info(`auto-update on; first check in ${Math.round(delay / 60000)} min, then daily at ${config.sdeCheckUtc} UTC`);
+  // Catch-up a few minutes after boot. Without this the first check is the next
+  // daily slot, so a restart after the slot (or a build CCP publishes off the
+  // 11:00-downtime cadence) leaves us stale for up to ~24h. The check is a cheap
+  // HEAD + early-return when nothing changed, so running it on every boot is fine.
+  setTimeout(() => { void checkSde(); }, BOOT_CHECK_DELAY_MS);
+
+  log.info(`auto-update on; catch-up in ${Math.round(BOOT_CHECK_DELAY_MS / 60000)} min, then daily at ${config.sdeCheckUtc} UTC`);
   setTimeout(() => {
     void checkSde();
     setInterval(() => { void checkSde(); }, DAY_MS);

--- a/server/src/services/sdeUpdate.ts
+++ b/server/src/services/sdeUpdate.ts
@@ -14,17 +14,71 @@ const log = createLogger('sde-update');
 // SDE_CHECK_UTC) so the export is up by the time we look.
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// CCP's "latest" SDE URL 302-redirects to a versioned filename embedding the
+// build number, e.g. `…/eve-online-static-data-3365090-jsonl.zip`. Same URL the
+// importer uses; kept here so the server can report the available build too.
+const SDE_URL = 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip';
+
 let running = false;
 
+// Pull the CCP build number out of an SDE filename/URL → "3365090".
+function parseBuild(s: string): string | null {
+  return s.match(/static-data-(\d+)-jsonl/)?.[1] ?? null;
+}
+
 async function storedVersion(): Promise<string | null> {
+  return (await getInstalledSde()).version;
+}
+
+/**
+ * The SDE build currently imported into this DB, plus when it was recorded.
+ * Returns nulls on a never-seeded DB (table may not exist yet).
+ */
+export async function getInstalledSde(): Promise<{ version: string | null; updatedAt: string | null }> {
   try {
-    const { rows } = await db.query<{ value: string }>(
-      `SELECT value FROM sde_meta WHERE key = 'sde_version'`,
+    const { rows } = await db.query<{ value: string; updated_at: string }>(
+      `SELECT value, updated_at FROM sde_meta WHERE key = 'sde_version'`,
     );
-    return rows[0]?.value ?? null;
+    return { version: rows[0]?.value ?? null, updatedAt: rows[0]?.updated_at ?? null };
   } catch {
-    return null; // table may not exist yet on a never-seeded DB
+    return { version: null, updatedAt: null };
   }
+}
+
+// Cache the remote-build lookup so a burst of callers makes at most one HEAD to
+// CCP. Successes are good for an hour (the SDE changes ~daily); failures retry
+// after 5 min so a brief CCP outage doesn't pin "unknown" for an hour.
+const LATEST_TTL_OK_MS  = 60 * 60 * 1000;
+const LATEST_TTL_ERR_MS = 5 * 60 * 1000;
+let latestCache: { build: string | null; at: number } | null = null;
+
+async function fetchRemoteBuild(): Promise<string | null> {
+  try {
+    const res = await fetch(SDE_URL, { method: 'HEAD', redirect: 'manual' });
+    const build = parseBuild(res.headers.get('location') ?? '');
+    if (build) return build;
+    // URL shape changed — fall back to a stable content identifier.
+    const head = await fetch(SDE_URL, { method: 'HEAD' });
+    return head.headers.get('etag') ?? head.headers.get('last-modified');
+  } catch (err) {
+    log.warn(`could not determine latest SDE build: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * The latest SDE build CCP currently offers, without downloading it. Cached;
+ * `at` is when the value was actually fetched. `build` is null if CCP was
+ * unreachable.
+ */
+export async function fetchLatestSdeBuild(): Promise<{ build: string | null; at: number }> {
+  const now = Date.now();
+  if (latestCache) {
+    const ttl = latestCache.build ? LATEST_TTL_OK_MS : LATEST_TTL_ERR_MS;
+    if (now - latestCache.at < ttl) return latestCache;
+  }
+  latestCache = { build: await fetchRemoteBuild(), at: now };
+  return latestCache;
 }
 
 // Run the compiled importer as a child process. It lives in the same image, so


### PR DESCRIPTION
Adds a public, browser-callable endpoint to check which EVE Static Data Export (SDE) build this instance is running vs. what CCP currently offers.

## `GET /api/sde/version`
```jsonc
{
  "installed":   "3365090",                  // build imported into this DB (null if never seeded)
  "installedAt": "2026-05-29T11:29:00.000Z", // when that build was imported
  "latest":      "3368760",                  // latest build CCP offers (null if unreachable)
  "latestCheckedAt": "2026-06-02T11:30:00.000Z",
  "upToDate":    false,                       // true | false | null (unknown)
  "autoUpdate":  true                         // daily auto-update enabled?
}
```

## How it works
- **Installed** comes from `sde_meta.sde_version` (+ `updated_at`), the build the importer recorded.
- **Latest** is a single HEAD to CCP's `…/eve-online-static-data-latest-jsonl.zip`, whose 302 redirect embeds the build number (e.g. `…-3368760-jsonl.zip`) — the same source the importer uses. Verified the redirect still resolves correctly.
- **`upToDate`** is `null` (unknown), not a misleading `false`, when either build can't be determined (CCP unreachable / never-seeded DB).

## Safety
- No auth (the SDE version isn't sensitive) and mounted under `publicLimiter`.
- The remote lookup is **cached in the service** — 1h on success, 5m on failure — so a burst of callers makes at most one HEAD to CCP. Cheap to poll.

Server builds clean; documented in the README's *Static data files* section.