### PR TITLE
Relax TOKEN_ENCRYPTION_KEY weak-key guard to a warning

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -102,12 +102,11 @@ const HEX_64 = /^[0-9a-fA-F]{64}$/;
 const isHex64Key = HEX_64.test(TOKEN_ENC_RAW);
 // A short passphrase SHA-256s into a low-entropy, brute-forceable key that
 // protects every stored EVE refresh token. The strong form is 64 hex chars
-// (`openssl rand -hex 32`); a >=32-char passphrase is tolerated as a fallback,
-// but anything weaker is refused in production and warned about in dev.
+// (`openssl rand -hex 32`). We only WARN about weaker keys — never refuse to
+// boot — so self-hosted deployments that already run with a short passphrase
+// keep starting. Operators are nudged to upgrade but not locked out.
 if (!isHex64Key && TOKEN_ENC_RAW.length < 32) {
-  const msg = 'TOKEN_ENCRYPTION_KEY is too weak — use 64 hex chars (openssl rand -hex 32) or at least a 32-character passphrase';
-  if (isProd) { console.error(`FATAL: ${msg}`); process.exit(1); }
-  else console.warn(`WARNING: ${msg}`);
+  console.warn('WARNING: TOKEN_ENCRYPTION_KEY is weak — for stronger token encryption use 64 hex chars (openssl rand -hex 32) or at least a 32-character passphrase');
 }
 const tokenEncryptionKey = isHex64Key
   ? TOKEN_ENC_RAW.toLowerCase()


### PR DESCRIPTION
The weak-key guard added in #173 called `process.exit(1)` in production when the key wasn't 64 hex chars or a >=32-char passphrase. That hard-stop would break existing self-hosted deployments that already boot with a short passphrase.

This downgrades it to a **warning in all environments** so those servers keep starting. An unset key is still fatal (it genuinely can't encrypt anything).

Key derivation is unchanged — a short key still SHA-256s into a usable 32-byte key, so existing encrypted refresh tokens keep decrypting. The warning still nudges operators toward `openssl rand -hex 32`.

`tsc` clean.