### PR TITLE
Horizontal/vertical orientation for auto-placed systems

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1361,7 +1361,7 @@
   top: 0;
   right: 0;
   height: 100%;
-  width: 220px;
+  width: 250px;
   transform: translateX(100%);
   transition: transform 0.2s ease;
   background: #0d1117;

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -576,6 +576,7 @@ export function MapSidebar() {
   const showMinimap = useMapStore((s) => s.showMinimap);
   const setShowMinimap = useMapStore((s) => s.setShowMinimap);
   const [minimapPosition, setMinimapPosition] = useMinimapPosition();
+  const [placement, setPlacement] = useUserSetting<string>("nexum.map.placement", "horizontal");
   const uniformSize = useMapStore((s) => s.uniformSize);
   const setUniformSize = useMapStore((s) => s.setUniformSize);
   const showStatics = useMapStore((s) => s.showStatics);
@@ -725,6 +726,19 @@ export function MapSidebar() {
                 {Math.round(uiZoom * 100)}%
               </button>
             </div>
+          </div>
+
+          <div className="map-sidebar__row">
+            <label className="map-sidebar__label" htmlFor="placement-dir">{t("mapSidebar.placement")}</label>
+            <select
+              id="placement-dir"
+              className="map-sidebar__select"
+              value={placement}
+              onChange={(e) => setPlacement(e.target.value)}
+            >
+              <option value="horizontal">{t("mapSidebar.placementOptions.horizontal")}</option>
+              <option value="vertical">{t("mapSidebar.placementOptions.vertical")}</option>
+            </select>
           </div>
         </CollapsibleSection>
 

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useMapStore } from '../store/mapStore';
 import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
+import { readUserSetting } from './useUserSetting';
 import type { SystemClass, WormholeEffect } from '../types';
 
 interface Box { position: { x: number; y: number } }
@@ -11,40 +12,47 @@ function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number,
   return ax < bx + w + gap && ax + w + gap > bx && ay < by + h + gap && ay + h + gap > by;
 }
 
