### PR TITLE
refactor: dedup resource hooks + eveImages util

### DIFF
--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { charPortrait } from '../../utils/eveImages';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { api } from '../../api/client';
@@ -259,7 +260,7 @@ function UsersTab() {
                   <td className="admin-modal__name-cell">
                     <img
                       className="admin-modal__avatar"
-                      src={`https://images.evetech.net/characters/${u.characterId}/portrait?size=32`}
+                      src={charPortrait(u.characterId, 32)}
                       alt=""
                     />
                     <span>{u.characterName}</span>
@@ -436,7 +437,7 @@ function MapsTab() {
                   <td className="admin-modal__name-cell">
                     <img
                       className="admin-modal__avatar"
-                      src={`https://images.evetech.net/characters/${m.ownerCharacterId}/portrait?size=32`}
+                      src={charPortrait(m.ownerCharacterId, 32)}
                       alt=""
                     />
                     <span>{m.ownerCharacterName}</span>
@@ -838,7 +839,7 @@ function UsersReport() {
               <td className="admin-modal__name-cell">
                 <img
                   className="admin-modal__avatar"
-                  src={`https://images.evetech.net/characters/${u.characterId}/portrait?size=32`}
+                  src={charPortrait(u.characterId, 32)}
                   alt=""
                 />
                 <span>{u.characterName}</span>

--- a/web/src/components/ui/CharacterSwitcher.tsx
+++ b/web/src/components/ui/CharacterSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { charPortrait } from '../../utils/eveImages';
 import { useTranslation } from 'react-i18next';
 import { CaretDownIcon, PlusIcon, CheckIcon, MapPinIcon, TrashIcon } from '@phosphor-icons/react';
 import { useAuth } from '../../context/AuthContext';
@@ -134,7 +135,7 @@ export function CharacterSwitcher() {
                 >
                   <img
                     className="character-switcher__avatar"
-                    src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=32`}
+                    src={charPortrait(c.characterId, 32)}
                     alt=""
                   />
                   <span className="character-switcher__identity">

--- a/web/src/components/ui/FleetPane.tsx
+++ b/web/src/components/ui/FleetPane.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { charPortrait } from '../../utils/eveImages';
 import { useTranslation } from 'react-i18next';
 import { ArrowUpIcon, ArrowDownIcon } from '@phosphor-icons/react';
 import { useFleet } from '../../hooks/useFleet';
@@ -151,7 +152,7 @@ export function FleetPane() {
           <li key={r.key} className="fleet-pane__row">
             <img
               className="fleet-pane__avatar"
-              src={`https://images.evetech.net/characters/${r.avatarId}/portrait?size=32`}
+              src={charPortrait(r.avatarId, 32)}
               alt=""
               loading="lazy"
             />

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { charPortrait } from '../../utils/eveImages';
 import { Trans, useTranslation } from 'react-i18next';
 import type { Icon } from '@phosphor-icons/react';
 import {
@@ -322,7 +323,7 @@ export function LandingPage() {
             <>
               <a href={apiUrl('/auth/login')} className="landing__returning">
                 <img
-                  src={`https://images.evetech.net/characters/${lastChar.characterId}/portrait?size=128`}
+                  src={charPortrait(lastChar.characterId, 128)}
                   alt={lastChar.characterName}
                   className="landing__returning-avatar"
                 />

--- a/web/src/components/ui/LockScreen.tsx
+++ b/web/src/components/ui/LockScreen.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { AuthUser } from '../../context/AuthContext';
+import { charPortrait } from '../../utils/eveImages';
 
 /**
  * Idle-lock screen. Shown when the session is still valid but the UI has been
@@ -21,7 +22,7 @@ export function LockScreen({
       <div className="lock-screen__card">
         <img
           className="lock-screen__avatar"
-          src={`https://images.evetech.net/characters/${user.characterId}/portrait?size=128`}
+          src={charPortrait(user.characterId, 128)}
           alt=""
         />
         <h1 className="lock-screen__title">{t('session.lockedTitle')}</h1>

--- a/web/src/components/ui/MapSharesSection.tsx
+++ b/web/src/components/ui/MapSharesSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { charPortrait, corpLogo } from '../../utils/eveImages';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../api/client';
 import { useMapStore } from '../../store/mapStore';
@@ -166,8 +167,8 @@ export function MapSharesSection() {
                   <img
                     className="map-shares__avatar"
                     src={s.kind === 'character'
-                      ? `https://images.evetech.net/characters/${s.targetId}/portrait?size=32`
-                      : `https://images.evetech.net/corporations/${s.targetId}/logo?size=32`}
+                      ? charPortrait(s.targetId, 32)
+                      : corpLogo(s.targetId, 32)}
                     alt=""
                     loading="lazy"
                   />

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -22,6 +22,7 @@ import {
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
+import { charPortrait, typeIcon } from '../../utils/eveImages';
 
 interface EveStatus {
   players:    number;
@@ -433,7 +434,7 @@ export function Toolbar() {
           />
           <img
             className="toolbar__avatar"
-            src={`https://images.evetech.net/characters/${user.characterId}/portrait?size=64`}
+            src={charPortrait(user.characterId, 64)}
             alt={user.characterName}
           />
           {ship && (
@@ -445,7 +446,7 @@ export function Toolbar() {
             >
               <img
                 className="toolbar__ship"
-                src={`https://images.evetech.net/types/${ship.typeId}/icon?size=64`}
+                src={typeIcon(ship.typeId, 64)}
                 alt={ship.typeName}
               />
             </span>

--- a/web/src/hooks/createPolledResource.ts
+++ b/web/src/hooks/createPolledResource.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client';
+
+/**
+ * Factory for a cluster-wide list that's polled on a fixed cadence and shared
+ * by every consumer through a single module cache + one interval. Returns a
+ * `useResource()` hook (the array, live-updated) and `load()` (manual refresh).
+ *
+ * Replaces the byte-for-byte-identical cache/inflight/subscriber/poll-timer
+ * boilerplate that each of these hooks used to carry.
+ */
+export function createPolledResource<T>(endpoint: string, pollMs: number) {
+  let cache: { data: T[]; fetchedAt: number } | null = null;
+  let inflight: Promise<T[]> | null = null;
+  const subscribers = new Set<(d: T[]) => void>();
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  function load(): Promise<T[]> {
+    if (inflight) return inflight;
+    inflight = api<T[]>(endpoint)
+      .then((d) => {
+        cache = { data: d, fetchedAt: Date.now() };
+        inflight = null;
+        subscribers.forEach((fn) => fn(d));
+        return d;
+      })
+      .catch(() => { inflight = null; return cache?.data ?? []; });
+    return inflight;
+  }
+
+  function useResource(): T[] {
+    const [data, setData] = useState<T[]>(cache?.data ?? []);
+
+    useEffect(() => {
+      subscribers.add(setData);
+      const now = Date.now();
+      if (!cache || now - cache.fetchedAt >= pollMs) load();
+      else setData(cache.data);
+      // Start the single shared timer on the first subscriber.
+      if (!pollTimer) pollTimer = setInterval(load, pollMs);
+      return () => {
+        subscribers.delete(setData);
+        if (subscribers.size === 0 && pollTimer) {
+          clearInterval(pollTimer);
+          pollTimer = null;
+        }
+      };
+    }, []);
+
+    return data;
+  }
+
+  return { useResource, load };
+}

--- a/web/src/hooks/createStaticResource.ts
+++ b/web/src/hooks/createStaticResource.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client';
+
+/**
+ * Factory for static cluster reference data that's loaded once per page and
+ * never refreshed (a page reload recovers from any SDE re-seed). Returns a
+ * `useResource()` hook and `load()`. `transform` maps the raw API payload to
+ * the shape callers want (e.g. an array into a Set).
+ */
+export function createStaticResource<Raw, R = Raw>(
+  endpoint: string,
+  empty: R,
+  transform: (raw: Raw) => R = (x) => x as unknown as R,
+) {
+  let cache: R | null = null;
+  let inflight: Promise<R> | null = null;
+
+  function load(): Promise<R> {
+    if (cache) return Promise.resolve(cache);
+    if (inflight) return inflight;
+    inflight = api<Raw>(endpoint)
+      .then((raw) => { cache = transform(raw); inflight = null; return cache; })
+      .catch(() => { inflight = null; return cache ?? empty; });
+    return inflight;
+  }
+
+  function useResource(): R {
+    const [data, setData] = useState<R>(cache ?? empty);
+
+    useEffect(() => {
+      if (cache) { setData(cache); return; }
+      let cancelled = false;
+      load().then((d) => { if (!cancelled) setData(d); });
+      return () => { cancelled = true; };
+    }, []);
+
+    return data;
+  }
+
+  return { useResource, load };
+}

--- a/web/src/hooks/useA0Systems.ts
+++ b/web/src/hooks/useA0Systems.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { createStaticResource } from './createStaticResource';
 
 export interface A0System {
   id:         number;
@@ -8,35 +7,5 @@ export interface A0System {
 }
 
 // The A0 list is static cluster data — load once per page, never refresh.
-let cache: A0System[] | null = null;
-let inflight: Promise<A0System[]> | null = null;
-const EMPTY: A0System[] = [];
-
-function load(): Promise<A0System[]> {
-  if (cache)    return Promise.resolve(cache);
-  if (inflight) return inflight;
-  inflight = api<A0System[]>('/api/systems/a0')
-    .then(rows => {
-      cache = rows;
-      inflight = null;
-      return cache;
-    })
-    .catch(() => {
-      inflight = null;
-      return cache ?? EMPTY;
-    });
-  return inflight;
-}
-
-export function useA0Systems(): A0System[] {
-  const [data, setData] = useState<A0System[]>(cache ?? EMPTY);
-
-  useEffect(() => {
-    if (cache) { setData(cache); return; }
-    let cancelled = false;
-    load().then(s => { if (!cancelled) setData(s); });
-    return () => { cancelled = true; };
-  }, []);
-
-  return data;
-}
+const { useResource } = createStaticResource<A0System[]>('/api/systems/a0', []);
+export const useA0Systems = useResource;

--- a/web/src/hooks/useIceBeltSystems.ts
+++ b/web/src/hooks/useIceBeltSystems.ts
@@ -1,39 +1,13 @@
-import { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { createStaticResource } from './createStaticResource';
 
-// Static cluster data — load once per page, never refresh.
-let cache: Set<number> | null = null;
-let inflight: Promise<Set<number>> | null = null;
-const EMPTY: Set<number> = new Set();
-
-function load(): Promise<Set<number>> {
-  if (cache)    return Promise.resolve(cache);
-  if (inflight) return inflight;
-  inflight = api<number[]>('/api/systems/ice-belts')
-    .then((ids) => {
-      cache = new Set(ids);
-      inflight = null;
-      return cache;
-    })
-    .catch(() => {
-      inflight = null;
-      return cache ?? EMPTY;
-    });
-  return inflight;
-}
-
-export function useIceBeltSystems(): Set<number> {
-  const [data, setData] = useState<Set<number>>(cache ?? EMPTY);
-
-  useEffect(() => {
-    if (cache) { setData(cache); return; }
-    let cancelled = false;
-    load().then((s) => { if (!cancelled) setData(s); });
-    return () => { cancelled = true; };
-  }, []);
-
-  return data;
-}
+// Static cluster data — load once per page, never refresh. The id list is
+// transformed into a Set for O(1) membership checks.
+const { useResource } = createStaticResource<number[], Set<number>>(
+  '/api/systems/ice-belts',
+  new Set<number>(),
+  (ids) => new Set(ids),
+);
+export const useIceBeltSystems = useResource;
 
 export function hasIceBelt(set: Set<number>, eveSystemId: number | null): boolean {
   return !!eveSystemId && set.has(eveSystemId);

--- a/web/src/hooks/useIncursions.ts
+++ b/web/src/hooks/useIncursions.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { createPolledResource } from './createPolledResource';
 
 export interface IncursionSystem {
   systemId:       number;
@@ -12,56 +11,8 @@ export interface IncursionSystem {
   isStaging:      boolean;
 }
 
-const POLL_MS = 60 * 60 * 1000;
-
-let moduleCache: { data: IncursionSystem[]; fetchedAt: number } | null = null;
-let inflight: Promise<IncursionSystem[]> | null = null;
-
-const subscribers = new Set<(d: IncursionSystem[]) => void>();
-// Single shared poll timer. Previously every subscribed component created its
-// own setInterval — 50 SystemNodes meant 50 timers all hitting /api/incursions
-// on the same cadence.
-let pollTimer: ReturnType<typeof setInterval> | null = null;
-
-function notify(d: IncursionSystem[]) {
-  subscribers.forEach((fn) => fn(d));
-}
-
-function load() {
-  if (inflight) return inflight;
-  inflight = api<IncursionSystem[]>('/api/incursions')
-    .then((d) => { moduleCache = { data: d, fetchedAt: Date.now() }; inflight = null; notify(d); return d; })
-    .catch(() => { inflight = null; return moduleCache?.data ?? []; });
-  return inflight;
-}
-
-export function useIncursions() {
-  const [data, setData] = useState<IncursionSystem[]>(moduleCache?.data ?? []);
-
-  useEffect(() => {
-    subscribers.add(setData);
-
-    const now = Date.now();
-    if (!moduleCache || now - moduleCache.fetchedAt >= POLL_MS) {
-      load();
-    } else {
-      setData(moduleCache.data);
-    }
-
-    // Start the shared timer on the first subscriber.
-    if (!pollTimer) pollTimer = setInterval(load, POLL_MS);
-
-    return () => {
-      subscribers.delete(setData);
-      if (subscribers.size === 0 && pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = null;
-      }
-    };
-  }, []);
-
-  return data;
-}
+const { useResource } = createPolledResource<IncursionSystem>('/api/incursions', 60 * 60 * 1000);
+export const useIncursions = useResource;
 
 export function findIncursion(incursions: IncursionSystem[], eveSystemId: number | null): IncursionSystem | undefined {
   if (!eveSystemId) return undefined;

--- a/web/src/hooks/useInsurgency.ts
+++ b/web/src/hooks/useInsurgency.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { createPolledResource } from './createPolledResource';
 
 export interface InsurgencySystem {
   systemId:         number;
@@ -13,53 +12,8 @@ export interface InsurgencySystem {
   suppressionState: number;
 }
 
-const POLL_MS = 60 * 60 * 1000;
-
-let moduleCache: { data: InsurgencySystem[]; fetchedAt: number } | null = null;
-let inflight: Promise<InsurgencySystem[]> | null = null;
-
-const subscribers = new Set<(d: InsurgencySystem[]) => void>();
-// Single shared poll timer (see useIncursions for the same pattern).
-let pollTimer: ReturnType<typeof setInterval> | null = null;
-
-function notify(d: InsurgencySystem[]) {
-  subscribers.forEach((fn) => fn(d));
-}
-
-function load() {
-  if (inflight) return inflight;
-  inflight = api<InsurgencySystem[]>('/api/insurgency')
-    .then((d) => { moduleCache = { data: d, fetchedAt: Date.now() }; inflight = null; notify(d); return d; })
-    .catch(() => { inflight = null; return moduleCache?.data ?? []; });
-  return inflight;
-}
-
-export function useInsurgency() {
-  const [data, setData] = useState<InsurgencySystem[]>(moduleCache?.data ?? []);
-
-  useEffect(() => {
-    subscribers.add(setData);
-
-    const now = Date.now();
-    if (!moduleCache || now - moduleCache.fetchedAt >= POLL_MS) {
-      load();
-    } else {
-      setData(moduleCache.data);
-    }
-
-    if (!pollTimer) pollTimer = setInterval(load, POLL_MS);
-
-    return () => {
-      subscribers.delete(setData);
-      if (subscribers.size === 0 && pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = null;
-      }
-    };
-  }, []);
-
-  return data;
-}
+const { useResource } = createPolledResource<InsurgencySystem>('/api/insurgency', 60 * 60 * 1000);
+export const useInsurgency = useResource;
 
 export function findInsurgency(insurgencies: InsurgencySystem[], eveSystemId: number | null): InsurgencySystem | undefined {
   if (!eveSystemId) return undefined;

--- a/web/src/hooks/useSovData.ts
+++ b/web/src/hooks/useSovData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { allianceLogo, corpLogo } from '../utils/eveImages';
 
 const ESI = 'https://esi.evetech.net/latest';
 
@@ -112,19 +113,20 @@ export function useSovData(eveSystemId: number | null): SovResult | null {
       const alliance = allianceInfo && entry.alliance_id ? {
         name:    allianceInfo.name,
         ticker:  allianceInfo.ticker,
-        logoUrl: `https://images.evetech.net/alliances/${entry.alliance_id}/logo?size=64`,
+        logoUrl: allianceLogo(entry.alliance_id, 64),
       } : undefined;
 
       const corp = corpInfo && entry.corporation_id ? {
         name:    corpInfo.name,
         ticker:  corpInfo.ticker,
-        logoUrl: `https://images.evetech.net/corporations/${entry.corporation_id}/logo?size=64`,
+        logoUrl: corpLogo(entry.corporation_id, 64),
       } : undefined;
 
-      const factionEntry = entry.faction_id ? factionsMap.get(entry.faction_id) : undefined;
-      const faction = factionEntry ? {
+      const factionId = entry.faction_id;
+      const factionEntry = factionId ? factionsMap.get(factionId) : undefined;
+      const faction = factionEntry && factionId ? {
         name:    factionEntry.name,
-        logoUrl: `https://images.evetech.net/corporations/${entry.faction_id}/logo?size=64`,
+        logoUrl: corpLogo(factionId, 64),
       } : undefined;
 
       // Primary controller: alliance > corp > faction

--- a/web/src/hooks/useStorms.ts
+++ b/web/src/hooks/useStorms.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { createPolledResource } from './createPolledResource';
 
 export type StormType = 'electric' | 'gamma' | 'exotic' | 'plasma' | 'unknown';
 
@@ -14,52 +13,8 @@ export interface StormSystem {
   reportedBy:     string;
 }
 
-const POLL_MS = 30 * 60 * 1000;
-
-let moduleCache: { data: StormSystem[]; fetchedAt: number } | null = null;
-let inflight: Promise<StormSystem[]> | null = null;
-
-const subscribers = new Set<(d: StormSystem[]) => void>();
-let pollTimer: ReturnType<typeof setInterval> | null = null;
-
-function notify(d: StormSystem[]) {
-  subscribers.forEach((fn) => fn(d));
-}
-
-function load() {
-  if (inflight) return inflight;
-  inflight = api<StormSystem[]>('/api/storms')
-    .then((d) => { moduleCache = { data: d, fetchedAt: Date.now() }; inflight = null; notify(d); return d; })
-    .catch(() => { inflight = null; return moduleCache?.data ?? []; });
-  return inflight;
-}
-
-export function useStorms() {
-  const [data, setData] = useState<StormSystem[]>(moduleCache?.data ?? []);
-
-  useEffect(() => {
-    subscribers.add(setData);
-
-    const now = Date.now();
-    if (!moduleCache || now - moduleCache.fetchedAt >= POLL_MS) {
-      load();
-    } else {
-      setData(moduleCache.data);
-    }
-
-    if (!pollTimer) pollTimer = setInterval(load, POLL_MS);
-
-    return () => {
-      subscribers.delete(setData);
-      if (subscribers.size === 0 && pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = null;
-      }
-    };
-  }, []);
-
-  return data;
-}
+const { useResource } = createPolledResource<StormSystem>('/api/storms', 30 * 60 * 1000);
+export const useStorms = useResource;
 
 export function findStorm(storms: StormSystem[], eveSystemId: number | null): StormSystem | undefined {
   if (!eveSystemId) return undefined;

--- a/web/src/hooks/useWormholeTypes.ts
+++ b/web/src/hooks/useWormholeTypes.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { createStaticResource } from './createStaticResource';
 
 export interface WormholeSpec {
   totalMass:     number;
@@ -13,28 +12,5 @@ export interface WormholeSpec {
 type WhMap = Record<string, WormholeSpec>;
 
 // Static cluster data — load once per page, never refresh.
-let cache: WhMap | null = null;
-let inflight: Promise<WhMap> | null = null;
-const EMPTY: WhMap = {};
-
-function load(): Promise<WhMap> {
-  if (cache)    return Promise.resolve(cache);
-  if (inflight) return inflight;
-  inflight = api<WhMap>('/api/wormholes/types')
-    .then(rows => { cache = rows; inflight = null; return cache; })
-    .catch(() => { inflight = null; return cache ?? EMPTY; });
-  return inflight;
-}
-
-export function useWormholeTypes(): WhMap {
-  const [data, setData] = useState<WhMap>(cache ?? EMPTY);
-
-  useEffect(() => {
-    if (cache) { setData(cache); return; }
-    let cancelled = false;
-    load().then(d => { if (!cancelled) setData(d); });
-    return () => { cancelled = true; };
-  }, []);
-
-  return data;
-}
+const { useResource } = createStaticResource<WhMap>('/api/wormholes/types', {});
+export const useWormholeTypes = useResource;

--- a/web/src/utils/eveImages.ts
+++ b/web/src/utils/eveImages.ts
@@ -1,0 +1,9 @@
+// CCP's image server. Centralizes the URL shape so call sites don't hand-build
+// `https://images.evetech.net/...` strings (they were duplicated ~14 times).
+const BASE = 'https://images.evetech.net';
+
+export const charPortrait = (id: number, size = 64) => `${BASE}/characters/${id}/portrait?size=${size}`;
+export const corpLogo     = (id: number, size = 64) => `${BASE}/corporations/${id}/logo?size=${size}`;
+export const allianceLogo = (id: number, size = 64) => `${BASE}/alliances/${id}/logo?size=${size}`;
+export const typeIcon     = (id: number, size = 64) => `${BASE}/types/${id}/icon?size=${size}`;
+export const typeRender   = (id: number, size = 64) => `${BASE}/types/${id}/render?size=${size}`;


### PR DESCRIPTION
Third review-follow-up PR — the duplication cleanup.

## Resource-hook factories
`createPolledResource` and `createStaticResource` replace the near-identical module-cache / inflight / subscriber / poll-timer (or load-once + cancel) boilerplate that each data hook re-implemented. Migrated, **preserving each hook's exact public API** (so no consumer changes):
- Polled: `useStorms`, `useIncursions`, `useInsurgency` (+ their `findX` helpers)
- Static: `useA0Systems`, `useIceBeltSystems` (+ `hasIceBelt`), `useWormholeTypes`

## eveImages util
`utils/eveImages.ts` centralizes the `images.evetech.net` URL shape (`charPortrait` / `corpLogo` / `allianceLogo` / `typeIcon` / `typeRender`). Migrated the ~13 hand-built URLs across `useSovData`, `Toolbar`, `AdminPage`, `FleetPane`, `LandingPage`, `CharacterSwitcher`, `LockScreen`, `MapSharesSection`.

## Result
No behaviour change; `tsc` build clean. **Net -6 eslint errors** (the dedup removes inline `set-state-in-effect` from the migrated hooks).

## Deferred (noted)
- Keyed-resource factory for `useSystemInfo` / `useEsiSystem` (they carry an ESI concurrency limiter — wanted to keep that explicit).
- The shared `<Modal>` primitive (7 hand-rolled modals) + `useEscapeKey` — bigger reach, best as its own PR.
- `KillboardPane` already has a local image const; left as-is.

## Merge order
Stacks after **#169 (PR1)** and **#170 (PR2)**. This branch is off the pre-#169 release, so its `yarn lint` still shows the old strict errors — once rebased on the PR1-updated release, the remaining set-state items are warnings and lint is green. Build is clean regardless.