### PR TITLE
Fix: centre wh-type/size row on Thera/Turnur cards

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -395,6 +395,7 @@
 
 .scout-row__meta {
   display: flex;
+  align-items: center;
   gap: 8px;
   color: #8a9ab8;
   font-size: calc(13px * var(--font-scale, 1));


### PR DESCRIPTION
On the Thera/Turnur scout cards, the row showing the wormhole type / size / destination signature (`.scout-row__meta`) was `display: flex` with no `align-items` (so `stretch`), and it mixes monospace text (WH code, signature) with the non-monospace size label — leaving the items vertically off-centre. Added `align-items: center`. One-line CSS fix; build clean.