### PR TITLE
Backend security hardening

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 
 // CORP_ID accepts a comma-separated list of corporation IDs. Any member of
 // any listed corp is allowed to log in.
@@ -99,7 +99,17 @@ if (!TOKEN_ENC_RAW) {
   process.exit(1);
 }
 const HEX_64 = /^[0-9a-fA-F]{64}$/;
-const tokenEncryptionKey = HEX_64.test(TOKEN_ENC_RAW)
+const isHex64Key = HEX_64.test(TOKEN_ENC_RAW);
+// A short passphrase SHA-256s into a low-entropy, brute-forceable key that
+// protects every stored EVE refresh token. The strong form is 64 hex chars
+// (`openssl rand -hex 32`); a >=32-char passphrase is tolerated as a fallback,
+// but anything weaker is refused in production and warned about in dev.
+if (!isHex64Key && TOKEN_ENC_RAW.length < 32) {
+  const msg = 'TOKEN_ENCRYPTION_KEY is too weak — use 64 hex chars (openssl rand -hex 32) or at least a 32-character passphrase';
+  if (isProd) { console.error(`FATAL: ${msg}`); process.exit(1); }
+  else console.warn(`WARNING: ${msg}`);
+}
+const tokenEncryptionKey = isHex64Key
   ? TOKEN_ENC_RAW.toLowerCase()
   : createHash('sha256').update(TOKEN_ENC_RAW).digest('hex');
 
@@ -128,7 +138,11 @@ export const config = {
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },
-  sessionSecret:       process.env.SESSION_SECRET ?? 'dev-secret-change-me',
+  // Required in non-dev (guarded above). The dev fallback is randomised per
+  // boot rather than a known literal, so a dev instance accidentally exposed
+  // can't have its sessions forged with a guessable secret (sessions just
+  // don't survive a restart in dev, which is fine).
+  sessionSecret:       process.env.SESSION_SECRET ?? randomBytes(32).toString('hex'),
   tokenEncryptionKey,
   isProd,
 } as const;

--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -26,7 +26,17 @@ const PERIODS: PeriodKey[] = ['forever', 'year', 'month', 'week', 'day'];
 const DAILY_DAYS = 30;
 
 router.get('/', async (req, res) => {
-  const userId = req.session.userId!;
+  const userId = req.session.userId;
+  // optionalAuth means a share-token viewer can reach here with no session —
+  // they have nothing to attribute, so return empty stats rather than running
+  // the queries with a NULL user id.
+  if (!userId) {
+    const empty: Record<PeriodKey, PeriodStats> = {
+      forever: emptyPeriod(), year: emptyPeriod(), month: emptyPeriod(),
+      week: emptyPeriod(), day: emptyPeriod(),
+    };
+    return res.json({ ...empty, daily: Array(DAILY_DAYS).fill(0) });
+  }
 
   const now   = new Date();
   const day   = new Date(now.getTime() - 24 * 60 * 60 * 1000);

--- a/server/src/utils/esi.ts
+++ b/server/src/utils/esi.ts
@@ -17,6 +17,7 @@ const ESI_AGENT = 'Eve-Nexum/1.0 (https://github.com/GQuantrill/eve-nexum; gq@ar
 // to pause.
 const SAFE_REMAIN = 10;       // start easing off once the budget dips this low
 let blockedUntil = 0;         // epoch ms; hold new requests until this passes
+const DEFAULT_TIMEOUT_MS = 15_000; // abort an ESI call that hasn't responded in time
 
 function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -35,15 +36,18 @@ function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
  * caller with a timeout won't hang past it.
  */
 export async function esiFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  // Default request timeout so a slow/hung ESI can't pin a request (and its DB
+  // pool slot) indefinitely — callers that pass their own signal keep it.
+  const signal = init.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
   const wait = blockedUntil - Date.now();
-  if (wait > 0) await sleep(wait, init.signal);
+  if (wait > 0) await sleep(wait, signal);
 
   const headers = {
     'User-Agent': ESI_AGENT,
     Accept: 'application/json',
     ...(init.headers as Record<string, string> | undefined),
   };
-  const res = await fetch(url, { ...init, headers });
+  const res = await fetch(url, { ...init, headers, signal });
 
   // Update backoff state from the error-limit headers (present on every ESI
   // response). Reset is seconds until the window clears; pad by 1s.


### PR DESCRIPTION
First of the backend review PRs. The audit found **no Critical/High vulnerabilities** — SQLi-clean (parameterized everywhere), strong IDOR/authz, encrypted tokens, server-enforced admin gates, scoped share links. These are the hardening items.

## Changes
- **`TOKEN_ENCRYPTION_KEY` strength.** It accepted any non-empty string and SHA-256-derived a key, so a short passphrase produced a brute-forceable key protecting every stored EVE refresh token. Now a non-hex key shorter than 32 chars is **fatal in production** (warned in dev). The strong form (`openssl rand -hex 32`) and any >=32-char passphrase are unchanged, so correctly-configured deployments are unaffected.
- **`esiFetch` default timeout.** Most callers passed no `AbortSignal`, so a slow/hung ESI could pin a request (and its DB-pool connection) indefinitely. Added a default 15s `AbortSignal.timeout`; callers with their own signal keep it.
- **Dev session secret.** The `'dev-secret-change-me'` fallback is now `randomBytes(32)` per boot, so an accidentally-exposed dev instance has no guessable/forgeable session secret. (Still required in non-dev.)
- **`/api/stats`** returns empty stats explicitly for the no-session path (share-token viewer under `optionalAuth`) instead of a misleading `userId!`.

## Notes
- No behaviour change for correctly-configured deployments. `tsc` clean.
- Deferred (low value): length caps on bulk import fields — those writes are already parameterized + column-whitelisted (injection-safe), so it's only oversized-string hygiene on the caller's own map.
- Stacks on the frontend CI PR (#169) for the lint/typecheck workflow.