### PR TITLE
Sig panel: show days (DD HH MM) for age/updated past 24h

### DIFF
--- a/web/src/i18n/format.ts
+++ b/web/src/i18n/format.ts
@@ -31,8 +31,8 @@ export function europeanDate(date: Date): string {
 }
 
 /**
- * Elapsed duration (counting up): "0s" / "42s" / "5m 03s" / "2h 09m".
- * Negative inputs clamp to 0.
+ * Elapsed duration (counting up): "0s" / "42s" / "5m 03s" / "2h 09m" /
+ * "3d 02h 09m" once past 24h. Negative inputs clamp to 0.
  */
 export function duration(t: TFunction, totalSeconds: number): string {
   const s = totalSeconds < 0 ? 0 : totalSeconds;
@@ -40,7 +40,9 @@ export function duration(t: TFunction, totalSeconds: number): string {
   const m = Math.floor(s / 60);
   if (m < 60) return t('duration.minutesSeconds', { minutes: m, seconds: pad2(s % 60) });
   const h = Math.floor(m / 60);
-  return t('duration.hoursMinutes', { hours: h, minutes: pad2(m % 60) });
+  if (h < 24) return t('duration.hoursMinutes', { hours: h, minutes: pad2(m % 60) });
+  const d = Math.floor(h / 24);
+  return t('duration.daysHoursMinutes', { days: d, hours: pad2(h % 24), minutes: pad2(m % 60) });
 }
 
 /** "expires in 2h 14m" / "expires in 14m" / "expired" from a millisecond remainder. */

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "abgelaufen",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "expired",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "caducado",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "expiré",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "期限切れ",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "만료됨",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "expirado",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -812,7 +812,8 @@
   "duration": {
     "seconds": "{{value}} с",
     "minutesSeconds": "{{minutes}} мин {{seconds}} с",
-    "hoursMinutes": "{{hours}} ч {{minutes}} мин"
+    "hoursMinutes": "{{hours}} ч {{minutes}} мин",
+    "daysHoursMinutes": "{{days}} д {{hours}} ч {{minutes}} мин"
   },
   "share": {
     "expired": "истекла",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -780,7 +780,8 @@
   "duration": {
     "seconds": "{{value}}s",
     "minutesSeconds": "{{minutes}}m {{seconds}}s",
-    "hoursMinutes": "{{hours}}h {{minutes}}m"
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "daysHoursMinutes": "{{days}}d {{hours}}h {{minutes}}m"
   },
   "share": {
     "expired": "已过期",


### PR DESCRIPTION
On the signature panel, the **age** and **updated** cells topped out at hours — a two-day-old sig read `50h 09m`.

## Fix
Extended the shared `duration()` formatter with a days tier: past 24h it now renders **`Dd HHh MMm`** (e.g. `2d 03h 45m`); under 24h is unchanged (`5m 03s`, `2h 09m`). Both the age (`createdAt`) and the updated (`updatedAt`) cells go through this same formatter, so both are covered.

`duration()` is only used by these two cells, so no other UI is affected. New `duration.daysHoursMinutes` string added across all nine locales (universal `d/h/m`, Russian uses its `д/ч/мин`). Web build + i18n parity clean.