### PR TITLE
Fix: node size snaps to whole grid squares

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2022,8 +2022,8 @@
 }
 
 .system-node {
-  min-width: 150px;
-  min-height: 80px; /* at least 4 snap-grid squares tall */
+  min-width: 160px;  /* 8 snap-grid squares — keep node size a grid multiple */
+  min-height: 80px;  /* 4 snap-grid squares tall */
   background: #111827;
   border: 1.5px solid color-mix(in srgb, var(--class-color) 40%, #1e2740);
   border-radius: 8px;

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -25,6 +25,14 @@ const moveTimers = new Map<string, ReturnType<typeof setTimeout>>();
 // to that height in uniform mode. The width max still considers them so
 // long J-codes / station names participate as expected.
 const nodeSizes = new Map<string, { w: number; h: number; countHeight: boolean }>();
+// Snap-grid size — must match MapCanvas's snapGrid. Uniform node dimensions are
+// rounded UP to whole grid squares so that, with the top-left snapped to the
+// grid, the bottom-right edge lands on a grid line too (nodes tile cleanly and
+// don't finish part-way through a square). Border-box is global, so a min-width
+// of N renders an N-px outer box.
+const GRID = 20;
+const snapUpToGrid = (n: number) => (n > 0 ? Math.ceil(n / GRID) * GRID : 0);
+
 function recomputeUniformMax(): { w: number; h: number } {
   let w = 0, h = 0, hAll = 0;
   let anyHeightEligible = false;
@@ -38,7 +46,7 @@ function recomputeUniformMax(): { w: number; h: number } {
   }
   // Fall back to the global max if every node has statics — without this
   // the height would lock at 0 and the inline minHeight would never apply.
-  return { w, h: anyHeightEligible ? h : hAll };
+  return { w: snapUpToGrid(w), h: snapUpToGrid(anyHeightEligible ? h : hAll) };
 }
 // Debounce map name saves — keyed by mapId so two tabs renaming two different
 // maps don't clobber each other through a shared timer slot.


### PR DESCRIPTION
Nodes were finishing part-way through a grid square (see report) — recent node changes (count badges, etc.) pushed the standardised size off a 20px-grid multiple, so with the top-left snapped to the grid the bottom-right edge fell mid-square.

## Fix
- `recomputeUniformMax` now rounds the uniform width **and** height **up to whole grid squares** (`Math.ceil(n / 20) * 20`). Since `snapGrid` snaps the top-left corner, a grid-multiple size puts the bottom-right on a grid line too — nodes tile cleanly. `box-sizing: border-box` is global, so a `min-width` of N renders an N-px outer box (edges align exactly).
- Base `.system-node min-width` 150 → **160** (8 squares) so the non-uniform/initial floor is also a grid multiple (`min-height` was already 80 = 4 squares).

This applies to the standardised (uniform-size) nodes, which is the default. Web build clean.

Note: with uniform size **off**, nodes are their natural content size and won't all be grid multiples — say the word if you want per-node rounding there too.