### PR TITLE
Admin: capture true last login (not last row-touch)

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -474,6 +474,14 @@ export async function migrate() {
     -- poll lands. No FK — system ids are immutable SDE data.
     ALTER TABLE users ADD COLUMN IF NOT EXISTS last_known_system_id INTEGER;
     ALTER TABLE users ADD COLUMN IF NOT EXISTS last_known_system_at TIMESTAMPTZ;
+
+    -- True last-login timestamp, written only on an SSO auth (see auth callback).
+    -- Distinct from updated_at, which is bumped by token refreshes, location
+    -- tracking, the SDE/standings jobs, etc. — so it can't stand in for "last
+    -- login". Seed it once from updated_at for pre-existing rows (a rough lower
+    -- bound); real logins overwrite it from then on.
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ;
+    UPDATE users SET last_login_at = updated_at WHERE last_login_at IS NULL;
     -- Normalise the column to INTEGER for any DB that got the earlier BIGINT
     -- definition (BIGINT comes back from node-pg as a string, which breaks the
     -- numeric id comparison on the client). Guarded so it only rewrites once.

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -132,7 +132,7 @@ adminReadRouter.get('/users', async (_req, res) => {
       u.alliance_id    AS "allianceId",
       u.blocked,
       u.created_at     AS "createdAt",
-      u.updated_at     AS "lastLogin",
+      u.last_login_at  AS "lastLogin",
       COALESCE(e.cnt, 0) AS "totalEvents",
       COALESCE(s.cnt, 0) AS "totalSignatures",
       u.last_known_system_id AS "lastKnownSystemId",
@@ -150,7 +150,7 @@ adminReadRouter.get('/users', async (_req, res) => {
       JOIN maps m          ON m.id  = sys.map_id
       GROUP BY m.user_id
     ) s ON s.user_id = u.id
-    ORDER BY u.updated_at DESC
+    ORDER BY u.last_login_at DESC NULLS LAST
   `);
 
   const [corpInfo, allianceInfo] = await Promise.all([
@@ -669,7 +669,7 @@ reportsRouter.get('/users', async (req, res) => {
       u.role,
       u.corp_id        AS "corpId",
       u.alliance_id    AS "allianceId",
-      u.updated_at     AS "lastLogin",
+      u.last_login_at  AS "lastLogin",
       u.last_known_system_id AS "lastKnownSystemId",
       lks.name               AS "lastKnownSystemName",
       lcs.ts           AS "lastCorpSigAt",

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -197,13 +197,14 @@ authRouter.get('/callback', async (req, res) => {
     const defaultRole = (!config.corpMode || isAdminChar) ? 'admin' : 'readonly';
 
     const { rows } = await db.query<{ id: number; role: string; blocked: boolean }>(
-      `INSERT INTO users (character_id, character_name, access_token, refresh_token, token_expires_at, role, corp_id, alliance_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $8, $10)
+      `INSERT INTO users (character_id, character_name, access_token, refresh_token, token_expires_at, role, corp_id, alliance_id, last_login_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $8, $10, NOW())
        ON CONFLICT (character_id) DO UPDATE SET
          character_name   = EXCLUDED.character_name,
          access_token     = EXCLUDED.access_token,
          refresh_token    = EXCLUDED.refresh_token,
          token_expires_at = EXCLUDED.token_expires_at,
+         last_login_at    = NOW(),
          corp_id          = COALESCE($8::int,  users.corp_id),
          alliance_id      = COALESCE($10::int, users.alliance_id),
          role             = CASE

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -1313,7 +1313,8 @@ function AuditTab() {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function formatRelative(t: TFunction, iso: string): string {
+function formatRelative(t: TFunction, iso: string | null | undefined): string {
+  if (!iso) return DASH;
   const date = new Date(iso);
   const then = date.getTime();
   if (Number.isNaN(then)) return DASH;


### PR DESCRIPTION
Fixes the admin **Users** and **Reports -> Users** tables showing everyone's "Last login" as a few minutes ago.

## Cause
Both tables read `users.updated_at` as "last login". But `updated_at` is a generic row-touch timestamp — bumped by token refreshes, **last-known-location tracking**, the location poller, standings refreshes, and admin actions. So once location tracking shipped, `updated_at` reflected the most recent background update, not the actual login. (Your suspicion was right.)

## Fix
- New **`users.last_login_at`** column, written **only on an SSO auth** — set in the `/auth/callback` upsert, which runs for the authenticating character on both a fresh login and an add-character link. A no-SSO **switch-character** and background updates never touch it.
- Both admin queries now read `last_login_at` (the Users table orders by it, `NULLS LAST`).
- **Migration** seeds `last_login_at = updated_at` once for existing rows (a rough lower bound so the column isn't blank); real logins overwrite it from then on, so it self-corrects as people log in.
- Client `formatRelative` renders a missing value as the dash placeholder instead of a 1970 date.

Server + web build clean. Note the backfilled values are approximate for users who haven't logged in since the upgrade — they become exact on each user's next login.