### PR TITLE
ESI: shared client with User-Agent + error-limit backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ These features only matter once `CORP_ID` is set — see [Corp mode](#corp-mode)
 **1. Clone and configure**
 
 ```bash
-git clone https://codeberg.org/GQuantrill/eve-nexum.git
+git clone https://github.com/GQuantrill/eve-nexum.git
 cd eve-nexum
 cp .env.example .env
 ```
@@ -306,7 +306,7 @@ Pulling a new Nexum release into a running instance:
 **1. Clone and configure**
 
 ```bash
-git clone https://codeberg.org/GQuantrill/eve-nexum.git
+git clone https://github.com/GQuantrill/eve-nexum.git
 cd eve-nexum
 cp .env.example .env
 ```

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { esiFetch } from '../utils/esi.js';
 import { db } from '../db.js';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 
@@ -51,8 +52,8 @@ async function fetchEsi(): Promise<EsiSnapshot | null> {
   fetching = (async () => {
     try {
       const [jRes, kRes] = await Promise.all([
-        fetch(`${ESI}/universe/system_jumps/?datasource=tranquility`),
-        fetch(`${ESI}/universe/system_kills/?datasource=tranquility`),
+        esiFetch(`${ESI}/universe/system_jumps/?datasource=tranquility`),
+        esiFetch(`${ESI}/universe/system_kills/?datasource=tranquility`),
       ]);
       if (!jRes.ok || !kRes.ok) return esiCache;
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { esiFetch } from '../utils/esi.js';
 import { db } from '../db.js';
 import { requireAdmin } from '../middleware/requireAdmin.js';
 import { requireAdminRead } from '../middleware/requireAdminRead.js';
@@ -43,7 +44,7 @@ async function resolveCorps(ids: number[]): Promise<Map<number, CorpInfo | null>
 
   await Promise.all(todo.map(async (id) => {
     try {
-      const r = await fetch(`https://esi.evetech.net/v5/corporations/${id}/`);
+      const r = await esiFetch(`https://esi.evetech.net/v5/corporations/${id}/`);
       if (!r.ok) {
         corpCache.set(id, { value: null, at: now });
         out.set(id, null);
@@ -81,7 +82,7 @@ async function resolveAlliances(ids: number[]): Promise<Map<number, CorpInfo | n
 
   await Promise.all(todo.map(async (id) => {
     try {
-      const r = await fetch(`https://esi.evetech.net/v3/alliances/${id}/`);
+      const r = await esiFetch(`https://esi.evetech.net/v3/alliances/${id}/`);
       if (!r.ok) {
         allianceCache.set(id, { value: null, at: now });
         out.set(id, null);
@@ -297,7 +298,7 @@ adminRouter.post('/users/:id/recheck-corp', async (req, res) => {
 
   let liveCorpId: number | null = null;
   try {
-    const r = await fetch(`https://esi.evetech.net/v4/characters/${target.character_id}/`);
+    const r = await esiFetch(`https://esi.evetech.net/v4/characters/${target.character_id}/`);
     if (!r.ok) {
       res.status(502).json({ error: `ESI returned ${r.status}` });
       return;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -4,6 +4,7 @@ import { db } from '../db.js';
 import { config } from '../config.js';
 import { encryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
+import { esiFetch } from '../utils/esi.js';
 import { refreshStandingsForUser } from '../services/standings.js';
 import { seedDemoMap } from '../services/demoMap.js';
 
@@ -160,7 +161,7 @@ authRouter.get('/callback', async (req, res) => {
     let userCorpId: number | null = null;
     let userAllianceId: number | null = null;
     try {
-      const esiChar = await fetch(`https://esi.evetech.net/v4/characters/${characterId}/`);
+      const esiChar = await esiFetch(`https://esi.evetech.net/v4/characters/${characterId}/`);
       if (!esiChar.ok) {
         if (config.corpMode) {
           res.redirect(failUrl('corp_check_failed'));

--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { esiFetch } from '../utils/esi.js';
 import { db } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { getValidToken } from '../utils/eveToken.js';
@@ -56,7 +57,7 @@ async function getLocationPayload(userId: number): Promise<LocationPayload> {
   const token       = await getValidToken(userId);
   const characterId = userRows[0].character_id;
 
-  const onlineRes = await fetch(
+  const onlineRes = await esiFetch(
     `https://esi.evetech.net/latest/characters/${characterId}/online/`,
     { headers: { Authorization: `Bearer ${token}` } },
   );
@@ -65,9 +66,9 @@ async function getLocationPayload(userId: number): Promise<LocationPayload> {
   if (!isReallyOnline(onlineData)) { lastSeenSystem.delete(userId); return { online: false }; }
 
   const [locRes, shipRes] = await Promise.all([
-    fetch(`https://esi.evetech.net/latest/characters/${characterId}/location/`,
+    esiFetch(`https://esi.evetech.net/latest/characters/${characterId}/location/`,
       { headers: { Authorization: `Bearer ${token}` } }),
-    fetch(`https://esi.evetech.net/latest/characters/${characterId}/ship/`,
+    esiFetch(`https://esi.evetech.net/latest/characters/${characterId}/ship/`,
       { headers: { Authorization: `Bearer ${token}` } }),
   ]);
   if (!locRes.ok) return { online: true, system: null, ship: null };
@@ -149,11 +150,11 @@ characterRouter.get('/:targetUserId/location', async (req, res) => {
 // Refreshes last_known as a free side effect. Throws on a dead token.
 async function readCharacterSystem(userId: number, characterId: number): Promise<{ online: boolean; eveSystemId: number; name: string; systemClass: string | null } | null> {
   const token = await getValidToken(userId);
-  const onlineRes = await fetch(`https://esi.evetech.net/latest/characters/${characterId}/online/`,
+  const onlineRes = await esiFetch(`https://esi.evetech.net/latest/characters/${characterId}/online/`,
     { headers: { Authorization: `Bearer ${token}` } });
   if (!onlineRes.ok) return null;
   if (!isReallyOnline(await onlineRes.json() as EsiOnlineResponse)) return null;
-  const locRes = await fetch(`https://esi.evetech.net/latest/characters/${characterId}/location/`,
+  const locRes = await esiFetch(`https://esi.evetech.net/latest/characters/${characterId}/location/`,
     { headers: { Authorization: `Bearer ${token}` } });
   if (!locRes.ok) return null;
   const { solar_system_id } = await locRes.json() as { solar_system_id: number };
@@ -220,7 +221,7 @@ characterRouter.post('/waypoint', async (req, res) => {
       clear_other_waypoints: String(clearOtherWaypoints),
       destination_id:       String(destNum),
     });
-    const esiRes = await fetch(
+    const esiRes = await esiFetch(
       `https://esi.evetech.net/latest/ui/autopilot/waypoint/?${params}`,
       { method: 'POST', headers: { Authorization: `Bearer ${token}` } },
     );
@@ -244,7 +245,7 @@ characterRouter.get('/online', async (req, res) => {
     const token = await getValidToken(req.session.userId!);
     const characterId = rows[0].character_id;
 
-    const esiRes = await fetch(
+    const esiRes = await esiFetch(
       `https://esi.evetech.net/latest/characters/${characterId}/online/`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
@@ -326,7 +327,7 @@ characterRouter.get('/fleet', async (req, res) => {
 
     // 1) Which fleet (if any) is this character in? ESI returns 404 when
     //    the character isn't in a fleet — that's expected, not an error.
-    const fleetRes = await fetch(
+    const fleetRes = await esiFetch(
       `https://esi.evetech.net/latest/characters/${characterId}/fleet/`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
@@ -356,7 +357,7 @@ characterRouter.get('/fleet', async (req, res) => {
     if (isFresh && entry) {
       members = entry.value;
     } else if (isBoss) {
-      const memRes = await fetch(
+      const memRes = await esiFetch(
         `https://esi.evetech.net/latest/fleets/${fleetInfo.fleet_id}/members/`,
         { headers: { Authorization: `Bearer ${token}` } },
       );

--- a/server/src/routes/incursions.ts
+++ b/server/src/routes/incursions.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { esiFetch } from '../utils/esi.js';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
 import { TtlValue } from '../utils/cache.js';
@@ -42,7 +43,7 @@ const cache = new TtlValue<IncursionSystem[]>(CACHE_TTL_MS);
 
 async function loadFactions(): Promise<Map<number, EsiFaction>> {
   if (factionMap) return factionMap;
-  const res = await fetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
+  const res = await esiFetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
   if (!res.ok) throw new Error(`ESI factions ${res.status}`);
   const list = await res.json() as EsiFaction[];
   factionMap = new Map(list.map((f) => [f.faction_id, f]));
@@ -51,7 +52,7 @@ async function loadFactions(): Promise<Map<number, EsiFaction>> {
 
 async function fetchAndBuild(): Promise<IncursionSystem[]> {
   const [incRes, factions] = await Promise.all([
-    fetch('https://esi.evetech.net/latest/incursions/?datasource=tranquility'),
+    esiFetch('https://esi.evetech.net/latest/incursions/?datasource=tranquility'),
     loadFactions(),
   ]);
   if (!incRes.ok) throw new Error(`ESI incursions ${incRes.status}`);

--- a/server/src/routes/insurgency.ts
+++ b/server/src/routes/insurgency.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
 import { TtlValue } from '../utils/cache.js';
+import { esiFetch } from '../utils/esi.js';
 
 const router = Router();
 router.use(optionalAuth);
@@ -58,7 +59,7 @@ const cache = new TtlValue<InsurgencySystem[]>(CACHE_TTL_MS);
 
 async function loadFactions(): Promise<Map<number, EsiFaction>> {
   if (factionMap) return factionMap;
-  const res = await fetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
+  const res = await esiFetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
   if (!res.ok) throw new Error(`ESI factions ${res.status}`);
   const list = await res.json() as EsiFaction[];
   factionMap = new Map(list.map((f) => [f.faction_id, f]));

--- a/server/src/routes/killboard.ts
+++ b/server/src/routes/killboard.ts
@@ -3,12 +3,13 @@ import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
 import { TtlCache } from '../utils/cache.js';
 import { resolveEntityNames } from '../services/entityNames.js';
+import { esiFetch } from '../utils/esi.js';
 
 const router = Router();
 router.use(optionalAuth);
 const log = createLogger('killboard');
 
-const ZKB_AGENT    = 'Eve-Nexum/1.0 (https://codeberg.org/GQuantrill/eve-nexum; gq@area404.org)';
+const ZKB_AGENT    = 'Eve-Nexum/1.0 (https://github.com/GQuantrill/eve-nexum; gq@area404.org)';
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 8_000;
 
@@ -100,9 +101,9 @@ async function fetchEsi(killmailId: number, hash: string): Promise<EsiKillmail |
   const promise = (async (): Promise<EsiKillmail | null> => {
     await acquireSlot();
     try {
-      const res = await fetch(
+      const res = await esiFetch(
         `https://esi.evetech.net/latest/killmails/${killmailId}/${hash}/`,
-        { headers: { 'User-Agent': ZKB_AGENT, Accept: 'application/json' }, signal: withTimeout(FETCH_TIMEOUT_MS) },
+        { signal: withTimeout(FETCH_TIMEOUT_MS) },
       );
       if (!res.ok) return null;
       return (await res.json()) as EsiKillmail;

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { esiFetch } from '../utils/esi.js';
 import type { Request, Response } from 'express';
 import { db } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
@@ -50,7 +51,7 @@ async function resolveStructureOwnerCorp(
     );
     if (!rows.length) return null;
     const token = decryptToken(rows[0].access_token);
-    const r = await fetch(`https://esi.evetech.net/v2/universe/structures/${eveStructureId}/`, {
+    const r = await esiFetch(`https://esi.evetech.net/v2/universe/structures/${eveStructureId}/`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!r.ok) {

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { esiFetch } from '../utils/esi.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { createLogger } from '../utils/logger.js';
 import { TtlCache } from '../utils/cache.js';
@@ -10,7 +11,6 @@ export const searchRouter = Router();
 searchRouter.use(requireAuth);
 
 const ESI_TIMEOUT_MS = 8_000;
-const ESI_AGENT      = 'Eve-Nexum/1.0 (https://codeberg.org/GQuantrill/eve-nexum; gq@area404.org)';
 
 // Cache exact-name lookups for 24h. Character / corp names are effectively
 // immutable; this stops a debounced search-as-you-type UI from hammering ESI.
@@ -28,13 +28,9 @@ interface IdsResponse {
 // for an interactive picker.
 async function lookupExactName(name: string): Promise<IdsResponse | null> {
   try {
-    const res = await fetch('https://esi.evetech.net/latest/universe/ids/', {
+    const res = await esiFetch('https://esi.evetech.net/latest/universe/ids/', {
       method:  'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent':   ESI_AGENT,
-        Accept:         'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
       body:    JSON.stringify([name]),
       signal:  AbortSignal.timeout(ESI_TIMEOUT_MS),
     });

--- a/server/src/services/entityNames.ts
+++ b/server/src/services/entityNames.ts
@@ -1,4 +1,5 @@
 import { db } from '../db.js';
+import { esiFetch } from '../utils/esi.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('entityNames');
@@ -6,7 +7,6 @@ const log = createLogger('entityNames');
 // ESI POST /universe/names/ accepts up to 1000 IDs per call.
 const ESI_BATCH_SIZE = 1000;
 const ESI_TIMEOUT_MS = 8_000;
-const ESI_AGENT      = 'Eve-Nexum/1.0 (https://codeberg.org/GQuantrill/eve-nexum; gq@area404.org)';
 
 export interface EntityName {
   name:     string;
@@ -60,13 +60,9 @@ export async function resolveEntityNames(rawIds: Array<number | null | undefined
   for (let i = 0; i < missing.length; i += ESI_BATCH_SIZE) {
     const chunk = missing.slice(i, i + ESI_BATCH_SIZE);
     try {
-      const res = await fetch('https://esi.evetech.net/latest/universe/names/', {
+      const res = await esiFetch('https://esi.evetech.net/latest/universe/names/', {
         method:  'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'User-Agent':   ESI_AGENT,
-          Accept:         'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(chunk),
         signal:  AbortSignal.timeout(ESI_TIMEOUT_MS),
       });

--- a/server/src/services/ghostSites.ts
+++ b/server/src/services/ghostSites.ts
@@ -1,4 +1,5 @@
 import { db } from '../db.js';
+import { esiFetch } from '../utils/esi.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('ghost-sites');
@@ -101,7 +102,7 @@ interface EsiSystemInfo {
 
 async function fetchEsiSystemInfo(eveSystemId: number): Promise<EsiSystemInfo | null> {
   try {
-    const res = await fetch(`https://esi.evetech.net/latest/universe/systems/${eveSystemId}/?datasource=tranquility`);
+    const res = await esiFetch(`https://esi.evetech.net/latest/universe/systems/${eveSystemId}/?datasource=tranquility`);
     if (!res.ok) return null;
     const json = await res.json() as { star_id?: number; planets?: Array<{ planet_id: number; moons?: number[] }> };
     const planets = Array.isArray(json.planets) ? json.planets : [];
@@ -115,7 +116,7 @@ async function fetchEsiSystemInfo(eveSystemId: number): Promise<EsiSystemInfo | 
 
 async function resolveSunType(starId: number): Promise<string | null> {
   try {
-    const res = await fetch(`https://esi.evetech.net/latest/universe/stars/${starId}/?datasource=tranquility`);
+    const res = await esiFetch(`https://esi.evetech.net/latest/universe/stars/${starId}/?datasource=tranquility`);
     if (!res.ok) return null;
     const json = await res.json() as { type_id?: number; spectral_class?: string };
     if (!json.type_id) return json.spectral_class ?? null;

--- a/server/src/services/locationPoll.ts
+++ b/server/src/services/locationPoll.ts
@@ -1,4 +1,5 @@
 import { db } from '../db.js';
+import { esiFetch } from '../utils/esi.js';
 import { getValidToken } from '../utils/eveToken.js';
 import { config } from '../config.js';
 import { createLogger } from '../utils/logger.js';
@@ -24,14 +25,14 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 // background detection shouldn't inflate a pilot's activity stats.
 async function pollOne(userId: number, characterId: number): Promise<void> {
   const token = await getValidToken(userId); // throws on a dead/revoked token
-  const onlineRes = await fetch(
+  const onlineRes = await esiFetch(
     `https://esi.evetech.net/latest/characters/${characterId}/online/`,
     { headers: { Authorization: `Bearer ${token}` } },
   );
   if (!onlineRes.ok) return;
   if (!reallyOnline(await onlineRes.json() as OnlineResp)) return;
 
-  const locRes = await fetch(
+  const locRes = await esiFetch(
     `https://esi.evetech.net/latest/characters/${characterId}/location/`,
     { headers: { Authorization: `Bearer ${token}` } },
   );

--- a/server/src/services/standings.ts
+++ b/server/src/services/standings.ts
@@ -1,4 +1,5 @@
 import { db } from '../db.js';
+import { esiFetch } from '../utils/esi.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('standings');
@@ -22,7 +23,7 @@ async function fetchAllContacts(url: string, token: string): Promise<EsiContact[
   const all: EsiContact[] = [];
   let page = 1;
   while (true) {
-    const r = await fetch(`${url}?page=${page}`, {
+    const r = await esiFetch(`${url}?page=${page}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (r.status === 403) return { error: 'forbidden',    status: 403 };

--- a/server/src/utils/esi.ts
+++ b/server/src/utils/esi.ts
@@ -1,0 +1,64 @@
+import { createLogger } from './logger.js';
+
+const log = createLogger('esi');
+
+// Descriptive User-Agent with contact info, per CCP's ESI best practices — sent
+// on every ESI request so they can identify (and reach) us instead of blocking.
+const ESI_AGENT = 'Eve-Nexum/1.0 (https://github.com/GQuantrill/eve-nexum; gq@area404.org)';
+
+// ── Error-limit backoff ──────────────────────────────────────────────────────
+// ESI allows ~100 errors per 60s sliding window per IP; exceed it and every
+// request 420s until the window resets. Each response carries the remaining
+// budget + seconds-to-reset, so we watch those and stop sending when the budget
+// runs low — shared module state because the limit is global to this process's
+// IP, not per call site. Successful requests barely touch the budget, so under
+// normal operation this never engages; it only bites when something is
+// error-spamming (a bad token, a wrong id), which is exactly when CCP wants us
+// to pause.
+const SAFE_REMAIN = 10;       // start easing off once the budget dips this low
+let blockedUntil = 0;         // epoch ms; hold new requests until this passes
+
+function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) { reject(signal.reason ?? new Error('aborted')); return; }
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => { clearTimeout(t); reject(signal.reason ?? new Error('aborted')); }, { once: true });
+  });
+}
+
+/**
+ * Drop-in replacement for fetch() against ESI. Always sends the User-Agent and
+ * Accept headers, and honours the error limit: if a recent response exhausted
+ * the budget (or 420'd), new calls wait for the reset rather than piling on.
+ * Returns the raw Response — callers do their own .ok / .json handling, exactly
+ * as with fetch. The pre-request wait respects an AbortSignal in `init`, so a
+ * caller with a timeout won't hang past it.
+ */
+export async function esiFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  const wait = blockedUntil - Date.now();
+  if (wait > 0) await sleep(wait, init.signal);
+
+  const headers = {
+    'User-Agent': ESI_AGENT,
+    Accept: 'application/json',
+    ...(init.headers as Record<string, string> | undefined),
+  };
+  const res = await fetch(url, { ...init, headers });
+
+  // Update backoff state from the error-limit headers (present on every ESI
+  // response). Reset is seconds until the window clears; pad by 1s.
+  const remainRaw = res.headers.get('x-esi-error-limit-remain');
+  if (remainRaw != null || res.status === 420) {
+    const remain   = remainRaw != null ? parseInt(remainRaw, 10) : 0;
+    const resetSec = parseInt(res.headers.get('x-esi-error-limit-reset') ?? '60', 10);
+    if (res.status === 420 || remain <= 0) {
+      blockedUntil = Date.now() + (resetSec + 1) * 1000;
+      log.warn(`error limit hit (status ${res.status}); backing off ${resetSec + 1}s`);
+    } else if (remain <= SAFE_REMAIN) {
+      // Close to the edge — brief pause so a burst doesn't blow the window.
+      blockedUntil = Date.now() + 1000;
+      log.warn(`error limit low (${remain} left); easing off`);
+    }
+  }
+  return res;
+}


### PR DESCRIPTION
Closes the two gaps from the ESI best-practices audit by routing every ESI call through one client.

## New `utils/esi.ts` — `esiFetch()`
A drop-in for `fetch()` against ESI that:
- **Always sends a descriptive User-Agent** with contact info (`Eve-Nexum/1.0 (https://github.com/GQuantrill/eve-nexum; gq@area404.org)`) and `Accept: application/json`. Before, the UA was set on only **3 of ~13** call sites — the authenticated character calls (location/online/ship/set-waypoint), standings, incursions, etc. sent none.
- **Honours the ESI error limit.** Reads `X-ESI-Error-Limit-Remain` / `-Reset` on every response and holds new requests until the window resets once the budget runs low or a `420` lands — so a burst of errors (bad token, wrong id) can't spiral into an IP ban. Shared module state (the limit is per-IP), and the pre-request wait respects the caller's `AbortSignal` so timeouts still apply.

## Migration
All ESI call sites now go through `esiFetch`: `character`, `standings`, `incursions`, `insurgency`, `activity`, `admin`, `auth` (corp check), `maps`, `ghostSites`, `locationPoll`, `search`, `entityNames`, and killboard's killmail lookup. Removed the now-redundant per-file `ESI_AGENT` constants/headers. Non-ESI fetches are deliberately left untouched (zKillboard keeps its own UA, EVE-Scout, the SSO token exchange).

## Also
Repo URL in the User-Agent strings and the README `git clone` commands updated from codeberg to **github**.

Server builds clean (`tsc`). Under normal operation the backoff never engages — successful requests barely touch the error budget; it only kicks in when something is actually erroring, which is exactly when CCP wants us to pause.