### PR TITLE
Map: invert mouse/trackpad zoom toggle (Map Controls)

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -28,9 +28,14 @@ import { pickHandles } from './edgeUtils';
 import { setDestination, addWaypoint } from '../../api/waypoint';
 import { toast } from '../ui/Toaster';
 import { useCustomIntel } from '../../hooks/useCustomIntel';
+import { useUserSetting } from '../../hooks/useUserSetting';
 import { resolveIntelColor } from '../../utils/intelColors';
 
 const NODE_TYPES = { system: SystemNode };
+
+// Zoom bounds — shared by the <ReactFlow> props and the inverted-wheel handler.
+const MIN_ZOOM = 0.2;
+const MAX_ZOOM = 2;
 
 function resolveOverlaps(
   items: Array<{ id: string; x: number; y: number; w: number; h: number; locked: boolean }>,
@@ -127,11 +132,45 @@ export function MapCanvas() {
   const accountLocations     = useAccountLocations();
   const pushUndo             = useMapStore((s) => s.pushUndo);
   const canEdit              = useCanEdit();
-  const { screenToFlowPosition, setViewport, getNode, getNodes, getZoom, fitView } = useReactFlow();
+  const { screenToFlowPosition, setViewport, getViewport, getNode, getNodes, getZoom, fitView } = useReactFlow();
+  // Invert mouse-wheel / trackpad zoom (per-user, cross-device). Off by default.
+  const [invertZoom] = useUserSetting<boolean>('nexum.map.invertZoom', false);
 
   const [pendingPosition, setPendingPosition] = useState<{ x: number; y: number } | null>(null);
   const [contextMenu, setContextMenu]         = useState<CtxMenu | null>(null);
   const [customIntel] = useCustomIntel();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Inverted-zoom handler. React Flow's own wheel zoom is off when this is on
+  // (zoomOnScroll={!invertZoom}); we zoom ourselves with the direction flipped,
+  // anchored at the cursor, matching d3-zoom's scaling so the feel is unchanged.
+  // Pinch (ctrl+wheel) is left to React Flow's zoomOnPinch so it stays natural.
+  // Non-passive listener so we can preventDefault the page scroll.
+  useEffect(() => {
+    if (!invertZoom) return;
+    const el = wrapperRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (e.ctrlKey) return; // pinch-zoom — leave it to React Flow
+      e.preventDefault();
+      const delta  = e.deltaY * (e.deltaMode === 1 ? 0.05 : e.deltaMode ? 1 : 0.002);
+      const factor = Math.pow(2, delta); // no negation → scroll-up zooms out
+      const { x, y, zoom } = getViewport();
+      const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom * factor));
+      if (next === zoom) return;
+      const rect = el.getBoundingClientRect();
+      const px = e.clientX - rect.left;
+      const py = e.clientY - rect.top;
+      // Keep the flow point under the cursor fixed across the zoom.
+      setViewport({
+        x: px - ((px - x) / zoom) * next,
+        y: py - ((py - y) / zoom) * next,
+        zoom: next,
+      });
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [invertZoom, getViewport, setViewport]);
 
   // React Flow's <Controls> buttons read their hover title + aria-label from
   // ariaLabelConfig (merged with the library defaults), so this translates the
@@ -855,7 +894,7 @@ export function MapCanvas() {
   })();
 
   return (
-    <div className="map-canvas">
+    <div className="map-canvas" ref={wrapperRef}>
       <ReactFlow
         ariaLabelConfig={ariaLabelConfig}
         nodes={nodes}
@@ -882,8 +921,9 @@ export function MapCanvas() {
         snapToGrid={snapToGrid}
         snapGrid={[20, 20]}
         fitView
-        minZoom={0.2}
-        maxZoom={2}
+        minZoom={MIN_ZOOM}
+        maxZoom={MAX_ZOOM}
+        zoomOnScroll={!invertZoom}
         deleteKeyCode={null}
       >
         <Background

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -141,20 +141,25 @@ export function MapCanvas() {
   const [customIntel] = useCustomIntel();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  // Inverted-zoom handler. React Flow's own wheel zoom is off when this is on
-  // (zoomOnScroll={!invertZoom}); we zoom ourselves with the direction flipped,
-  // anchored at the cursor, matching d3-zoom's scaling so the feel is unchanged.
-  // Pinch (ctrl+wheel) is left to React Flow's zoomOnPinch so it stays natural.
-  // Non-passive listener so we can preventDefault the page scroll.
+  // Inverted-zoom handler. When on, React Flow's own wheel AND pinch zoom are
+  // off (zoomOnScroll / zoomOnPinch = !invertZoom) and we handle both here with
+  // the direction flipped, anchored at the cursor, matching d3-zoom's scaling so
+  // the feel is unchanged. Covers a mac trackpad pinch too — the browser
+  // delivers that as a ctrl+wheel event, so it must NOT be skipped. Non-passive
+  // listener so we can preventDefault the page scroll / browser pinch-zoom.
   useEffect(() => {
     if (!invertZoom) return;
     const el = wrapperRef.current;
     if (!el) return;
     const onWheel = (e: WheelEvent) => {
-      if (e.ctrlKey) return; // pinch-zoom — leave it to React Flow
       e.preventDefault();
-      const delta  = e.deltaY * (e.deltaMode === 1 ? 0.05 : e.deltaMode ? 1 : 0.002);
-      const factor = Math.pow(2, delta); // no negation → scroll-up zooms out
+      // Match d3-zoom's wheelDelta (incl. its x10 for ctrl/pinch) so the speed
+      // is identical to React Flow's native zoom; only the sign is flipped (no
+      // negation here) so scroll-up / pinch-out zooms out instead of in.
+      const delta  = e.deltaY
+        * (e.deltaMode === 1 ? 0.05 : e.deltaMode ? 1 : 0.002)
+        * (e.ctrlKey ? 10 : 1);
+      const factor = Math.pow(2, delta);
       const { x, y, zoom } = getViewport();
       const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom * factor));
       if (next === zoom) return;
@@ -924,6 +929,7 @@ export function MapCanvas() {
         minZoom={MIN_ZOOM}
         maxZoom={MAX_ZOOM}
         zoomOnScroll={!invertZoom}
+        zoomOnPinch={!invertZoom}
         deleteKeyCode={null}
       >
         <Background

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -33,11 +33,13 @@ import type { WormholeMap } from "../../types";
 function SettingToggle({
   settingKey,
   label,
+  defaultOn = true,
 }: {
   settingKey: string;
   label: string;
+  defaultOn?: boolean;
 }) {
-  const [enabled, setEnabled] = useUserSetting<boolean>(settingKey, true);
+  const [enabled, setEnabled] = useUserSetting<boolean>(settingKey, defaultOn);
   return (
     <label className="map-sidebar__row map-sidebar__toggle-row">
       <span className="map-sidebar__label">{label}</span>
@@ -93,6 +95,7 @@ function CollapsibleSection({
 // shared "which section is open" setting; null means everything collapsed.
 type SectionId =
   | "mapOptions"
+  | "mapControls"
   | "systemOptions"
   | "connections"
   | "route"
@@ -723,6 +726,14 @@ export function MapSidebar() {
               </button>
             </div>
           </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title={t("mapSidebar.sections.mapControls")} {...sectionProps("mapControls")}>
+          <SettingToggle
+            settingKey="nexum.map.invertZoom"
+            label={t("mapSidebar.invertZoom")}
+            defaultOn={false}
+          />
         </CollapsibleSection>
 
         <CollapsibleSection

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "Kartenoptionen schließen",
     "sections": {
       "mapOptions": "Kartenoptionen",
+      "mapControls": "Kartensteuerung",
       "systemOptions": "Systemoptionen",
       "connections": "Verbindungen",
       "route": "Route",
@@ -314,6 +315,7 @@
       "shortcuts": "Tastenkürzel"
     },
     "snapToGrid": "Am Raster ausrichten",
+    "invertZoom": "Zoom umkehren (Maus/Trackpad)",
     "minimap": "Minikarte",
     "position": "Position",
     "minimapPos": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "Close map options",
     "sections": {
       "mapOptions": "Map Options",
+      "mapControls": "Map Controls",
       "systemOptions": "System Options",
       "connections": "Connections",
       "route": "Route",
@@ -314,6 +315,7 @@
       "shortcuts": "Shortcuts"
     },
     "snapToGrid": "Snap to Grid",
+    "invertZoom": "Invert zoom (mouse/trackpad)",
     "minimap": "Minimap",
     "position": "Position",
     "minimapPos": {

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "Cerrar opciones de mapa",
     "sections": {
       "mapOptions": "Opciones de mapa",
+      "mapControls": "Controles del mapa",
       "systemOptions": "Opciones de sistema",
       "connections": "Conexiones",
       "route": "Ruta",
@@ -314,6 +315,7 @@
       "shortcuts": "Atajos"
     },
     "snapToGrid": "Ajustar a la cuadrícula",
+    "invertZoom": "Invertir zoom (ratón/trackpad)",
     "minimap": "Minimapa",
     "position": "Posición",
     "minimapPos": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "Fermer les options de carte",
     "sections": {
       "mapOptions": "Options de carte",
+      "mapControls": "Commandes de carte",
       "systemOptions": "Options de système",
       "connections": "Connexions",
       "route": "Itinéraire",
@@ -314,6 +315,7 @@
       "shortcuts": "Raccourcis"
     },
     "snapToGrid": "Aligner sur la grille",
+    "invertZoom": "Inverser le zoom (souris/pavé tactile)",
     "minimap": "Mini-carte",
     "position": "Position",
     "minimapPos": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "マップオプションを閉じる",
     "sections": {
       "mapOptions": "マップオプション",
+      "mapControls": "マップ操作",
       "systemOptions": "星系オプション",
       "connections": "接続",
       "route": "ルート",
@@ -314,6 +315,7 @@
       "shortcuts": "ショートカット"
     },
     "snapToGrid": "グリッドに合わせる",
+    "invertZoom": "ズーム反転（マウス/トラックパッド）",
     "minimap": "ミニマップ",
     "position": "位置",
     "minimapPos": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "지도 옵션 닫기",
     "sections": {
       "mapOptions": "지도 옵션",
+      "mapControls": "지도 컨트롤",
       "systemOptions": "성계 옵션",
       "connections": "연결",
       "route": "경로",
@@ -314,6 +315,7 @@
       "shortcuts": "단축키"
     },
     "snapToGrid": "격자에 맞추기",
+    "invertZoom": "확대/축소 반전 (마우스/트랙패드)",
     "minimap": "미니맵",
     "position": "위치",
     "minimapPos": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "Fechar opções de mapa",
     "sections": {
       "mapOptions": "Opções de mapa",
+      "mapControls": "Controlos do mapa",
       "systemOptions": "Opções de sistema",
       "connections": "Conexões",
       "route": "Rota",
@@ -314,6 +315,7 @@
       "shortcuts": "Atalhos"
     },
     "snapToGrid": "Ajustar à grade",
+    "invertZoom": "Inverter zoom (rato/trackpad)",
     "minimap": "Minimapa",
     "position": "Posição",
     "minimapPos": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -313,6 +313,7 @@
     "closeOptions": "Закрыть параметры карты",
     "sections": {
       "mapOptions": "Параметры карты",
+      "mapControls": "Управление картой",
       "systemOptions": "Параметры системы",
       "connections": "Соединения",
       "route": "Маршрут",
@@ -328,6 +329,7 @@
       "shortcuts": "Горячие клавиши"
     },
     "snapToGrid": "Привязка к сетке",
+    "invertZoom": "Инвертировать масштаб (мышь/трекпад)",
     "minimap": "Миникарта",
     "position": "Положение",
     "minimapPos": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -299,6 +299,7 @@
     "closeOptions": "关闭地图选项",
     "sections": {
       "mapOptions": "地图选项",
+      "mapControls": "地图控制",
       "systemOptions": "星系选项",
       "connections": "连接",
       "route": "路线",
@@ -314,6 +315,7 @@
       "shortcuts": "快捷键"
     },
     "snapToGrid": "对齐网格",
+    "invertZoom": "反转缩放（鼠标/触控板）",
     "minimap": "小地图",
     "position": "位置",
     "minimapPos": {


### PR DESCRIPTION
Adds a per-user toggle to invert the scroll-wheel / trackpad zoom direction, as discussed.

## UI
A new **Map Controls** section in the map sidebar with an **Invert zoom (mouse/trackpad)** toggle. Off by default, stored per-user and cross-device via `useUserSetting` (`nexum.map.invertZoom`) — so it's opt-in, not a global flip.

## Behaviour
- When **off**: unchanged — React Flow's native wheel zoom.
- When **on**: `zoomOnScroll={false}` disables React Flow's wheel zoom, and a non-passive `wheel` handler zooms with the direction flipped, **anchored at the cursor**, using the same d3-zoom scaling (`2^(deltaY * deltaMode-factor)`) so the speed/feel matches the default.
- **Pinch (ctrl+wheel) is left to React Flow's `zoomOnPinch`**, so trackpad pinch stays natural and only scroll is inverted.
- The `+`/`-` Controls buttons are unaffected.

Shared `MIN_ZOOM`/`MAX_ZOOM` constants keep the handler and the `<ReactFlow>` bounds in sync. New `mapSidebar.sections.mapControls` + `mapSidebar.invertZoom` strings across all nine locales. Web build + i18n parity clean; no new lint (the MapSidebar/MapCanvas lint hits are pre-existing).