### PR TITLE
Don't track self-hosters: gate GTM + opt-in telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,23 @@ CORP_MAP_SHARED=false
 # DISCORD_WEBHOOK_URL=
 
 
+# ── Analytics & telemetry ─────────────────────────────────────────────────────
+# Both are OFF by default. A self-hosted instance phones home to no one unless
+# you explicitly opt in here.
+
+# Optional Google Tag Manager container ID for the WEB build (e.g. GTM-XXXXXXX).
+# Unset => the frontend ships with no analytics at all. Only set it to measure
+# YOUR OWN deployment; never use a container ID you don't own. Consumed as a
+# Docker build arg, so rebuild the web image after changing it.
+# VITE_GTM_ID=
+
+# Opt-in anonymous deployment ping. When enabled, the server sends a tiny daily
+# request containing ONLY the app version and a random per-instance id — no user
+# data, no map data, no IP is stored by the receiver. It just lets the project
+# count active self-hosted installs and which versions are in the wild.
+# NEXUM_TELEMETRY=1
+# Override where the ping goes (defaults to the project's collector). Point it
+# at your own collector, or leave unset.
+# NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
+
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [What happens when a user leaves the corp](#what-happens-when-a-user-leaves-the-corp)
   - [Discord notifications](#discord-notifications)
   - [Admin operations](#admin-operations)
+- [Analytics & telemetry](#analytics--telemetry)
 - [Static data files](#static-data-files)
 - [Technology overview](#technology-overview)
 - [Troubleshooting](#troubleshooting)
@@ -540,6 +541,42 @@ Each tab is also reachable at its own hash route (`#/admin/maps`, `#/admin/audit
 - Demote themselves (use another admin).
 - Demote or block the character whose ID is in `ADMIN_CHAR_ID` — that character is the safety hatch.
 - Force-terminate an existing live session. A blocked user stays signed in until they log out or their session cookie expires; the next login then fails. If you need someone offline *right now*, blocking + revoking their EVE OAuth in CCP's developer panel is the immediate path.
+
+---
+
+## Analytics & telemetry
+
+**By default a self-hosted Nexum reports to no one.** No analytics, no tracking, no phone-home. Both of the following are off until *you* turn them on, and neither sends any user, character, or map data.
+
+### Frontend analytics (Google Tag Manager) — off by default
+
+The web build only loads Google Tag Manager if you provide a container ID at build time via `VITE_GTM_ID`. Leave it unset (the default) and the built site contains no analytics whatsoever — no GTM, no Google Analytics, nothing.
+
+To enable it **for your own deployment**, set your own container ID in `.env` and rebuild the web image:
+
+```bash
+VITE_GTM_ID=GTM-XXXXXXX        # in .env
+docker compose build web && docker compose up -d
+```
+
+Only ever use a container ID you own. The ID is inlined at build time, so a rebuild is required to change it.
+
+### Deployment telemetry (version ping) — opt-in
+
+So the project can gauge how many people self-host and which versions are live, the server can send a tiny **opt-in** ping. It is **off unless you set `NEXUM_TELEMETRY=1`**, and when enabled it sends, once a day:
+
+- the app **version** (e.g. `0.1.0`)
+- a **random per-instance id** (generated once, stored locally), so repeat pings count as one install
+
+That's the entire payload. It contains **no** user data, character names, corp IDs, map data, or settings, and the receiver **does not store your IP**. To enable it:
+
+```bash
+NEXUM_TELEMETRY=1                                  # in .env
+# optional: send to your own collector instead of the project's
+# NEXUM_TELEMETRY_URL=https://your-host/api/telemetry
+```
+
+Unset `NEXUM_TELEMETRY` (the default) and the server never makes the call. The receiving endpoint (`POST /api/telemetry`) exists on every deployment but stays empty unless instances are pointed at it.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,11 @@ services:
     build:
       context: ./web
       dockerfile: Dockerfile
+      args:
+        # Optional GTM container ID baked into the build. Unset => no analytics
+        # (the default for self-hosters). Set VITE_GTM_ID in .env to enable it
+        # for your own deployment only.
+        VITE_GTM_ID: ${VITE_GTM_ID:-}
     restart: unless-stopped
     environment:
       # Tells nginx which port to proxy /api/* and /auth/* to inside the

--- a/server/.env.example
+++ b/server/.env.example
@@ -81,4 +81,14 @@ CORP_MAP_SHARED=false
 #       DISCORD_WEBHOOK_URL=98000001=https://discord.com/api/webhooks/1/a,98000002=https://discord.com/api/webhooks/2/b
 # DISCORD_WEBHOOK_URL=
 
+# ── Telemetry ─────────────────────────────────────────────────────────────────
+# Opt-in anonymous deployment ping. OFF unless set. When enabled the server
+# sends a tiny daily request with ONLY the app version and a random per-instance
+# id — no user data, no map data, and the receiver stores no IP. It just lets
+# the project count active self-hosted installs and versions in the wild.
+# NEXUM_TELEMETRY=1
+# Override the collector URL (defaults to the project's). Point at your own, or
+# leave unset.
+# NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
+
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -103,6 +103,13 @@ const tokenEncryptionKey = HEX_64.test(TOKEN_ENC_RAW)
   ? TOKEN_ENC_RAW.toLowerCase()
   : createHash('sha256').update(TOKEN_ENC_RAW).digest('hex');
 
+// Opt-in anonymous deployment ping. OFF by default — a self-hosted instance
+// phones home to nobody unless the operator sets NEXUM_TELEMETRY=1. When on,
+// the server sends only { version, instanceId } once a day so the project can
+// count active installs. NEXUM_TELEMETRY_URL overrides the collector endpoint.
+const TELEMETRY_ENABLED = /^(1|true|yes|on)$/i.test(process.env.NEXUM_TELEMETRY ?? '');
+const TELEMETRY_URL = process.env.NEXUM_TELEMETRY_URL?.trim() || 'https://eve-nexum.com/api/telemetry';
+
 export const config = {
   corpMode:            CORP_IDS.length > 0,
   corpIds:             CORP_IDS,
@@ -120,6 +127,7 @@ export const config = {
   discord:             DISCORD_WEBHOOKS,
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
+  telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },
   sessionSecret:       process.env.SESSION_SECRET ?? 'dev-secret-change-me',
   tokenEncryptionKey,
   isProd,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,8 @@ import wormholesRouter    from './routes/wormholes.js';
 import { loadRouteGraph } from './services/routeGraph.js';
 import { startSdeAutoUpdate } from './services/sdeUpdate.js';
 import { startLocationPoller } from './services/locationPoll.js';
+import { startTelemetry } from './services/telemetry.js';
+import { telemetryRouter } from './routes/telemetry.js';
 import { adminRouter, adminReadRouter, reportsRouter } from './routes/admin.js';
 import { standingsRouter } from './routes/standings.js';
 import { shareRouter } from './routes/share.js';
@@ -94,6 +96,7 @@ app.use(['/auth/login', '/auth/callback', '/auth/add-character'], authLimiter);
 app.use('/auth', appLimiter, authRouter);
 app.use('/api/systems', publicLimiter, systemsRouter);
 app.use('/api/sde', publicLimiter, sdeRouter);
+app.use('/api/telemetry', publicLimiter, telemetryRouter);
 app.use('/api/regions', appLimiter, regionsRouter);
 app.use('/api/maps', appLimiter, mapsRouter);
 // Public read-only share endpoint — no auth, validates the share_token
@@ -154,5 +157,6 @@ migrate()
     app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));
     startSdeAutoUpdate();
     startLocationPoller();
+    void startTelemetry();
   })
   .catch((err) => { console.error('Migration failed:', err); process.exit(1); });

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -259,6 +259,18 @@ export async function migrate() {
     ALTER TABLE IF EXISTS solar_systems ADD COLUMN IF NOT EXISTS belt_count     INTEGER;
     ALTER TABLE IF EXISTS solar_systems ADD COLUMN IF NOT EXISTS stargate_count INTEGER;
 
+    -- Opt-in anonymous deployment pings (NEXUM_TELEMETRY). One row per install,
+    -- keyed by a random per-instance id; stores only the app version and seen
+    -- timestamps — deliberately NO IP and no user/map data. On most installs
+    -- this stays empty; only the project's central collector receives pings.
+    CREATE TABLE IF NOT EXISTS telemetry_pings (
+      instance_id TEXT        PRIMARY KEY,
+      version     TEXT,
+      first_seen  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      ping_count  INTEGER     NOT NULL DEFAULT 1
+    );
+
     CREATE TABLE IF NOT EXISTS user_events (
       id          BIGSERIAL   PRIMARY KEY,
       user_id     INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/server/src/routes/telemetry.ts
+++ b/server/src/routes/telemetry.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import { db } from '../db.js';
+import { createLogger } from '../utils/logger.js';
+
+export const telemetryRouter = Router();
+const log = createLogger('telemetry');
+
+// POST /api/telemetry — receive an opt-in anonymous deployment ping from a
+// self-hosted instance: { version, instanceId }. We store ONLY those two
+// fields (deliberately no IP, no user/map data) and upsert so repeated pings
+// from the same install collapse to one row with a refreshed last_seen.
+//
+// This endpoint exists on every deployment but stays empty on all but the
+// project's central collector — only instances that opted in (and point at
+// this host) ever send anything.
+telemetryRouter.post('/', async (req, res) => {
+  const body = (req.body ?? {}) as { version?: unknown; instanceId?: unknown };
+  const instanceId = typeof body.instanceId === 'string' ? body.instanceId.trim() : '';
+  const version    = typeof body.version === 'string' ? body.version.trim().slice(0, 32) : '';
+
+  // instanceId must look like the randomUUID the sender generates — cheap
+  // guard against junk / spam writes.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(instanceId)) {
+    return res.status(400).json({ error: 'bad instanceId' });
+  }
+
+  try {
+    await db.query(
+      `INSERT INTO telemetry_pings (instance_id, version, first_seen, last_seen, ping_count)
+         VALUES ($1, $2, NOW(), NOW(), 1)
+       ON CONFLICT (instance_id) DO UPDATE
+         SET version    = EXCLUDED.version,
+             last_seen  = NOW(),
+             ping_count = telemetry_pings.ping_count + 1`,
+      [instanceId, version || null],
+    );
+    return res.status(204).end();
+  } catch (err) {
+    log.error('store failed:', err);
+    return res.status(500).json({ error: 'store failed' });
+  }
+});

--- a/server/src/services/telemetry.ts
+++ b/server/src/services/telemetry.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { db } from '../db.js';
+import { config } from '../config.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('telemetry');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const INSTANCE_KEY = 'telemetry_instance_id';
+
+// App version, read from package.json relative to the process working dir
+// (/app in Docker, server/ in dev — both have package.json at the cwd root).
+function appVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+// A stable, random, anonymous id for this install — generated once and kept in
+// sde_meta. Lets the collector count unique instances without ever needing an
+// IP or anything identifying.
+async function getInstanceId(): Promise<string> {
+  const existing = await db.query<{ value: string }>(
+    `SELECT value FROM sde_meta WHERE key = $1`, [INSTANCE_KEY],
+  );
+  if (existing.rows[0]?.value) return existing.rows[0].value;
+
+  await db.query(
+    `INSERT INTO sde_meta (key, value, updated_at) VALUES ($1, $2, NOW())
+       ON CONFLICT (key) DO NOTHING`,
+    [INSTANCE_KEY, randomUUID()],
+  );
+  // Re-read so a concurrent boot that won the insert still gives us its id.
+  const settled = await db.query<{ value: string }>(
+    `SELECT value FROM sde_meta WHERE key = $1`, [INSTANCE_KEY],
+  );
+  return settled.rows[0]?.value ?? randomUUID();
+}
+
+async function sendPing(instanceId: string): Promise<void> {
+  try {
+    const res = await fetch(config.telemetry.url, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ version: appVersion(), instanceId }),
+      signal:  AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) log.warn(`ping rejected (status ${res.status})`);
+  } catch (err) {
+    // Offline / collector down / DNS — all non-fatal and expected.
+    log.warn('ping failed:', err instanceof Error ? err.message : String(err));
+  }
+}
+
+/**
+ * Opt-in anonymous deployment ping (NEXUM_TELEMETRY). Sends only the app
+ * version + a random per-instance id, now and once a day after. No-op unless
+ * the operator opted in. Wrapped so a failure here never affects boot.
+ */
+export async function startTelemetry(): Promise<void> {
+  if (!config.telemetry.enabled) return;
+  try {
+    log.info(
+      `anonymous telemetry enabled — sending { version, instanceId } to ${config.telemetry.url} ` +
+      `once a day (disable by unsetting NEXUM_TELEMETRY)`,
+    );
+    const instanceId = await getInstanceId();
+    await sendPing(instanceId);
+    setInterval(() => { void sendPing(instanceId); }, DAY_MS);
+  } catch (err) {
+    log.warn('telemetry init failed:', err instanceof Error ? err.message : String(err));
+  }
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,9 @@
 # Override the API server URL for the Vite dev proxy
 # Docker: http://server:3001  |  Local: http://localhost:3001
 API_TARGET=http://localhost:3001
+
+# Optional Google Tag Manager container ID (e.g. GTM-XXXXXXX). Leave UNSET to
+# build with no analytics at all — that's the default and the right choice for
+# a self-hosted instance. Only set it to track your OWN deployment; never point
+# it at a container you don't own. Inlined into the build by vite.config.ts.
+# VITE_GTM_ID=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 COPY . .
+# Optional Google Tag Manager container ID. Unset (the default) => no analytics
+# is baked into the build, so self-hosters report nothing. Our deployment passes
+# it as a build arg. Must be set before `yarn build` since Vite inlines it.
+ARG VITE_GTM_ID=
+ENV VITE_GTM_ID=$VITE_GTM_ID
 RUN yarn build
 
 FROM nginx:alpine

--- a/web/index.html
+++ b/web/index.html
@@ -4,13 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NXX5CRPH');</script>
-    <!-- End Google Tag Manager -->
+    <!-- Google Tag Manager is injected at build time by vite.config.ts, and
+         ONLY when VITE_GTM_ID is set. Self-hosters get no analytics unless
+         they configure their own container, so this deployment never reports
+         anyone else's instance. -->
 
     <title>Nexum — EVE Online Wormhole Mapper (open-source Pathfinder/Tripwire alternative)</title>
     <meta name="description" content="Nexum is a free, open-source, self-hosted wormhole mapping tool for EVE Online — a Pathfinder and Tripwire alternative. Map your chain in real time, manage signatures, track kills and jumps, plan wormhole rolls, and coordinate with your corp and fleet." />
@@ -127,11 +124,6 @@
     </style>
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXX5CRPH"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-
     <div id="root">
       <!-- Static fallback: first paint for users, and the content crawlers / AI
            bots (which don't run JavaScript) read. The React app replaces this. -->

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,19 +1,58 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv, type PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5174,
-    proxy: {
-      '/api': {
-        target: process.env.API_TARGET ?? 'http://localhost:3001',
-        changeOrigin: true,
-      },
-      '/auth': {
-        target: process.env.API_TARGET ?? 'http://localhost:3001',
-        changeOrigin: true,
+// Inject the Google Tag Manager snippet at build time, but ONLY when a
+// container ID is provided via VITE_GTM_ID. With no ID (the default, and what
+// every self-hoster gets), nothing is injected — so a deployment never loads
+// someone else's GTM container or reports its users to a third party. Our own
+// deployment sets VITE_GTM_ID at build time (Docker build arg).
+function gtmPlugin(gtmId: string): PluginOption {
+  return {
+    name: 'inject-gtm',
+    transformIndexHtml() {
+      if (!gtmId) return []
+      return [
+        {
+          tag: 'script',
+          injectTo: 'head-prepend',
+          children:
+            `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});` +
+            `var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;` +
+            `j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);` +
+            `})(window,document,'script','dataLayer','${gtmId}');`,
+        },
+        {
+          tag: 'noscript',
+          injectTo: 'body-prepend',
+          children:
+            `<iframe src="https://www.googletagmanager.com/ns.html?id=${gtmId}" ` +
+            `height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+        },
+      ]
+    },
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  // loadEnv reads .env files; fall back to process.env so the Docker build arg
+  // (passed as an env var, not a file) is also picked up.
+  const env = loadEnv(mode, process.cwd(), '')
+  const gtmId = (env.VITE_GTM_ID ?? process.env.VITE_GTM_ID ?? '').trim()
+
+  return {
+    plugins: [react(), gtmPlugin(gtmId)],
+    server: {
+      port: 5174,
+      proxy: {
+        '/api': {
+          target: process.env.API_TARGET ?? 'http://localhost:3001',
+          changeOrigin: true,
+        },
+        '/auth': {
+          target: process.env.API_TARGET ?? 'http://localhost:3001',
+          changeOrigin: true,
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
Makes a self-hosted Nexum report to **no one by default**, and replaces the implicit tracking of other people's instances with a transparent opt-in.

## 1. Gate Google Tag Manager behind `VITE_GTM_ID`
Previously the GTM container (`GTM-NXX5CRPH`) was hardcoded in `index.html`, so every self-hosted build loaded **our** container and sent their visitors' data to **our** GA. That's removed.
- GTM is now injected at build time by a Vite plugin **only when `VITE_GTM_ID` is set**.
- Plumbed through `web/Dockerfile` (build arg) + `docker-compose.yml`.
- Default build ships **zero** analytics (verified: 0 GTM references in `dist/index.html` without the env; fully injected with it).
- We set `VITE_GTM_ID=GTM-NXX5CRPH` only for our own deployment.

## 2. Opt-in anonymous deployment telemetry
A transparent way to count self-hosted installs without touching anyone's users.
- **Off** unless `NEXUM_TELEMETRY=1`.
- When on, the server sends a **daily** ping with **only** `{ version, instanceId }` — `instanceId` is a random per-install UUID (persisted in `sde_meta`), so repeat pings collapse to one install.
- **No** user data, character/corp info, or map data. Receiver (`POST /api/telemetry` → `telemetry_pings` upsert) **stores no IP**.
- Collector URL configurable (`NEXUM_TELEMETRY_URL`, default eve-nexum.com).

## Docs
New **Analytics & telemetry** README section + `.env.example` entries spelling out exactly what each does and how to enable/disable.

## Notes
- Server typecheck + web build both clean.
- After merge, **our** deployment must rebuild the web image **with `VITE_GTM_ID` set in .env** or eve-nexum.com loses its (legitimate, first-party) analytics: `docker compose build web && docker compose up -d`.