### PR TITLE
perf(map): stabilize useStandings + memoize per-node scans

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -106,19 +106,22 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   }, [standings, sov]);
   const isSovHostile = sovEffective < 0;
   const isSovBlue    = sovEffective > 0;
+  // Each of these scans a cluster-wide array; memoize per-node so the O(n)
+  // find/filter only runs when the array or this system's id changes, not on
+  // every (re-)render of every node.
   const incursions      = useIncursions();
-  const incursion       = findIncursion(incursions, sys.eveSystemId);
+  const incursion       = useMemo(() => findIncursion(incursions, sys.eveSystemId), [incursions, sys.eveSystemId]);
   const insurgencies    = useInsurgency();
-  const insurgency      = findInsurgency(insurgencies, sys.eveSystemId);
+  const insurgency      = useMemo(() => findInsurgency(insurgencies, sys.eveSystemId), [insurgencies, sys.eveSystemId]);
   const storms          = useStorms();
-  const storm           = findStorm(storms, sys.eveSystemId);
+  const storm           = useMemo(() => findStorm(storms, sys.eveSystemId), [storms, sys.eveSystemId]);
   const scoutAll        = useScoutConnections();
-  const scoutMatches    = findScoutConnections(scoutAll, sys.eveSystemId);
+  const scoutMatches    = useMemo(() => findScoutConnections(scoutAll, sys.eveSystemId), [scoutAll, sys.eveSystemId]);
   const a0Systems       = useA0Systems();
   const a0Ids           = useMemo(() => new Set(a0Systems.map(s => s.id)), [a0Systems]);
   const isA0            = sys.eveSystemId !== null && a0Ids.has(sys.eveSystemId);
   const iceBeltSystems  = useIceBeltSystems();
-  const isIceBelt       = hasIceBelt(iceBeltSystems, sys.eveSystemId);
+  const isIceBelt       = useMemo(() => hasIceBelt(iceBeltSystems, sys.eveSystemId), [iceBeltSystems, sys.eveSystemId]);
   const allKills        = useCurrentHourKills();
   const myKills         = sys.eveSystemId !== null ? allKills.get(sys.eveSystemId) : undefined;
   const hotKills        = !!myKills && myKills.shipKills + myKills.podKills > 0;
@@ -149,14 +152,13 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
 
   // Tooltip label: dedupe by scout system name (Thera / Turnur). Multiple
   // connections from the same scout are summarised, mixed scouts are listed.
-  const scoutLabel = scoutMatches.length === 0
-    ? ''
-    : (() => {
-        const names = Array.from(new Set(scoutMatches.map(c => c.outSystemName)));
-        return names.length === 1
-          ? t('mapNode.scoutConnections', { name: names[0], count: scoutMatches.length })
-          : t('mapNode.scoutConnectionsMulti', { names: names.join(' & ') });
-      })();
+  const scoutLabel = useMemo(() => {
+    if (scoutMatches.length === 0) return '';
+    const names = Array.from(new Set(scoutMatches.map(c => c.outSystemName)));
+    return names.length === 1
+      ? t('mapNode.scoutConnections', { name: names[0], count: scoutMatches.length })
+      : t('mapNode.scoutConnectionsMulti', { names: names.join(' & ') });
+  }, [scoutMatches, t]);
   const isTarget        = connection.inProgress && connection.fromNode?.id !== sys.id;
 
   // Measure the node so the map store can compute the largest natural

--- a/web/src/hooks/useStandings.ts
+++ b/web/src/hooks/useStandings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api } from '../api/client';
 import { useShareMode } from '../context/ShareModeContext';
 
@@ -87,7 +87,10 @@ const EMPTY: StandingsLookup = {
 };
 
 export function useStandings() {
-  const [, setTick] = useState(0);
+  // Increments on every standings change (notify) — used as the memo key so
+  // the returned object updates exactly when the data changes and is otherwise
+  // referentially stable, letting consumers (every map node) memoize cleanly.
+  const [tick, setTick] = useState(0);
   const { isShareMode } = useShareMode();
 
   useEffect(() => {
@@ -101,7 +104,9 @@ export function useStandings() {
     return () => { listeners.delete(listener); };
   }, [isShareMode]);
 
-  function getStanding(kind: ContactKind, id: number): StandingsLookup {
+  // Stable identity; reads the module cache at call time so it stays correct
+  // as the cache updates without forcing a new closure each render.
+  const getStanding = useCallback((kind: ContactKind, id: number): StandingsLookup => {
     if (!cache) return EMPTY;
     const key = `${kind}:${id}`;
     const character = cache.character[key] ?? null;
@@ -116,15 +121,16 @@ export function useStandings() {
       isFriendly: effective >  5,
       isNeutral:  effective >= -5 && effective <= 5,
     };
-  }
+  }, []);
 
-  return {
+  return useMemo(() => ({
     loaded: !!cache,
     refreshing,
     getStanding,
     self: cache ? { characterId: cache.characterId, corpId: cache.corpId, allianceId: cache.allianceId } : null,
     refresh: refreshFromEsi,
-  };
+  // `tick` (bumped by notify) is the data-version key; getStanding is stable.
+  }), [tick, getStanding]);
 }
 
 // Convenience for code that only needs the loader (no per-target lookups).


### PR DESCRIPTION
Second review-follow-up PR. Two **behaviour-preserving** optimizations on the map render hot path (the top-3 perf findings that are safe to ship without interactive testing).

## Changes
- **useStandings returns a stable object.** It was rebuilding the return object + `getStanding` closure + `self` on every render; every `SystemNode` consumes it, so its `sovEffective` memo could never stabilize and a single standings load/refresh re-rendered every node with churned identity. Now the object is memoized on a data-version tick (bumped by `notify`) with `getStanding` via `useCallback` — same output, stable identity.
- **SystemNode memoizes its per-node cluster scans.** `findIncursion / findInsurgency / findStorm / findScoutConnections / hasIceBelt` and the scout label each scan a cluster-wide array on every render of every node; now wrapped in `useMemo` keyed on `(array, sys.eveSystemId)`, so the O(n) work only re-runs when its inputs change.

Both are pure identity/recompute optimizations — **no behaviour change**, so they can't affect selection, dragging, sov display, etc. Lint + build clean.

## Deferred (need interactive testing, follow-up)
- Dropping the dead `data.selected` and decoupling the node rebuild from selection (the biggest win, but reworks RF selection sync — needs drag/multi-select/delete testing).
- Presence `bySystem` indexing + `useShallow` selector.
- Edge EOL-countdown moved into a child so non-EOL edges don't re-render on the 30s tick.

## Merge order
Stacks logically after **#169** (PR1) — that PR brings the eslint config + CI workflow. This branch is off the pre-#169 release, so rebase it (or just merge #169 first) before relying on CI here.