### PR TITLE
ops: DB backup + restore scripts + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,3 @@ server/data/*.zip
 .claude/
 
 changes.md
-
-# Local ops scripts kept outside the public OSS distribution.
-scripts/backup-db.sh

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Updating the SDE](#updating-the-sde)
   - [Refreshing wormhole types](#refreshing-wormhole-types)
   - [Upgrading an existing deployment](#upgrading-an-existing-deployment)
+  - [Backup & restore](#backup--restore)
 - [Corp mode](#corp-mode)
   - [Allowing multiple corporations](#allowing-multiple-corporations)
   - [How corp map visibility works](#how-corp-map-visibility-works)
@@ -324,6 +325,27 @@ Pulling a new Nexum release into a running instance:
   ```bash
   docker compose build server && docker compose up -d
   ```
+
+#### Backup & restore
+
+Two scripts under `scripts/` handle the Postgres database for a docker-compose deployment. Both read `PG_USER` / `PG_DB` from your `.env`, so they stay in sync with the running stack. Paths are configurable via env vars (`NEXUM_PROJECT_DIR`, `NEXUM_BACKUP_DIR`, `NEXUM_KEEP`, `NEXUM_FORCE`).
+
+**Backup** — `scripts/backup-db.sh` runs `pg_dump`, gzips it, writes atomically, and prunes to the last `NEXUM_KEEP` (default 7). Safe under cron:
+```bash
+# one-off
+./scripts/backup-db.sh
+# daily at 05:00, as the user that owns the compose project
+0 5 * * *  /opt/eve-nexum/scripts/backup-db.sh >> /var/log/nexum-backup.log 2>&1
+```
+
+**Restore** — `scripts/restore-db.sh` restores a dump (a given file, or the most recent in `NEXUM_BACKUP_DIR`). It's **destructive** (the dumps are `--clean --if-exists`, so it drops & recreates the dumped objects), so it prompts for confirmation and stops the server for the duration:
+```bash
+./scripts/restore-db.sh                                   # newest backup
+./scripts/restore-db.sh /var/backups/nexum/nexum-2026-06-02.sql.gz
+NEXUM_FORCE=1 ./scripts/restore-db.sh <file>              # skip the prompt (cron/automation)
+```
+
+The dump includes the EVE SDE tables (systems, stargates, dogma, …) alongside your user data — simplest and self-contained. The app schema applies on the next server boot and the SDE re-seeds if missing, so a restore heals itself even against a newer build.
 
 ---
 

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Daily Postgres backup for the Nexum docker-compose deployment.
+#
+# Dumps the database via `docker compose exec`, gzips the output, writes it
+# atomically into BACKUP_DIR, and keeps only the most recent KEEP files.
+# Designed to be safe under cron: no TTY, hard fail on errors, log to stdout.
+#
+# Suggested cron entry (run as the user that owns the compose project):
+#
+#   0 5 * * *  /opt/eve-nexum/scripts/backup-db.sh >> /var/log/nexum-backup.log 2>&1
+#
+# All paths are configurable via env vars (defaults shown):
+#
+#   NEXUM_PROJECT_DIR=/opt/eve-nexum     # docker-compose project root
+#   NEXUM_BACKUP_DIR=/var/backups/nexum  # where the .sql.gz files land
+#   NEXUM_KEEP=7                         # number of dumps to retain
+#
+# Restoring from a dump: gunzip -c nexum-YYYY-MM-DD.sql.gz |
+#                          docker compose exec -T postgres psql -U <PG_USER> -d <PG_DB>
+#
+
+set -euo pipefail
+
+PROJECT_DIR="${NEXUM_PROJECT_DIR:-/opt/eve-nexum}"
+BACKUP_DIR="${NEXUM_BACKUP_DIR:-/var/backups/nexum}"
+KEEP="${NEXUM_KEEP:-7}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+if [ ! -d "$PROJECT_DIR" ]; then
+  log "ERROR: project dir not found: $PROJECT_DIR" >&2
+  exit 1
+fi
+cd "$PROJECT_DIR"
+
+if [ ! -f .env ]; then
+  log "ERROR: .env not found in $PROJECT_DIR" >&2
+  exit 1
+fi
+
+# Read PG_USER / PG_DB straight from the deployed .env so this script stays in
+# sync with whatever the running stack is using.
+set -a
+# shellcheck disable=SC1091
+. ./.env
+set +a
+
+: "${PG_USER:?PG_USER not set in .env}"
+: "${PG_DB:?PG_DB not set in .env}"
+
+mkdir -p "$BACKUP_DIR"
+
+# ── Dump ──────────────────────────────────────────────────────────────────────
+STAMP="$(date +%Y-%m-%d)"
+TARGET="$BACKUP_DIR/nexum-$STAMP.sql.gz"
+TEMP="$TARGET.tmp"
+
+log "dumping $PG_DB -> $TARGET"
+
+# -T disables a TTY (cron has no terminal); --clean / --if-exists makes the
+# dump restorable on top of an existing database without manual cleanup;
+# --no-owner / --no-privileges keeps it portable across PG roles. We pipe
+# through gzip on the host, write to a .tmp file, and rename only on success
+# so a partial dump can never overwrite a previous good one.
+if docker compose exec -T postgres pg_dump \
+      --username="$PG_USER" \
+      --dbname="$PG_DB" \
+      --no-owner --no-privileges \
+      --clean --if-exists \
+   | gzip -9 > "$TEMP"; then
+  mv "$TEMP" "$TARGET"
+  log "OK ($(du -h "$TARGET" | cut -f1)): $TARGET"
+else
+  rc=$?
+  rm -f "$TEMP"
+  log "ERROR: pg_dump failed (exit $rc)" >&2
+  exit "$rc"
+fi
+
+# ── Prune old backups ─────────────────────────────────────────────────────────
+# Keep only the most recent $KEEP files matching the strict naming pattern.
+# Count-based rather than mtime-based, and constrained to our own filename
+# pattern so nothing else in BACKUP_DIR could be touched even by accident.
+mapfile -t OLD < <(ls -1t "$BACKUP_DIR"/nexum-*.sql.gz 2>/dev/null | tail -n +"$((KEEP + 1))" || true)
+if [ "${#OLD[@]}" -gt 0 ]; then
+  log "pruning ${#OLD[@]} old backup(s) (keeping $KEEP):"
+  for f in "${OLD[@]}"; do
+    log "  removing $f"
+    rm -f -- "$f"
+  done
+else
+  log "no old backups to prune (keeping $KEEP)"
+fi

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Restore a Nexum Postgres backup produced by backup-db.sh, for the
+# docker-compose deployment.
+#
+# Usage:
+#   scripts/restore-db.sh [BACKUP_FILE]
+#     - with a path: restores that .sql.gz
+#     - with no arg: restores the most recent backup in NEXUM_BACKUP_DIR
+#
+# DESTRUCTIVE: the dumps are written with --clean --if-exists, so a restore
+# drops and recreates the dumped objects, replacing current data. The server
+# container is stopped for the duration so it can't write mid-restore, then
+# started again.
+#
+# All paths are configurable via env vars (defaults shown):
+#
+#   NEXUM_PROJECT_DIR=/opt/eve-nexum     # docker-compose project root
+#   NEXUM_BACKUP_DIR=/var/backups/nexum  # where the .sql.gz files live
+#   NEXUM_FORCE=0                        # set to 1 to skip the confirm prompt
+#
+set -euo pipefail
+
+PROJECT_DIR="${NEXUM_PROJECT_DIR:-/opt/eve-nexum}"
+BACKUP_DIR="${NEXUM_BACKUP_DIR:-/var/backups/nexum}"
+FORCE="${NEXUM_FORCE:-0}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+if [ ! -d "$PROJECT_DIR" ]; then
+  log "ERROR: project dir not found: $PROJECT_DIR" >&2
+  exit 1
+fi
+cd "$PROJECT_DIR"
+
+if [ ! -f .env ]; then
+  log "ERROR: .env not found in $PROJECT_DIR" >&2
+  exit 1
+fi
+
+# Read PG_USER / PG_DB from the deployed .env so this stays in sync with the
+# running stack (same as backup-db.sh).
+set -a
+# shellcheck disable=SC1091
+. ./.env
+set +a
+
+: "${PG_USER:?PG_USER not set in .env}"
+: "${PG_DB:?PG_DB not set in .env}"
+
+# ── Resolve the backup file ───────────────────────────────────────────────────
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  FILE="$(ls -1t "$BACKUP_DIR"/nexum-*.sql.gz 2>/dev/null | head -n1 || true)"
+  if [ -z "$FILE" ]; then
+    log "ERROR: no backups found in $BACKUP_DIR (and no file given)" >&2
+    exit 1
+  fi
+  log "no file given; using most recent: $FILE"
+fi
+if [ ! -f "$FILE" ]; then
+  log "ERROR: backup file not found: $FILE" >&2
+  exit 1
+fi
+
+# ── Confirm (destructive) ─────────────────────────────────────────────────────
+log "About to restore '$FILE' into database '$PG_DB' on this deployment."
+log "This OVERWRITES current data (drops & recreates the dumped objects)."
+if [ "$FORCE" != "1" ]; then
+  read -r -p "Type the database name ('$PG_DB') to confirm: " ans
+  if [ "$ans" != "$PG_DB" ]; then
+    log "aborted"
+    exit 1
+  fi
+fi
+
+# ── Restore ───────────────────────────────────────────────────────────────────
+# Stop the server so it can't read/write a half-applied schema during the
+# restore; bring it back afterwards (even if the restore fails). ON_ERROR_STOP
+# makes psql abort on the first error rather than silently half-applying.
+log "stopping server container"
+docker compose stop server || true
+
+log "restoring (can take a while if the dump includes the SDE tables)..."
+if gunzip -c "$FILE" | docker compose exec -T postgres psql \
+      --username="$PG_USER" \
+      --dbname="$PG_DB" \
+      --set ON_ERROR_STOP=1 \
+      --quiet; then
+  log "restore OK"
+else
+  rc=$?
+  log "ERROR: restore failed (exit $rc)" >&2
+  log "starting server container again"
+  docker compose start server || true
+  exit "$rc"
+fi
+
+log "starting server container"
+docker compose start server
+log "done"


### PR DESCRIPTION
Adds database backup/restore tooling for self-hosted docker-compose deployments.

- **`scripts/restore-db.sh`** (new) — restores a dump (a given file, or the most recent in `NEXUM_BACKUP_DIR`). It's destructive (dumps are `--clean --if-exists`), so it confirms before overwriting, **stops the `server` container** for the duration and restarts it after, and runs `psql` with `ON_ERROR_STOP=1`. `NEXUM_FORCE=1` skips the prompt.
- **`scripts/backup-db.sh`** — was previously gitignored ("kept outside the public OSS distribution"); now shipped so self-hosters get it. Unchanged content (pg_dump → gzip → atomic write → prune to `NEXUM_KEEP`).
- **`.gitignore`** — removed the `scripts/backup-db.sh` ignore (+ its comment).
- **README** — new "Backup & restore" subsection under Installation (+ Contents entry) covering cron, the destructive restore, and that the dump includes the SDE (self-heals on next boot).

Both scripts pass `bash -n`. Note: this **publishes** the formerly-local `backup-db.sh` — done deliberately per request so self-hosters have backup/restore out of the box.