### PR TITLE
Map nodes: fleet/alt headcount badges instead of dots

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1941,12 +1941,24 @@
   margin-right: 4px;
 }
 
-.system-node__fleet-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #c084fc;
-  box-shadow: 0 0 5px #c084fc;
+/* Count badge: how many fleet members are in this system, inside a purple
+   ring. Circular for a single digit, expands to a pill for larger counts
+   (fleets run big). */
+.system-node__fleet-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  border: 1.5px solid #c084fc;
+  background: rgba(192, 132, 252, 0.15);
+  box-shadow: 0 0 5px rgba(192, 132, 252, 0.5);
+  color: #e7d6ff;
+  font-size: calc(10px * var(--font-scale, 1));
+  font-weight: 600;
+  line-height: 1;
   flex-shrink: 0;
   cursor: help;
 }
@@ -1990,12 +2002,22 @@
   align-items: center;
   margin-right: 4px;
 }
-.system-node__alt-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #f5b96a;
-  box-shadow: 0 0 5px #f5b96a;
+/* Count badge: how many of your alts are in this system, inside a gold ring. */
+.system-node__alt-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  border: 1.5px solid #f5b96a;
+  background: rgba(245, 185, 106, 0.15);
+  box-shadow: 0 0 5px rgba(245, 185, 106, 0.5);
+  color: #f5e3c8;
+  font-size: calc(10px * var(--font-scale, 1));
+  font-weight: 600;
+  line-height: 1;
   flex-shrink: 0;
   cursor: help;
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1945,20 +1945,22 @@
    ring. Circular for a single digit, expands to a pill for larger counts
    (fleets run big). */
 .system-node__fleet-count {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
   border-radius: 999px;
   border: 1.5px solid #c084fc;
   background: rgba(192, 132, 252, 0.15);
   box-shadow: 0 0 5px rgba(192, 132, 252, 0.5);
   color: #e7d6ff;
-  font-size: calc(10px * var(--font-scale, 1));
+  font-size: calc(11px * var(--font-scale, 1));
   font-weight: 600;
-  line-height: 1;
+  line-height: 18px;
+  font-variant-numeric: tabular-nums;
   flex-shrink: 0;
   cursor: help;
 }
@@ -2004,20 +2006,22 @@
 }
 /* Count badge: how many of your alts are in this system, inside a gold ring. */
 .system-node__alt-count {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
   border-radius: 999px;
   border: 1.5px solid #f5b96a;
   background: rgba(245, 185, 106, 0.15);
   box-shadow: 0 0 5px rgba(245, 185, 106, 0.5);
   color: #f5e3c8;
-  font-size: calc(10px * var(--font-scale, 1));
+  font-size: calc(11px * var(--font-scale, 1));
   font-weight: 600;
-  line-height: 1;
+  line-height: 18px;
+  font-variant-numeric: tabular-nums;
   flex-shrink: 0;
   cursor: help;
 }

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -215,7 +215,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
         {isCurrent && <span className="system-node__current-dot" />}
         {fleetHere && fleetHere.length > 0 && (
           <span className="system-node__fleet-dot-wrap">
-            <span className="system-node__fleet-dot" />
+            <span className="system-node__fleet-count">{fleetHere.length}</span>
             <span className="system-node__fleet-tooltip">
               {fleetHere.map((m) => (
                 <span key={m.characterId} className="system-node__fleet-tooltip-row">
@@ -227,7 +227,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
         )}
         {accountHere && (
           <span className="system-node__alt-dot-wrap">
-            <span className="system-node__alt-dot" />
+            <span className="system-node__alt-count">{accountHere.length}</span>
             <span className="system-node__alt-tooltip">
               {accountHere.map((c) => (
                 <span key={c.charId} className="system-node__alt-tooltip-row">


### PR DESCRIPTION
On a system node, the fleet and alt presence markers are now **count badges** rather than plain dots: the number of people in that system inside a coloured ring —

- **purple ring** = fleet members in that system,
- **gold ring** = your own alts in that system.

Circular for a single digit, expanding to a pill for larger counts (fleets get big). The hover tooltips listing the actual names are unchanged. CSS-only swap of `.system-node__fleet-dot`/`__alt-dot` for `__fleet-count`/`__alt-count`, plus rendering the `.length` in SystemNode. Web build clean.