### PR TITLE
Forward async route rejections to the error handler (DoS fix)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^8.5.1",
     "express-session": "^1.19.0",
     "helmet": "^8.2.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,9 @@
 import 'dotenv/config';
+// Patches Express 4 so a rejected promise from an async route handler is
+// forwarded to the error-handling middleware instead of becoming an unhandled
+// rejection that crashes the process (a DoS vector). Must be imported before
+// any routes are registered.
+import 'express-async-errors';
 import './config.js'; // validates env vars at startup
 import express from 'express';
 import cors from 'cors';

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -573,6 +573,11 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+express-async-errors@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
+  integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
+
 express-rate-limit@^8.5.1:
   version "8.5.1"
   resolved "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz"


### PR DESCRIPTION
Third backend review PR — the security-relevant one from the duplication audit.

## Problem
This is Express 4, which does **not** catch rejected promises from async route handlers, and there's **no process-level `unhandledRejection` handler**. So a bare `async` handler (most of them) that throws before responding — e.g. a malformed input that trips a DB error — becomes an unhandled rejection. On Node 15+ that **crashes the process**: a denial-of-service vector reachable from ordinary bad input.

## Fix
Add **`express-async-errors`** (imported before any routes register). It patches Express so a rejected handler promise is forwarded to the existing central error-handling middleware, which returns a clean `500 {error:'internal'}` (and headersSent-safe). One line; happy-path behaviour unchanged.

`tsc` clean.

## Scope note
I intentionally did **not** strip the ~15 redundant inline `try/catch` blocks — several return bespoke messages, so removing them changes responses. That's the separate dedup (can fold into the consistency PR). This PR is just the safety fix.

Stacks on the other backend PRs (independent files); merge order doesn't matter for this one.