### PR TITLE
Map: thicker intel bezel on nodes

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1606,7 +1606,7 @@
   width: 12px;
   height: 12px;
   border-radius: 3px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 5px solid rgba(255, 255, 255, 0.15);
 }
 
 /* Read-only display of a generated share URL. Monospace so the UUID
@@ -1818,7 +1818,7 @@
    feedback is preserved. */
 .system-node[data-intel] {
   border-color: var(--intel-color);
-  border-width: 2.5px;
+  border-width: 4px;
 
   &:hover,
   &[data-selected='true'] {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1827,11 +1827,11 @@
 }
 
 /* Folded-corner triangle in the top-right when intel is set — a second,
-   shape-based cue so the intel state reads at a glance alongside the coloured
-   border. CSS-only via ::after, keyed off data-intel and the same
+   shape-based cue alongside the coloured border. A real element (rendered by
+   SystemNode) rather than a ::after so it can carry a tooltip with the intel
+   label on hover; pointer-events enabled for exactly that. Uses the same
    --intel-color SystemNode sets inline. */
-.system-node[data-intel]::after {
-  content: '';
+.system-node__intel-corner {
   position: absolute;
   top: 0;
   right: 0;
@@ -1840,7 +1840,7 @@
   border-top: 16px solid var(--intel-color);
   border-left: 16px solid transparent;
   border-top-right-radius: 6px;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .system-node {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1826,6 +1826,23 @@
   }
 }
 
+/* Folded-corner triangle in the top-right when intel is set — a second,
+   shape-based cue so the intel state reads at a glance alongside the coloured
+   border. CSS-only via ::after, keyed off data-intel and the same
+   --intel-color SystemNode sets inline. */
+.system-node[data-intel]::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-top: 16px solid var(--intel-color);
+  border-left: 16px solid transparent;
+  border-top-right-radius: 6px;
+  pointer-events: none;
+}
+
 .system-node {
   min-width: 150px;
   min-height: 80px; /* at least 4 snap-grid squares tall */

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -26,7 +26,7 @@ import { useCurrentHourKills } from '../../hooks/useCurrentHourKills';
 import { useNow30s } from '../../hooks/useNow30s';
 import { useStaleThreshold } from '../../hooks/useStaleThreshold';
 import { useCustomIntel } from '../../hooks/useCustomIntel';
-import { resolveIntelColor } from '../../utils/intelColors';
+import { resolveIntelColor, resolveIntelLabel } from '../../utils/intelColors';
 import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
@@ -127,6 +127,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const connection      = useConnection();
   const [customIntel]   = useCustomIntel();
   const intelColor      = resolveIntelColor(sys.intel, customIntel);
+  const intelLabel      = resolveIntelLabel(sys.intel, customIntel, t);
 
   // Tooltip label: dedupe by scout system name (Thera / Turnur). Multiple
   // connections from the same scout are summarised, mixed scouts are listed.
@@ -199,6 +200,16 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
       <Handle type="source" position={Position.Right}  id="right"  className={easyConnect ? 'system-handle system-handle--ghost' : 'system-handle'} />
       <Handle type="source" position={Position.Bottom} id="bottom" className={easyConnect ? 'system-handle system-handle--ghost' : 'system-handle'} />
       <Handle type="source" position={Position.Left}   id="left"   className={easyConnect ? 'system-handle system-handle--ghost' : 'system-handle'} />
+
+      {/* Top-right intel marker. Real element (not a ::after) so it can carry
+          a tooltip showing the intel label on hover. */}
+      {sys.intel && (
+        <span
+          className="system-node__intel-corner"
+          data-tooltip={intelLabel ?? undefined}
+          aria-label={intelLabel ?? undefined}
+        />
+      )}
 
       {easyConnect && (
         <>


### PR DESCRIPTION
When a node has manual intel set, its coloured border now renders at `4px` (was `2.5px`) so the intel state reads at a glance. Single CSS change on `.system-node[data-intel]`; the base node border (1.5px) and hover/selected box-shadow are unchanged.