### PR TITLE
Security: audit hardening (config guards, log hygiene, SQL scoping)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -59,11 +59,21 @@ const SDE_CHECK_UTC   = /^\d{1,2}:\d{2}$/.test(process.env.SDE_CHECK_UTC ?? '')
   : '11:30';
 
 const isProd = process.env.NODE_ENV === 'production';
+const isDev  = process.env.NODE_ENV === 'development';
 
-// Session secret must be explicitly set in production — a guessable default
-// is a critical session-forgery risk.
-if (isProd && !process.env.SESSION_SECRET) {
-  console.error('FATAL: SESSION_SECRET must be set in production');
+// Session secret must be explicitly set unless we're explicitly in development
+// — the guessable dev fallback below is a session-forgery risk, so it must
+// never apply just because NODE_ENV happens to be unset on a real deployment.
+if (!isDev && !process.env.SESSION_SECRET) {
+  console.error('FATAL: SESSION_SECRET must be set (NODE_ENV is not "development")');
+  process.exit(1);
+}
+
+// FRONTEND_URL builds post-login redirects and seeds the CSRF origin check, so
+// a malformed value would silently break auth / weaken that check. Validate the
+// effective value (default is the local dev URL) before anything uses it.
+if (!URL.canParse(process.env.FRONTEND_URL ?? 'http://localhost:5174')) {
+  console.error('FATAL: FRONTEND_URL is not a valid URL');
   process.exit(1);
 }
 

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1765,8 +1765,11 @@ mapsRouter.patch('/:mapId/systems/:systemId/signatures/:sigId', async (req, res)
   }
 
   await db.query(
-    `UPDATE map_signatures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2}`,
-    [...vals, sigId, systemId],
+    // map_id scoping is defence-in-depth: verifySystemInMap above already
+    // guarantees systemId is in this map, but enforcing it in SQL too means a
+    // future refactor can't open a cross-map write.
+    `UPDATE map_signatures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND system_id IN (SELECT id FROM map_systems WHERE map_id = $${vals.length + 3})`,
+    [...vals, sigId, systemId, mapId],
   );
   db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
   if (typeof updates.name === 'string') recordGhostSiteIfMatch(systemId, updates.name);
@@ -1783,7 +1786,7 @@ mapsRouter.delete('/:mapId/systems/:systemId/signatures/:sigId', async (req, res
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  await db.query(`DELETE FROM map_signatures WHERE id = $1 AND system_id = $2`, [sigId, systemId]);
+  await db.query(`DELETE FROM map_signatures WHERE id = $1 AND system_id = $2 AND system_id IN (SELECT id FROM map_systems WHERE map_id = $3)`, [sigId, systemId, mapId]);
   db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
   publishToMap(mapId, { type: 'sig.changed', actor: req.get('x-client-id') ?? null, systemId });
   res.json({ ok: true });
@@ -1845,8 +1848,9 @@ mapsRouter.patch('/:mapId/systems/:systemId/structures/:structureId', async (req
   }
 
   await db.query(
-    `UPDATE map_structures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2}`,
-    [...vals, structureId, systemId],
+    // map_id scoping is defence-in-depth (see the signature PATCH above).
+    `UPDATE map_structures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND system_id IN (SELECT id FROM map_systems WHERE map_id = $${vals.length + 3})`,
+    [...vals, structureId, systemId, mapId],
   );
   publishToMap(mapId, { type: 'structure.changed', actor: req.get('x-client-id') ?? null, systemId });
   res.json({ ok: true });
@@ -1857,7 +1861,7 @@ mapsRouter.delete('/:mapId/systems/:systemId/structures/:structureId', async (re
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  await db.query(`DELETE FROM map_structures WHERE id = $1 AND system_id = $2`, [structureId, systemId]);
+  await db.query(`DELETE FROM map_structures WHERE id = $1 AND system_id = $2 AND system_id IN (SELECT id FROM map_systems WHERE map_id = $3)`, [structureId, systemId, mapId]);
   publishToMap(mapId, { type: 'structure.changed', actor: req.get('x-client-id') ?? null, systemId });
   res.json({ ok: true });
 });

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -10,11 +10,18 @@ export interface Logger {
   error: (msg: string, ...rest: unknown[]) => void;
 }
 
+// Reduce Error args to "Name: message" so log lines never carry full stack
+// traces or other internal error properties (which can include query
+// fragments, tokens, etc.). Non-Error args pass through untouched.
+function safeArg(a: unknown): unknown {
+  return a instanceof Error ? `${a.name}: ${a.message}` : a;
+}
+
 function emit(level: Level, prefix: string, msg: string, rest: unknown[]) {
   const stream = level === 'error' ? console.error
               : level === 'warn'  ? console.warn
               : console.log;
-  stream(`[${prefix}] ${msg}`, ...rest);
+  stream(`[${prefix}] ${msg}`, ...rest.map(safeArg));
 }
 
 export function createLogger(prefix: string): Logger {

--- a/web/public/compare/index.html
+++ b/web/public/compare/index.html
@@ -1283,6 +1283,12 @@
           var DICT = DICTS[lang];
           document.documentElement.lang = lang;
           if (DICT.__title) document.title = DICT.__title;
+          // SECURITY: innerHTML is used because these strings intentionally
+          // contain markup (<a>, <span>, <br>). This is ONLY safe because every
+          // value in DICTS is a hard-coded, trusted literal in this file. Do NOT
+          // ever populate DICTS from user input, a CMS, an API, or URL params —
+          // that would make this a stored/DOM XSS sink. Add new translations as
+          // static literals above; never interpolate untrusted data here.
           document.querySelectorAll('[data-i18n]').forEach(function (el) {
             var key = el.getAttribute('data-i18n');
             if (DICT[key] != null) el.innerHTML = DICT[key];


### PR DESCRIPTION
Addresses the low/info hardening items from the security audit. No critical/high code issues were found; these are defense-in-depth.

- **Session secret fallback (config.ts)** — `SESSION_SECRET` is now required unless `NODE_ENV` is explicitly `development`, so the guessable dev fallback can't silently apply on a real deployment where `NODE_ENV` is merely unset.
- **FRONTEND_URL validation (config.ts)** — fail fast via `URL.canParse` at boot; it builds post-login redirects and seeds the CSRF origin check, so a malformed value shouldn't slip through.
- **Log hygiene (logger.ts)** — `emit()` now reduces `Error` args to `Name: message`, so log lines never carry full stack traces / internal error fields. One central change covers every `log.error('...', err)` site (~39).
- **Explicit map scoping (maps.ts)** — the signature/structure PATCH & DELETE queries now also scope by `map_id`. `verifySystemInMap` already guarantees the system is in the map, but enforcing it in SQL means a future refactor can't open a cross-map write.
- **Compare page innerHTML (compare/index.html)** — kept (the strings intentionally contain markup) but added a prominent SECURITY comment locking in the invariant: DICTS must stay hard-coded literals and never be fed user/CMS/API/URL input.

Note: the audit's scary "secrets committed to git" finding was a **false positive** — `.env` is gitignored and untracked; only `.env.example` is in the repo. Nothing to fix there.

Server + web build clean.