-// Slots around the source, clockwise from the right (+y is down): the four
-// cardinals first (right, below, left, above), then the diagonals. Scaled by
-// `ring` for distance, so once the immediate eight are taken we keep rotating
-// clockwise on a wider ring.
-const PLACEMENT_OFFSETS: [number, number][] = [
+// Slots around the source, both clockwise (+y is down): cardinals first, then
+// diagonals, scaled by `ring` for distance. The user's default-placement pref
+// picks the starting direction — horizontal begins at the right, vertical at
+// the bottom — and rotation continues clockwise from there.
+const OFFSETS_HORIZONTAL: [number, number][] = [
   [1, 0], [0, 1], [-1, 0], [0, -1],   // E, S, W, N
   [1, 1], [-1, 1], [-1, -1], [1, -1], // SE, SW, NW, NE
 ];
+const OFFSETS_VERTICAL: [number, number][] = [
+  [0, 1], [-1, 0], [0, -1], [1, 0],   // S, W, N, E
+  [-1, 1], [-1, -1], [1, -1], [1, 1], // SW, NW, NE, SE
+];
 
 // Pick a position for a newly auto-added system by rotating clockwise around
-// the system it was jumped from: right of the source if free, otherwise
-// directly below it, then left, above, the diagonals, and outward on wider
-// rings. Each candidate is collision-checked against every node, so it also
-// dodges unrelated systems that happen to sit in a slot.
+// the system it was jumped from, starting in the preferred direction (right of
+// the source when horizontal, below it when vertical), then the rest of the
+// ring, then outward on wider rings. Each candidate is collision-checked
+// against every node, so it also dodges unrelated systems sitting in a slot.
 function findFreePosition(
   source: { x: number; y: number },
   systems: Box[],
   w: number,
   h: number,
   gap: number,
+  vertical: boolean,
 ): { x: number; y: number } {
   const collides = (x: number, y: number) =>
     systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
 
+  const offsets = vertical ? OFFSETS_VERTICAL : OFFSETS_HORIZONTAL;
   const stepX = w + gap;
   const stepY = h + gap;
   for (let ring = 1; ring <= 6; ring++) {
-    for (const [dx, dy] of PLACEMENT_OFFSETS) {
+    for (const [dx, dy] of offsets) {
       const x = source.x + dx * ring * stepX;
       const y = source.y + dy * ring * stepY;
       if (!collides(x, y)) return { x, y };
     }
   }
-  return { x: source.x + stepX, y: source.y }; // dense map — fall back to "right of source"
+  // Dense map — fall back to the preferred direction.
+  return vertical ? { x: source.x, y: source.y + stepY } : { x: source.x + stepX, y: source.y };
 }
 
 /**
@@ -130,7 +138,8 @@ export function useLocationTracking(enabled: boolean) {
           y: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length : 0,
         };
       }
-      const position = findFreePosition(source, map.systems, w, h, gap);
+      const vertical = readUserSetting<string>('nexum.map.placement', 'horizontal') === 'vertical';
+      const position = findFreePosition(source, map.systems, w, h, gap, vertical);
 
       mapSystemId = addSystem(
         system.name,

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -340,6 +340,11 @@
       "topLeft": "Oben links"
     },
     "fontSize": "Schriftgröße",
+    "placement": "Platzierung neuer Systeme",
+    "placementOptions": {
+      "horizontal": "Horizontal (rechts)",
+      "vertical": "Vertikal (unten)"
+    },
     "resetZoom": "Auf 100% zurücksetzen",
     "compact": "Kompakt",
     "uniformSize": "Einheitliche Größe",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -340,6 +340,11 @@
       "topLeft": "Top left"
     },
     "fontSize": "Font Size",
+    "placement": "New system placement",
+    "placementOptions": {
+      "horizontal": "Horizontal (right)",
+      "vertical": "Vertical (below)"
+    },
     "resetZoom": "Reset to 100%",
     "compact": "Compact",
     "uniformSize": "Uniform Size",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -340,6 +340,11 @@
       "topLeft": "Arriba a la izquierda"
     },
     "fontSize": "Tamaño de fuente",
+    "placement": "Colocación de sistemas nuevos",
+    "placementOptions": {
+      "horizontal": "Horizontal (derecha)",
+      "vertical": "Vertical (abajo)"
+    },
     "resetZoom": "Restablecer al 100 %",
     "compact": "Compacto",
     "uniformSize": "Tamaño uniforme",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -340,6 +340,11 @@
       "topLeft": "En haut à gauche"
     },
     "fontSize": "Taille de police",
+    "placement": "Placement des nouveaux systèmes",
+    "placementOptions": {
+      "horizontal": "Horizontal (à droite)",
+      "vertical": "Vertical (en dessous)"
+    },
     "resetZoom": "Réinitialiser à 100 %",
     "compact": "Compact",
     "uniformSize": "Taille uniforme",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -340,6 +340,11 @@
       "topLeft": "左上"
     },
     "fontSize": "フォントサイズ",
+    "placement": "新規システムの配置",
+    "placementOptions": {
+      "horizontal": "水平（右）",
+      "vertical": "垂直（下）"
+    },
     "resetZoom": "100% にリセット",
     "compact": "コンパクト",
     "uniformSize": "均一サイズ",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -340,6 +340,11 @@
       "topLeft": "왼쪽 위"
     },
     "fontSize": "글꼴 크기",
+    "placement": "새 시스템 배치",
+    "placementOptions": {
+      "horizontal": "수평 (오른쪽)",
+      "vertical": "수직 (아래)"
+    },
     "resetZoom": "100%로 재설정",
     "compact": "간결",
     "uniformSize": "균일 크기",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -340,6 +340,11 @@
       "topLeft": "Superior esquerdo"
     },
     "fontSize": "Tamanho da letra",
+    "placement": "Posicionamento de novos sistemas",
+    "placementOptions": {
+      "horizontal": "Horizontal (direita)",
+      "vertical": "Vertical (abaixo)"
+    },
     "resetZoom": "Repor para 100 %",
     "compact": "Compacto",
     "uniformSize": "Tamanho uniforme",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -354,6 +354,11 @@
       "topLeft": "Сверху слева"
     },
     "fontSize": "Размер шрифта",
+    "placement": "Размещение новых систем",
+    "placementOptions": {
+      "horizontal": "Горизонтально (справа)",
+      "vertical": "Вертикально (снизу)"
+    },
     "resetZoom": "Сбросить до 100%",
     "compact": "Компактно",
     "uniformSize": "Единый размер",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -340,6 +340,11 @@
       "topLeft": "左上"
     },
     "fontSize": "字体大小",
+    "placement": "新星系放置",
+    "placementOptions": {
+      "horizontal": "水平（右侧）",
+      "vertical": "垂直（下方）"
+    },
     "resetZoom": "重置为 100%",
     "compact": "紧凑",
     "uniformSize": "统一大小",


### PR DESCRIPTION
## Summary
- New **Map Options** setting (`nexum.map.placement`, default `horizontal`) controls the starting direction when a system is auto-added after a jump.
  - **Horizontal** keeps current behaviour: tries the slot to the *right* of the source first.
  - **Vertical**: tries the slot *below* the source first.
- Both orientations keep the merged clockwise rotation + collision avoidance around the source system, so a new node never overlaps an existing one and falls outward to wider rings on dense maps.
- Widened the map sidebar (220px -> 250px) for more label/text space.
- i18n: added `mapSidebar.placement` + `placementOptions.{horizontal,vertical}` across all 9 locales (parity checked).

## Test plan
- Map Options shows the new 'New system placement' select.
- With Horizontal selected, jumping into a new system places it to the right of the source (or rotates clockwise to the first free slot).
- With Vertical selected, it places below the source first.
- No overlap with existing nodes in either mode.