### PR TITLE
GTM login event + CSP fix for Google Analytics

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -311,7 +311,9 @@ authRouter.get('/callback', async (req, res) => {
     });
 
     kickStandings();
-    res.redirect(FRONTEND_URL);
+    // ?login=success lets the frontend fire a one-time analytics "login" event
+    // (it's only present on the post-callback redirect, not on normal loads).
+    res.redirect(`${FRONTEND_URL}?login=success`);
   } catch (err) {
     log.error('Auth callback error:', err);
     res.status(500).json({ error: 'Authentication failed' });

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -12,14 +12,20 @@ server {
     #
     # CSP: locked down for the SPA. img-src needs the EVE image server
     # (portraits + corp/alliance logos). style-src needs 'unsafe-inline'
-    # because React's `style` prop emits inline styles; we don't use
-    # inline <script>, so script-src stays strict. connect-src allows
+    # because React's `style` prop emits inline styles. connect-src allows
     # 'self' (most external APIs are proxied through /api) plus
     # esi.evetech.net, which the SPA fetches directly from the browser
     # for TQ server status, system/sov data, NPC stations and entity
     # name resolution (Toolbar, useEsiSystem, useSovData, NpcStationsPane,
     # esiEntities). Without it those calls are blocked in production.
-    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: https://images.evetech.net; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://esi.evetech.net; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    #
+    # Google Tag Manager / Analytics (GTM-NXX5CRPH -> GA4): GTM ships an
+    # inline bootstrap <script> and injects more scripts at runtime, so
+    # script-src needs 'unsafe-inline' + googletagmanager.com. GA4 sends
+    # hits to *.google-analytics.com (connect + img beacons), and the GTM
+    # noscript fallback frames googletagmanager.com. This deliberately
+    # loosens the formerly-strict script-src — the price of running GTM.
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: https://images.evetech.net https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://esi.evetech.net https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; font-src 'self' data:; frame-src https://www.googletagmanager.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
 
     # Clickjacking + MIME-sniff defenses. frame-ancestors above is the
     # modern equivalent of X-Frame-Options, but legacy browsers still

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,13 +119,24 @@ function AppShell() {
     const params = new URLSearchParams(window.location.search);
     const added = params.get('added');
     const linkError = params.get('link_error');
-    if (!added && !linkError) return;
+    // The server adds ?login=success only on the redirect right after a real
+    // EVE SSO login — so this fires once per login, not on every page load.
+    const loggedIn = params.get('login') === 'success';
+    if (!added && !linkError && !loggedIn) return;
     // Strip the params synchronously so a refresh — or StrictMode's dev
-    // re-run of this effect — doesn't repeat the toast.
+    // re-run of this effect — doesn't repeat the toast / re-fire analytics.
     const url = new URL(window.location.href);
     url.searchParams.delete('added');
     url.searchParams.delete('link_error');
+    url.searchParams.delete('login');
     window.history.replaceState({}, '', url.toString());
+
+    // Push a GTM "login" event so a tag can record the sign-in. dataLayer is
+    // created by the GTM snippet in index.html; guard in case it's absent.
+    if (loggedIn) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ event: 'login', method: 'eve_sso' });
+    }
     // Emit on a macrotask so the Toaster (a sibling) has subscribed before we
     // notify, and deliberately do NOT clear it on cleanup — otherwise
     // StrictMode's mount/unmount/remount would cancel it and nothing shows.

--- a/web/src/gtm.d.ts
+++ b/web/src/gtm.d.ts
@@ -1,0 +1,10 @@
+// Google Tag Manager's dataLayer queue, created by the GTM snippet in
+// index.html. We push app events (e.g. { event: 'login' }) onto it for tags
+// configured in the GTM UI to react to.
+export {};
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+  }
+}


### PR DESCRIPTION
Follow-up to #145 (which only contained the GTM snippet). These two commits were pushed to the branch after #145 was merged, so they need their own PR.

### 1. Track a `login` event on EVE SSO sign-in
- The fresh-login callback now redirects with `?login=success`; the frontend reads it once (then strips it) and pushes `dataLayer.push({ event: 'login', method: 'eve_sso' })` so a GTM tag can record the sign-in. Fires only on a real login, not on every page load.

### 2. Relax CSP so GTM + GA4 can actually run
- The strict `script-src 'self'` blocked GTM's inline bootstrap, so the container never initialised and Tag Assistant couldn't connect ("Couldn't connect... no debuggable Google tags").
- `script-src` now allows `'unsafe-inline'` + `googletagmanager.com`; GA4 collection endpoints added to `connect-src`/`img-src`; `frame-src` allows `googletagmanager.com` for the noscript fallback.
- **This loosens the previously-strict script-src** (re-allows inline scripts) — the deliberate cost of running GTM on the page.

### Deploy note
The CSP lives in the nginx config baked into the web image, so a rebuild is required: `docker compose build web && docker compose up -d` (with the Traefik overlay), then hard-refresh.