### PR TITLE
Map connection type now follows a sig's WH-type edit

### DIFF
--- a/web/src/utils/whAutoDetect.ts
+++ b/web/src/utils/whAutoDetect.ts
@@ -25,6 +25,8 @@ export function reevaluateConnectionsForSystem(
   oldSig:   Signature | undefined,
 ): void {
   const { map, updateConnection } = useMapStore.getState();
+  const oldType  = oldSig?.whType?.toUpperCase();
+  const oldLeads = oldSig?.whLeadsTo?.toUpperCase();
 
   for (const conn of map.connections) {
     const otherId =
@@ -45,27 +47,32 @@ export function reevaluateConnectionsForSystem(
     }
     const best = backingCodes.find(t => t !== 'K162') ?? backingCodes[0];
 
-    if (best) {
-      // A sig backs this connection — fill if empty, upgrade K162 → real code.
-      if (conn.type === null) {
-        updateConnection(conn.id, { type: best });
-      } else if (conn.type.toUpperCase() === 'K162' && best !== 'K162') {
-        updateConnection(conn.id, { type: best });
-      }
-      // else: '' (user cleared) or already a real code — leave it.
-      continue;
-    }
-
-    // No sig backs the connection. If the old sig USED to back it and
-    // conn.type still matches what the old sig had, treat as orphaned
-    // auto-fill and clear.
-    const oldType  = oldSig?.whType?.toUpperCase();
-    const oldLeads = oldSig?.whLeadsTo?.toUpperCase();
-    if (
+    // True when this connection's current type was auto-filled from the sig
+    // being re-evaluated (its OLD whType still equals conn.type, and its old
+    // leadsTo pointed at the other endpoint). Lets us follow edits to that sig
+    // without clobbering a type the user typed by hand.
+    const oldBackedThis = !!(
       oldType && oldLeads &&
       (oldLeads === oc || oldLeads === on) &&
       conn.type && conn.type.toUpperCase() === oldType
-    ) {
+    );
+
+    if (best) {
+      if (conn.type === null || (conn.type.toUpperCase() === 'K162' && best !== 'K162')) {
+        // Empty, or a K162 placeholder being upgraded to a real code.
+        updateConnection(conn.id, { type: best });
+      } else if (oldBackedThis && conn.type.toUpperCase() !== best.toUpperCase()) {
+        // The sig that auto-filled this connection had its WH type changed —
+        // follow it so editing a sig's type updates the map label too.
+        updateConnection(conn.id, { type: best });
+      }
+      // else: '' (user cleared) or a manual real code — leave it.
+      continue;
+    }
+
+    // No sig backs the connection any more. If this sig used to back it,
+    // clear the now-orphaned auto-filled type.
+    if (oldBackedThis) {
       updateConnection(conn.id, { type: null });
     }
   }


### PR DESCRIPTION
## Bug
Setting a signature's WH type fills the matching map connection's type label. But **changing** that sig's WH type afterward (e.g. A641 -> B449) left the connection showing the old code.

## Cause
`reevaluateConnectionsForSystem` only wrote `conn.type` when it was `null` (empty) or a `K162` placeholder being upgraded. An already-set real code was deliberately left alone to avoid clobbering manually-typed values — but that also blocked legitimate edits to the sig that *created* the value.

## Fix
Track whether the connection's current type was auto-filled from the sig being edited (its current `conn.type` equals the sig's **previous** whType, and the old `leadsTo` pointed at the other endpoint). When it was, follow the edit and update the connection to the new type. Manual connection values (where `conn.type` doesn't match the sig's old type) are still left untouched.

## Test
On a connection whose type was set from a sig, change that sig's WH type in the panel - the map label updates to match. A connection type you typed by hand is unaffected.