### PR TITLE
refactor(backend): shared factions util + cachedJsonHandler

### DIFF
--- a/server/src/routes/incursions.ts
+++ b/server/src/routes/incursions.ts
@@ -2,17 +2,12 @@ import { Router } from 'express';
 import { esiFetch } from '../utils/esi.js';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
-import { TtlValue } from '../utils/cache.js';
+import { TtlValue, cachedJsonHandler } from '../utils/cache.js';
+import { loadFactions, factionLogoUrl } from '../utils/esiFactions.js';
 
 const router = Router();
 router.use(optionalAuth);
 const log = createLogger('incursions');
-
-interface EsiFaction {
-  faction_id: number;
-  name: string;
-  corporation_id?: number;
-}
 
 interface EsiIncursion {
   constellation_id:       number;
@@ -36,19 +31,7 @@ export interface IncursionSystem {
   isStaging:      boolean;
 }
 
-const CACHE_TTL_MS = 60 * 60 * 1000;
-
-let factionMap: Map<number, EsiFaction> | null = null;
-const cache = new TtlValue<IncursionSystem[]>(CACHE_TTL_MS);
-
-async function loadFactions(): Promise<Map<number, EsiFaction>> {
-  if (factionMap) return factionMap;
-  const res = await esiFetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
-  if (!res.ok) throw new Error(`ESI factions ${res.status}`);
-  const list = await res.json() as EsiFaction[];
-  factionMap = new Map(list.map((f) => [f.faction_id, f]));
-  return factionMap;
-}
+const cache = new TtlValue<IncursionSystem[]>(60 * 60 * 1000);
 
 async function fetchAndBuild(): Promise<IncursionSystem[]> {
   const [incRes, factions] = await Promise.all([
@@ -62,17 +45,14 @@ async function fetchAndBuild(): Promise<IncursionSystem[]> {
 
   for (const inc of incursions) {
     const faction = factions.get(inc.faction_id);
-    const factionName    = faction?.name ?? 'Unknown';
-    const factionLogoUrl = faction?.corporation_id
-      ? `https://images.evetech.net/corporations/${faction.corporation_id}/logo?size=64`
-      : '';
-
+    const factionName = faction?.name ?? 'Unknown';
+    const logoUrl     = factionLogoUrl(faction);
     for (const sysId of inc.infested_solar_systems) {
       result.push({
         systemId:       sysId,
         factionId:      inc.faction_id,
         factionName,
-        factionLogoUrl,
+        factionLogoUrl: logoUrl,
         state:          inc.state,
         influence:      inc.influence,
         hasBoss:        inc.has_boss,
@@ -83,19 +63,8 @@ async function fetchAndBuild(): Promise<IncursionSystem[]> {
   return result;
 }
 
-router.get('/', async (_req, res) => {
-  const fresh = cache.get();
-  if (fresh) { res.json(fresh); return; }
-  try {
-    const data = await fetchAndBuild();
-    cache.set(data);
-    res.json(data);
-  } catch (err) {
-    log.error('Incursions fetch failed:', err);
-    const stale = cache.getStale();
-    if (stale) { res.json(stale); return; }
-    res.status(502).json({ error: 'Failed to fetch incursions' });
-  }
-});
+router.get('/', cachedJsonHandler(cache, fetchAndBuild, {
+  log, logMsg: 'Incursions fetch failed:', errorMsg: 'Failed to fetch incursions',
+}));
 
 export default router;

--- a/server/src/routes/insurgency.ts
+++ b/server/src/routes/insurgency.ts
@@ -1,18 +1,12 @@
 import { Router } from 'express';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
-import { TtlValue } from '../utils/cache.js';
-import { esiFetch } from '../utils/esi.js';
+import { TtlValue, cachedJsonHandler } from '../utils/cache.js';
+import { loadFactions, factionLogoUrl } from '../utils/esiFactions.js';
 
 const router = Router();
 router.use(optionalAuth);
 const log = createLogger('insurgency');
-
-interface EsiFaction {
-  faction_id:     number;
-  name:           string;
-  corporation_id?: number;
-}
 
 interface SolarSystemEntry {
   id:              number;
@@ -52,19 +46,7 @@ export interface InsurgencySystem {
   suppressionState: number;
 }
 
-const CACHE_TTL_MS = 60 * 60 * 1000;
-
-let factionMap: Map<number, EsiFaction> | null = null;
-const cache = new TtlValue<InsurgencySystem[]>(CACHE_TTL_MS);
-
-async function loadFactions(): Promise<Map<number, EsiFaction>> {
-  if (factionMap) return factionMap;
-  const res = await esiFetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
-  if (!res.ok) throw new Error(`ESI factions ${res.status}`);
-  const list = await res.json() as EsiFaction[];
-  factionMap = new Map(list.map((f) => [f.faction_id, f]));
-  return factionMap;
-}
+const cache = new TtlValue<InsurgencySystem[]>(60 * 60 * 1000);
 
 async function fetchAndBuild(): Promise<InsurgencySystem[]> {
   const [warzoneRes, factions] = await Promise.all([
@@ -79,10 +61,8 @@ async function fetchAndBuild(): Promise<InsurgencySystem[]> {
   for (const campaign of campaigns) {
     if (campaign.state !== 'ACTIVE') continue;
     const faction = factions.get(campaign.pirateFactionId);
-    const factionName    = faction?.name ?? 'Unknown';
-    const factionLogoUrl = faction?.corporation_id
-      ? `https://images.evetech.net/corporations/${faction.corporation_id}/logo?size=64`
-      : '';
+    const factionName = faction?.name ?? 'Unknown';
+    const logoUrl     = factionLogoUrl(faction);
 
     for (const ins of campaign.insurgencies) {
       result.push({
@@ -90,7 +70,7 @@ async function fetchAndBuild(): Promise<InsurgencySystem[]> {
         campaignId:       campaign.campaignId,
         factionId:        campaign.pirateFactionId,
         factionName,
-        factionLogoUrl,
+        factionLogoUrl:   logoUrl,
         corruptionPct:    ins.corruptionPercentage,
         corruptionState:  ins.corruptionState,
         suppressionPct:   ins.suppressionPercentage,
@@ -102,19 +82,8 @@ async function fetchAndBuild(): Promise<InsurgencySystem[]> {
   return result;
 }
 
-router.get('/', async (_req, res) => {
-  const fresh = cache.get();
-  if (fresh) { res.json(fresh); return; }
-  try {
-    const data = await fetchAndBuild();
-    cache.set(data);
-    res.json(data);
-  } catch (err) {
-    log.error('Insurgency fetch failed:', err);
-    const stale = cache.getStale();
-    if (stale) { res.json(stale); return; }
-    res.status(502).json({ error: 'Failed to fetch insurgency data' });
-  }
-});
+router.get('/', cachedJsonHandler(cache, fetchAndBuild, {
+  log, logMsg: 'Insurgency fetch failed:', errorMsg: 'Failed to fetch insurgency data',
+}));
 
 export default router;

--- a/server/src/routes/scout.ts
+++ b/server/src/routes/scout.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
-import { TtlValue } from '../utils/cache.js';
+import { TtlValue, cachedJsonHandler } from '../utils/cache.js';
 
 const router = Router();
 router.use(optionalAuth);
@@ -73,19 +73,8 @@ async function fetchAndBuild(): Promise<ScoutConnection[]> {
     }));
 }
 
-router.get('/', async (_req, res) => {
-  const fresh = cache.get();
-  if (fresh) { res.json(fresh); return; }
-  try {
-    const data = await fetchAndBuild();
-    cache.set(data);
-    res.json(data);
-  } catch (err) {
-    log.error('Scout fetch failed:', err);
-    const stale = cache.getStale();
-    if (stale) { res.json(stale); return; }
-    res.status(502).json({ error: 'Failed to fetch scout signatures' });
-  }
-});
+router.get('/', cachedJsonHandler(cache, fetchAndBuild, {
+  log, logMsg: 'Scout fetch failed:', errorMsg: 'Failed to fetch scout signatures',
+}));
 
 export default router;

--- a/server/src/routes/storms.ts
+++ b/server/src/routes/storms.ts
@@ -3,7 +3,7 @@ import * as cheerio from 'cheerio';
 import { db } from '../db.js';
 import { optionalAuth } from '../middleware/optionalAuth.js';
 import { createLogger } from '../utils/logger.js';
-import { TtlValue } from '../utils/cache.js';
+import { TtlValue, cachedJsonHandler } from '../utils/cache.js';
 
 // Scrapes the EveScout Rescue stormtrack page — the only public-facing
 // source for null-sec storm locations right now (ESI doesn't expose
@@ -118,19 +118,8 @@ async function fetchAndParse(): Promise<StormSystem[]> {
   return raw.map((r) => ({ ...r, eveSystemId: idMap.get(r.systemName) ?? null }));
 }
 
-router.get('/', async (_req, res) => {
-  const fresh = cache.get();
-  if (fresh) { res.json(fresh); return; }
-  try {
-    const data = await fetchAndParse();
-    cache.set(data);
-    res.json(data);
-  } catch (err) {
-    log.error('storm scrape failed:', err);
-    const stale = cache.getStale();
-    if (stale) { res.json(stale); return; }
-    res.status(502).json({ error: 'Failed to fetch storms' });
-  }
-});
+router.get('/', cachedJsonHandler(cache, fetchAndParse, {
+  log, logMsg: 'storm scrape failed:', errorMsg: 'Failed to fetch storms',
+}));
 
 export default router;

--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -1,3 +1,5 @@
+import type { Request, Response } from 'express';
+
 // Two small TTL cache primitives used by routes that proxy ESI / zKillboard.
 //
 // - TtlValue<V>: a single TTL-guarded slot with last-success fallback. Used by
@@ -74,4 +76,28 @@ export class TtlCache<K, V> {
       if (entry.fetchedAt < cutoff) this.store.delete(k);
     }
   }
+}
+
+// Express handler for the "serve from a TtlValue, refresh on miss, fall back to
+// stale on error, else 502" shape that the incursions/insurgency/storms/scout
+// proxy routes all repeated verbatim.
+export function cachedJsonHandler<V>(
+  cache: TtlValue<V>,
+  build: () => Promise<V>,
+  opts: { log: { error: (msg: string, ...rest: unknown[]) => void }; logMsg: string; errorMsg: string },
+) {
+  return async (_req: Request, res: Response): Promise<void> => {
+    const fresh = cache.get();
+    if (fresh) { res.json(fresh); return; }
+    try {
+      const data = await build();
+      cache.set(data);
+      res.json(data);
+    } catch (err) {
+      opts.log.error(opts.logMsg, err);
+      const stale = cache.getStale();
+      if (stale) { res.json(stale); return; }
+      res.status(502).json({ error: opts.errorMsg });
+    }
+  };
 }

--- a/server/src/utils/esiFactions.ts
+++ b/server/src/utils/esiFactions.ts
@@ -1,0 +1,27 @@
+import { esiFetch } from './esi.js';
+
+export interface EsiFaction {
+  faction_id:      number;
+  name:            string;
+  corporation_id?: number;
+}
+
+// The ESI faction list is static-ish reference data; fetched once and shared
+// (incursions + insurgency both map pirate-faction ids to names/logos).
+let factionMap: Map<number, EsiFaction> | null = null;
+
+export async function loadFactions(): Promise<Map<number, EsiFaction>> {
+  if (factionMap) return factionMap;
+  const res = await esiFetch('https://esi.evetech.net/latest/universe/factions/?datasource=tranquility');
+  if (!res.ok) throw new Error(`ESI factions ${res.status}`);
+  const list = await res.json() as EsiFaction[];
+  factionMap = new Map(list.map((f) => [f.faction_id, f]));
+  return factionMap;
+}
+
+// A faction's logo is its corporation's logo (factions have no logo endpoint).
+export function factionLogoUrl(faction: EsiFaction | undefined): string {
+  return faction?.corporation_id
+    ? `https://images.evetech.net/corporations/${faction.corporation_id}/logo?size=64`
+    : '';
+}


### PR DESCRIPTION
Final backend review PR — the **safe** dedup subset (no behaviour, security, or perf change).

## Changes
- **`utils/esiFactions.ts`**: shared `loadFactions()` + `factionLogoUrl()`, used by incursions and insurgency (they had verbatim copies; now one shared faction fetch).
- **`cachedJsonHandler`** (in `utils/cache.ts`): the "serve from `TtlValue`, refresh on miss, fall back to stale on error, else 502" Express handler that incursions / insurgency / storms / scout each repeated character-for-character. Each route now passes its `build` fn plus its **exact** log and 502 messages, so responses are byte-identical.

`tsc` clean.

## Deliberately NOT done
- **Centralizing the create-map quota/role gate** — that's *authorization* logic, and you asked me to be wary of introducing security issues; refactoring it without runtime testing is exactly that risk. Left for a session where the create-map paths can be tested.
- **Router named-vs-default export unification** — lowest value, touches `index.ts` imports, pure style.

Stacks on the other backend PRs (independent files).