### PR TITLE
Add Google Tag Manager to the web app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-NXX5CRPH');</script>
+    <!-- End Google Tag Manager -->
+
     <title>Nexum — EVE Online Wormhole Mapper (open-source Pathfinder/Tripwire alternative)</title>
     <meta name="description" content="Nexum is a free, open-source, self-hosted wormhole mapping tool for EVE Online — a Pathfinder and Tripwire alternative. Map your chain in real time, manage signatures, track kills and jumps, plan wormhole rolls, and coordinate with your corp and fleet." />
     <meta name="keywords" content="EVE Online, wormhole mapper, wormhole mapping, chain mapping, EVE mapper, wormhole tool, J-space, Pathfinder alternative, Tripwire alternative, self-hosted, open source, EVE Online tools" />
@@ -119,6 +127,11 @@
     </style>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXX5CRPH"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <div id="root">
       <!-- Static fallback: first paint for users, and the content crawlers / AI
            bots (which don't run JavaScript) read. The React app replaces this. -->


### PR DESCRIPTION
Adds the Google Tag Manager container (`GTM-NXX5CRPH`) to the SPA per Google's standard two-part install:

- The GTM `<script>` loader high in the `<head>` of `web/index.html`.
- The matching `<noscript>` iframe immediately after `<body>`.

Verified the snippet is present in the built `dist/index.html` after `yarn build`.

> Note: the container ID is hardcoded, so anyone self-hosting Nexum from this repo will load this GTM container. If that becomes a concern, it can later be moved behind a `VITE_GTM_ID` build arg so it only loads when explicitly set.