### PR TITLE
Fix empty {size}/{mass} in wormhole bookmark names

### DIFF
--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -16,6 +16,7 @@ import { reevaluateConnectionsForSystem } from '../../utils/whAutoDetect';
 import { alertInboundK162 } from '../../utils/k162Alert';
 import { WORMHOLE_TYPES } from '../../data/wormholes';
 import { formatBookmarkName, DEFAULT_BOOKMARK_FORMAT } from '../../utils/signatureBookmark';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { duration, DASH } from '../../i18n/format';
 
 // Aging bands for wormhole signatures, anchored to the WH type's known
@@ -250,14 +251,17 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   // Token format for the per-row "copy bookmark name" button. Edited in the
   // sidebar's Map Options; read here to build the pasted name.
   const [bookmarkFormat] = useUserSetting<string>('nexum.sig.bookmarkFormat', DEFAULT_BOOKMARK_FORMAT);
+  // Full wormhole catalog — needed so size/mass tokens resolve for every WH
+  // type (the static map only covers k-space statics).
+  const whTypes = useWormholeTypes();
 
   const copyBookmark = useCallback((sig: Signature) => {
-    const name = formatBookmarkName(bookmarkFormat, sig);
+    const name = formatBookmarkName(bookmarkFormat, sig, whTypes);
     if (!name) return;
     navigator.clipboard.writeText(name)
       .then(() => toast.success(t('signatures.bookmarkCopied', { name })))
       .catch(() => toast.error(t('signatures.bookmarkCopyFailed')));
-  }, [bookmarkFormat, t]);
+  }, [bookmarkFormat, whTypes, t]);
 
   // Sigs currently shown with the pending-removal indicator, plus the timers
   // that delete them once the grace period elapses.

--- a/web/src/utils/signatureBookmark.ts
+++ b/web/src/utils/signatureBookmark.ts
@@ -1,5 +1,5 @@
 import type { Signature } from '../types';
-import { WORMHOLE_TYPES } from '../data/wormholes';
+import type { WormholeSpec } from '../hooks/useWormholeTypes';
 
 // Tokens the bookmark-name format understands. Also drives the legend shown
 // next to the format setting.
@@ -38,9 +38,16 @@ const TOKEN_RE = /\{sig_letters\}|\{sig\}|\{type\}|\{dest_type\}|\{size\}|\{mass
  * string. Unfillable tokens collapse to empty and surrounding whitespace is
  * squeezed, so a partially-known sig still yields a tidy, paste-ready name.
  */
-export function formatBookmarkName(format: string, sig: Signature, now: number = Date.now()): string {
-  const wh   = sig.whType ? WORMHOLE_TYPES[sig.whType] : undefined;
-  const dest = sig.whLeadsTo || wh?.leadsTo || '';
+export function formatBookmarkName(
+  format: string,
+  sig: Signature,
+  whTypes: Record<string, WormholeSpec> = {},
+  now: number = Date.now(),
+): string {
+  // The full wormhole catalog (useWormholeTypes) keyed by type code — the small
+  // static map only covers k-space statics, so most holes (e.g. A641) miss it.
+  const wh   = sig.whType ? whTypes[sig.whType] : undefined;
+  const dest = sig.whLeadsTo || wh?.dest || '';
   const ageH = sig.createdAt
     ? Math.max(0, Math.floor((now - new Date(sig.createdAt).getTime()) / 3_600_000))
     : null;
@@ -50,8 +57,8 @@ export function formatBookmarkName(format: string, sig: Signature, now: number =
     '{sig_letters}': (sig.sigId ?? '').slice(0, 3).toUpperCase(),
     '{type}':        sig.whType ?? '',
     '{dest_type}':   dest,
-    '{size}':        wh ? sizeLetter(wh.jumpMassKg) : '',
-    '{mass}':        wh && wh.maxMassKg ? String(Number((wh.maxMassKg / 1_000_000_000).toFixed(1))) : '',
+    '{size}':        wh ? sizeLetter(wh.maxJumpMass) : '',
+    '{mass}':        wh && wh.totalMass ? String(Number((wh.totalMass / 1_000_000_000).toFixed(1))) : '',
     '{age}':         ageH != null ? `${ageH}h` : '',
     '{name}':        sig.name ?? '',
     '{notes}':       sig.notes ?? '',


### PR DESCRIPTION
## Bug
Copying a wormhole bookmark gave e.g. `PIZ-705 HS` with **no size** — the `{size}` (and `{mass}`) token resolved to empty for most holes.

## Cause
`formatBookmarkName` looked the wormhole type up in the small static `WORMHOLE_TYPES` map in `wormholes.ts`, which only contains ~10 k-space statics. Real holes like **A641** aren't in it, so `maxJumpMass`/`totalMass` were undefined and the tokens blanked. (`{dest_type}` still worked because it falls back to the signature's stored `whLeadsTo`.)

## Fix
Use the **full** wormhole catalog the rest of the app already loads via `useWormholeTypes()` (`/api/wormholes/types`). `formatBookmarkName` now takes the catalog and reads `maxJumpMass` (size bucket) and `totalMass` (mass, in billions of kg) from it, with `dest` as the destination fallback. `SignaturePane` passes the catalog in.

Now `A641` resolves to `PIZ-705 HS L` (large hole). Build clean.

## Test
Copy a bookmark on a wormhole sig that isn't a k-space static (e.g. A641) - the size letter now appears.