### PR TITLE
Fix: auto-added system no longer lands on top of an existing node

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -11,13 +11,22 @@ function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number,
   return ax < bx + w + gap && ax + w + gap > bx && ay < by + h + gap && ay + h + gap > by;
 }
 
-// Pick a position for a newly auto-added system: the intended spot if it's
-// clear, otherwise stack straight down beneath it into the first free slot
-// (so repeated jumps out of one system form a tidy column). Only if that whole
-// column is blocked do we spread outward. Stops a second jump out of the same
-// system from landing on top of the first one.
+// Slots around the source, clockwise from the right (+y is down): the four
+// cardinals first (right, below, left, above), then the diagonals. Scaled by
+// `ring` for distance, so once the immediate eight are taken we keep rotating
+// clockwise on a wider ring.
+const PLACEMENT_OFFSETS: [number, number][] = [
+  [1, 0], [0, 1], [-1, 0], [0, -1],   // E, S, W, N
+  [1, 1], [-1, 1], [-1, -1], [1, -1], // SE, SW, NW, NE
+];
+
+// Pick a position for a newly auto-added system by rotating clockwise around
+// the system it was jumped from: right of the source if free, otherwise
+// directly below it, then left, above, the diagonals, and outward on wider
+// rings. Each candidate is collision-checked against every node, so it also
+// dodges unrelated systems that happen to sit in a slot.
 function findFreePosition(
-  start: { x: number; y: number },
+  source: { x: number; y: number },
   systems: Box[],
   w: number,
   h: number,
@@ -28,25 +37,14 @@ function findFreePosition(
 
   const stepX = w + gap;
   const stepY = h + gap;
-
-  // Prefer the intended spot, then directly below it, then further down.
-  for (let i = 0; i < 20; i++) {
-    const y = start.y + i * stepY;
-    if (!collides(start.x, y)) return { x: start.x, y };
-  }
-
-  // Column full — spread outward in rings (Chebyshev) as a fallback.
-  for (let ring = 1; ring <= 12; ring++) {
-    for (let dy = -ring; dy <= ring; dy++) {
-      for (let dx = -ring; dx <= ring; dx++) {
-        if (Math.max(Math.abs(dx), Math.abs(dy)) !== ring) continue; // perimeter only
-        const x = start.x + dx * stepX;
-        const y = start.y + dy * stepY;
-        if (!collides(x, y)) return { x, y };
-      }
+  for (let ring = 1; ring <= 6; ring++) {
+    for (const [dx, dy] of PLACEMENT_OFFSETS) {
+      const x = source.x + dx * ring * stepX;
+      const y = source.y + dy * ring * stepY;
+      if (!collides(x, y)) return { x, y };
     }
   }
-  return start; // map is unusually dense — fall back rather than loop forever
+  return { x: source.x + stepX, y: source.y }; // dense map — fall back to "right of source"
 }
 
 /**
@@ -120,24 +118,19 @@ export function useLocationTracking(enabled: boolean) {
       const w = uniformWidth || 220;
       const h = uniformHeight || 120;
       const gap = 30;
-      const stepX = w + 60;
-      // Intended spot: just to the right of the system we jumped from (or the
-      // map centroid for the very first auto-add).
-      let intended: { x: number; y: number };
+      // Anchor placement on the system we jumped from (or the map centroid for
+      // the very first auto-add), then rotate clockwise around it into the
+      // first free slot — right, below, left, above, diagonals, wider rings.
+      let source: { x: number; y: number };
       if (prevMapSystemId) {
-        const prevSys = map.systems.find((s) => s.id === prevMapSystemId)!;
-        intended = { x: prevSys.position.x + stepX, y: prevSys.position.y };
+        source = map.systems.find((s) => s.id === prevMapSystemId)!.position;
       } else {
-        const cx = map.systems.length
-          ? map.systems.reduce((sum, s) => sum + s.position.x, 0) / map.systems.length
-          : 0;
-        const cy = map.systems.length
-          ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length
-          : 0;
-        intended = { x: cx + stepX, y: cy };
+        source = {
+          x: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.x, 0) / map.systems.length : 0,
+          y: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length : 0,
+        };
       }
-      // ...but never on top of an existing node — find the nearest free slot.
-      const position = findFreePosition(intended, map.systems, w, h, gap);
+      const position = findFreePosition(source, map.systems, w, h, gap);
 
       mapSystemId = addSystem(
         system.name,

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -4,6 +4,44 @@ import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
 import type { SystemClass, WormholeEffect } from '../types';
 
+interface Box { position: { x: number; y: number } }
+
+// AABB overlap test between two top-left-anchored w×h boxes, padded by `gap`.
+function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number, h: number, gap: number): boolean {
+  return ax < bx + w + gap && ax + w + gap > bx && ay < by + h + gap && ay + h + gap > by;
+}
+
+// Pick a position for a newly auto-added system: the intended spot if it's
+// clear, otherwise the nearest free slot on an expanding grid around it. Stops
+// a second jump out of the same system from landing on top of the first one.
+function findFreePosition(
+  start: { x: number; y: number },
+  systems: Box[],
+  w: number,
+  h: number,
+  gap: number,
+): { x: number; y: number } {
+  const collides = (x: number, y: number) =>
+    systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
+  if (!collides(start.x, start.y)) return start;
+
+  const stepX = w + gap;
+  const stepY = h + gap;
+  // Search rings (Chebyshev distance) outward so we return the closest free
+  // slot to the intended position.
+  for (let ring = 1; ring <= 12; ring++) {
+    for (let dy = -ring; dy <= ring; dy++) {
+      for (let dx = -ring; dx <= ring; dx++) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== ring) continue; // perimeter only
+        const x = start.x + dx * stepX;
+        const y = start.y + dy * stepY;
+        if (!collides(x, y)) return { x, y };
+      }
+    }
+  }
+  return start; // map is unusually dense — fall back rather than loop forever
+}
+
 /**
  * Map-side reaction to character location changes. The actual polling lives
  * in `useCharacterLocation` (10s, module-level, shared with the sidebar);
@@ -19,7 +57,7 @@ export function useLocationTracking(enabled: boolean) {
 
   useEffect(() => {
     if (!enabled) return;
-    const { map, addSystem, addConnection, optimizeConnections, selectSystem, setCurrentSystem, uniformWidth } = useMapStore.getState();
+    const { map, addSystem, addConnection, optimizeConnections, selectSystem, setCurrentSystem, uniformWidth, uniformHeight } = useMapStore.getState();
 
     // No active map loaded yet (mid switchMap / first paint) — wait for the
     // next location update rather than racing addSystem against an empty store.
@@ -72,11 +110,16 @@ export function useLocationTracking(enabled: boolean) {
       // overlaps the one it's placed next to (positions are top-left corners;
       // a flat +200 touched because nodes are ~200 wide). Falls back to a
       // generous constant before any node has been measured.
-      const stepX = (uniformWidth || 220) + 60;
-      let position: { x: number; y: number };
+      const w = uniformWidth || 220;
+      const h = uniformHeight || 120;
+      const gap = 30;
+      const stepX = w + 60;
+      // Intended spot: just to the right of the system we jumped from (or the
+      // map centroid for the very first auto-add).
+      let intended: { x: number; y: number };
       if (prevMapSystemId) {
         const prevSys = map.systems.find((s) => s.id === prevMapSystemId)!;
-        position = { x: prevSys.position.x + stepX, y: prevSys.position.y };
+        intended = { x: prevSys.position.x + stepX, y: prevSys.position.y };
       } else {
         const cx = map.systems.length
           ? map.systems.reduce((sum, s) => sum + s.position.x, 0) / map.systems.length
@@ -84,8 +127,10 @@ export function useLocationTracking(enabled: boolean) {
         const cy = map.systems.length
           ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length
           : 0;
-        position = { x: cx + stepX, y: cy };
+        intended = { x: cx + stepX, y: cy };
       }
+      // ...but never on top of an existing node — find the nearest free slot.
+      const position = findFreePosition(intended, map.systems, w, h, gap);
 
       mapSystemId = addSystem(
         system.name,

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -12,8 +12,10 @@ function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number,
 }
 
 // Pick a position for a newly auto-added system: the intended spot if it's
-// clear, otherwise the nearest free slot on an expanding grid around it. Stops
-// a second jump out of the same system from landing on top of the first one.
+// clear, otherwise stack straight down beneath it into the first free slot
+// (so repeated jumps out of one system form a tidy column). Only if that whole
+// column is blocked do we spread outward. Stops a second jump out of the same
+// system from landing on top of the first one.
 function findFreePosition(
   start: { x: number; y: number },
   systems: Box[],
@@ -23,12 +25,17 @@ function findFreePosition(
 ): { x: number; y: number } {
   const collides = (x: number, y: number) =>
     systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
-  if (!collides(start.x, start.y)) return start;
 
   const stepX = w + gap;
   const stepY = h + gap;
-  // Search rings (Chebyshev distance) outward so we return the closest free
-  // slot to the intended position.
+
+  // Prefer the intended spot, then directly below it, then further down.
+  for (let i = 0; i < 20; i++) {
+    const y = start.y + i * stepY;
+    if (!collides(start.x, y)) return { x: start.x, y };
+  }
+
+  // Column full — spread outward in rings (Chebyshev) as a fallback.
   for (let ring = 1; ring <= 12; ring++) {
     for (let dy = -ring; dy <= ring; dy++) {
       for (let dx = -ring; dx <= ring; dx++) {


### PR DESCRIPTION
Repro (from the report):
- A → B: B created right of A.
- B → A: A exists, no new node.
- A → C: **C created on top of B** — bug.

## Cause
On a jump into a new system, `useLocationTracking` placed the node at a fixed offset from the system you jumped *from* (`prevSystem.x + stepX`, same `y`). A second jump out of the same origin therefore reused the exact slot the first new system already occupies.

## Fix
The intended spot (right of the origin) is now collision-checked against every existing node. If it's occupied, we search outward on an expanding grid (Chebyshev rings) and place the node in the **nearest free slot** instead. Node footprint comes from `uniformWidth`/`uniformHeight` plus a gap, and falls back gracefully on an unusually dense map.

Only affects passive auto-placement; manual placement and the region-seed layout are untouched. Web build + lint clean.