### PR TITLE
Bookmark format input on its own full-width line

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1850,6 +1850,18 @@
   color: #c0ccde;
 }
 
+/* Stacked field: label on its own line above a full-width control. */
+.map-sidebar__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.map-sidebar__select--full {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .map-sidebar__toggle-row {
   cursor: pointer;
 }

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -1087,9 +1087,9 @@ export function MapSidebar() {
 
               {settingsTab === "signatures" && (
                 <>
-                  <div className="map-sidebar__row">
+                  <div className="map-sidebar__field">
                     <label className="map-sidebar__label" htmlFor="sig-bookmark-fmt">{t("mapSidebar.sigBookmark")}</label>
-                    <input id="sig-bookmark-fmt" className="map-sidebar__select" type="text" spellCheck={false} value={sigBookmarkFmt} onChange={(e) => setSigBookmarkFmt(e.target.value)} placeholder={DEFAULT_BOOKMARK_FORMAT} />
+                    <input id="sig-bookmark-fmt" className="map-sidebar__select map-sidebar__select--full" type="text" spellCheck={false} value={sigBookmarkFmt} onChange={(e) => setSigBookmarkFmt(e.target.value)} placeholder={DEFAULT_BOOKMARK_FORMAT} />
                   </div>
                   <p className="map-sidebar__help">{t("mapSidebar.bookmarkHelp")}</p>
                   <ul className="map-sidebar__tokens">


### PR DESCRIPTION
In the Settings dialog's **Wormhole bookmarks** (Signatures) tab, the bookmark-format field was a cramped side-by-side row. Stack the label above a **full-width** input so the format string is readable and easy to edit. CSS-only layout change (`map-sidebar__field` column + `map-sidebar__select--full`); build clean.