### PR TITLE
Add Anomalies panel (paste from probe scanner)

### DIFF
--- a/server/scripts/setup-db.ts
+++ b/server/scripts/setup-db.ts
@@ -406,9 +406,21 @@ async function createTables() {
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
 
+    CREATE TABLE IF NOT EXISTS map_anomalies (
+      id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      system_id   UUID        NOT NULL REFERENCES map_systems(id) ON DELETE CASCADE,
+      anom_id     TEXT        NOT NULL DEFAULT '',
+      anom_type   TEXT        NOT NULL DEFAULT 'unknown',
+      name        TEXT        NOT NULL DEFAULT '',
+      notes       TEXT        NOT NULL DEFAULT '',
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+    );
+
     ALTER TABLE map_structures ADD COLUMN IF NOT EXISTS eve_id BIGINT;
 
-    ALTER TABLE users ALTER COLUMN panel_order SET DEFAULT '{notes,signatures,structures,npcStations}';
+    ALTER TABLE users ALTER COLUMN panel_order SET DEFAULT '{notes,signatures,anomalies,structures,npcStations}';
   `);
 
   // Step 2: indexes (columns guaranteed to exist after step 1)
@@ -427,6 +439,8 @@ async function createTables() {
     CREATE INDEX IF NOT EXISTS idx_map_structures_system       ON map_structures (system_id);
     CREATE INDEX IF NOT EXISTS idx_map_signatures_creator      ON map_signatures (created_by_user_id);
     CREATE INDEX IF NOT EXISTS idx_map_structures_creator      ON map_structures (created_by_user_id);
+    CREATE INDEX IF NOT EXISTS idx_map_anomalies_system        ON map_anomalies (system_id);
+    CREATE INDEX IF NOT EXISTS idx_map_anomalies_creator       ON map_anomalies (created_by_user_id);
     CREATE INDEX IF NOT EXISTS idx_user_events_map             ON user_events (map_id);
     CREATE INDEX IF NOT EXISTS idx_maps_corp                   ON maps (corp_id);
   `);

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -203,6 +203,22 @@ export async function migrate() {
       updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
 
+    -- Cosmic anomalies (no scanning required — already 100% on the probe
+    -- scanner). Separate from map_signatures: anomalies have no wormhole
+    -- type / leads-to, never back a connection, and aren't part of scan
+    -- stats. Brand-new table, so created_by_user_id is included up front.
+    CREATE TABLE IF NOT EXISTS map_anomalies (
+      id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      system_id   UUID        NOT NULL REFERENCES map_systems(id) ON DELETE CASCADE,
+      anom_id     TEXT        NOT NULL DEFAULT '',
+      anom_type   TEXT        NOT NULL DEFAULT 'unknown',
+      name        TEXT        NOT NULL DEFAULT '',
+      notes       TEXT        NOT NULL DEFAULT '',
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+    );
+
     -- Attribute sigs and structures to the user who created them, so the
     -- admin Users report can answer "last time X added a sig/struct on a
     -- corp map". Nullable: rows created before this migration stay NULL,
@@ -394,6 +410,8 @@ export async function migrate() {
     -- index they sequential-scan the whole table.
     CREATE INDEX IF NOT EXISTS idx_map_signatures_creator ON map_signatures (created_by_user_id);
     CREATE INDEX IF NOT EXISTS idx_map_structures_creator ON map_structures (created_by_user_id);
+    CREATE INDEX IF NOT EXISTS idx_map_anomalies_system  ON map_anomalies (system_id);
+    CREATE INDEX IF NOT EXISTS idx_map_anomalies_creator ON map_anomalies (created_by_user_id);
     CREATE INDEX IF NOT EXISTS idx_user_events_map         ON user_events (map_id);
     CREATE INDEX IF NOT EXISTS idx_maps_corp               ON maps (corp_id);
 

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1793,6 +1793,79 @@ mapsRouter.delete('/:mapId/systems/:systemId/signatures/:sigId', async (req, res
   res.json({ ok: true });
 });
 
+// ── Anomalies ─────────────────────────────────────────────────────────────────
+// Cosmic anomalies pasted from the probe scanner. Same shape as the signature
+// routes but simpler: no wormhole type / leads-to, no K162 dispatch, no ghost
+// site recording, and they don't back map connections.
+
+mapsRouter.get('/:mapId/systems/:systemId/anomalies', async (req, res) => {
+  const { mapId, systemId } = req.params;
+  const access = await getMapAccess(mapId, req);
+  if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
+  if (!(await verifySystemInMap(res, systemId, mapId))) return;
+  const { rows } = await db.query(
+    `SELECT id, anom_id AS "anomId", anom_type AS "anomType", name, notes, created_at AS "createdAt", updated_at AS "updatedAt"
+     FROM map_anomalies WHERE system_id = $1 ORDER BY created_at`,
+    [systemId],
+  );
+  res.json(rows);
+});
+
+mapsRouter.post('/:mapId/systems/:systemId/anomalies', async (req, res) => {
+  const { mapId, systemId } = req.params;
+  const access = await requireMapContentWrite(res, mapId, req);
+  if (!access) return;
+  if (!(await verifySystemInMap(res, systemId, mapId))) return;
+  const { anomId = '', anomType = 'unknown', name = '', notes = '' } = req.body as Record<string, string>;
+  const { rows } = await db.query(
+    `INSERT INTO map_anomalies (system_id, anom_id, anom_type, name, notes, created_by_user_id)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id, anom_id AS "anomId", anom_type AS "anomType", name, notes, created_at AS "createdAt", updated_at AS "updatedAt"`,
+    [systemId, anomId, anomType, name, notes, req.session.userId],
+  );
+  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
+  publishToMap(mapId, { type: 'anom.changed', actor: req.get('x-client-id') ?? null, systemId });
+  res.status(201).json(rows[0]);
+});
+
+mapsRouter.patch('/:mapId/systems/:systemId/anomalies/:anomId', async (req, res) => {
+  const { mapId, systemId, anomId } = req.params;
+  const access = await requireMapContentWrite(res, mapId, req);
+  if (!access) return;
+  if (!(await verifySystemInMap(res, systemId, mapId))) return;
+
+  const colMap: Record<string, string> = { anomId: 'anom_id', anomType: 'anom_type', name: 'name', notes: 'notes' };
+  const updates = req.body as Record<string, unknown>;
+
+  const sets: string[] = ['updated_at = NOW()'];
+  const vals: unknown[] = [];
+  for (const [key, col] of Object.entries(colMap)) {
+    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
+  }
+
+  await db.query(
+    // map_id scoping is defence-in-depth: verifySystemInMap above already
+    // guarantees systemId is in this map, but enforcing it in SQL too means a
+    // future refactor can't open a cross-map write.
+    `UPDATE map_anomalies SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND system_id IN (SELECT id FROM map_systems WHERE map_id = $${vals.length + 3})`,
+    [...vals, anomId, systemId, mapId],
+  );
+  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
+  publishToMap(mapId, { type: 'anom.changed', actor: req.get('x-client-id') ?? null, systemId });
+  res.json({ ok: true });
+});
+
+mapsRouter.delete('/:mapId/systems/:systemId/anomalies/:anomId', async (req, res) => {
+  const { mapId, systemId, anomId } = req.params;
+  const access = await requireMapContentWrite(res, mapId, req);
+  if (!access) return;
+  if (!(await verifySystemInMap(res, systemId, mapId))) return;
+  await db.query(`DELETE FROM map_anomalies WHERE id = $1 AND system_id = $2 AND system_id IN (SELECT id FROM map_systems WHERE map_id = $3)`, [anomId, systemId, mapId]);
+  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
+  publishToMap(mapId, { type: 'anom.changed', actor: req.get('x-client-id') ?? null, systemId });
+  res.json({ ok: true });
+});
+
 // ── Structures (manual player structures) ─────────────────────────────────────
 
 mapsRouter.get('/:mapId/systems/:systemId/structures', async (req, res) => {

--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -334,10 +334,6 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
     () => { for (const id of selected) deleteAnom(id); },
   );
 
-  const setSelectedType = (type: AnomType) => {
-    for (const id of selected) updateAnom(id, { anomType: type });
-  };
-
   const deleteAll = () => confirm(
     t('anomalies.deleteAllConfirm', { count: anomsRef.current.length }),
     () => { for (const a of anomsRef.current) deleteAnom(a.id); },
@@ -446,26 +442,9 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
             ))}
           </select>
           {selected.size > 0 && (
-            <>
-              <select
-                className="sig-toolbar-btn"
-                value=""
-                onChange={(e) => {
-                  if (!e.target.value) return;
-                  setSelectedType(e.target.value as AnomType);
-                  e.target.value = '';
-                }}
-                aria-label={t('anomalies.setTypeAria')}
-              >
-                <option value="">{t('anomalies.setType', { count: selected.size })}</option>
-                {ANOM_TYPE_OPTIONS.map((type) => (
-                  <option key={type} value={type}>{t(`anomType.${type}`)}</option>
-                ))}
-              </select>
-              <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteSelected}>
-                {t('anomalies.deleteSelected', { count: selected.size })}
-              </button>
-            </>
+            <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteSelected}>
+              {t('anomalies.deleteSelected', { count: selected.size })}
+            </button>
           )}
           {anoms.length > 0 && (
             <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteAll}>

--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -1,0 +1,614 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { api } from '../../api/client';
+import { useMapStore } from '../../store/mapStore';
+import { useCanEditContent } from '../../hooks/useCanEditContent';
+import { useShareMode } from '../../context/ShareModeContext';
+import { useUserSetting } from '../../hooks/useUserSetting';
+import type { Anomaly, AnomType } from '../../types';
+import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
+import { NotesEditor } from './NotesEditor';
+import { XIcon } from '@phosphor-icons/react';
+import { toast } from './Toaster';
+
+// Cosmic anomalies don't need scanning — the probe scanner lists them at 100%
+// straight away. The scanner's "group" column is "Cosmic Anomaly" (vs "Cosmic
+// Signature" for sigs), so a single Ctrl+A / Ctrl+C of the whole window can be
+// routed by group: this pane takes the anomalies, the signature pane takes the
+// signatures (see SignaturePane's parser, which now rejects anomaly rows).
+const ANOM_GROUP = 'cosmic anomaly';
+
+const ANOM_TYPE_LABELS: Record<AnomType, string> = {
+  unknown: 'Unknown',
+  combat:  'Combat',
+  ore:     'Ore',
+  gas:     'Gas',
+};
+
+// Scanner "type" column ("Combat Site", "Ore Site", "Gas Site") → our enum.
+const EVE_ANOM_TYPE: Record<string, AnomType> = {
+  'combat site': 'combat',
+  'ore site':    'ore',
+  'gas site':    'gas',
+};
+
+interface ParsedAnom { anomId: string; anomType: AnomType; name: string; }
+
+function parseAnomClipboard(text: string): ParsedAnom[] {
+  return text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .flatMap((line): ParsedAnom[] => {
+      const parts = line.split('\t');
+      const anomId = parts[0]?.trim().toUpperCase() ?? '';
+      if (!/^[A-Z]{3}-\d{3}$/.test(anomId)) return [];
+      // Only rows the scanner classes as a Cosmic Anomaly — everything else
+      // (signatures) is left for the signature pane.
+      if ((parts[1]?.trim().toLowerCase() ?? '') !== ANOM_GROUP) return [];
+      const type = parts[2]?.trim().toLowerCase() ?? '';
+      const anomType = EVE_ANOM_TYPE[type] ?? 'unknown';
+      const col3 = parts[3]?.trim() ?? '';
+      const name = /^\d+\.?\d*%$/.test(col3) ? '' : col3;
+      return [{ anomId, anomType, name }];
+    });
+}
+
+type SortCol = 'anomId' | 'anomType' | 'name' | 'createdAt' | 'updatedAt';
+type ColKey  = 'id' | 'type' | 'name' | 'notes';
+
+const DEFAULT_WIDTHS: Record<ColKey, number> = {
+  id:    72,
+  type:  108,
+  name:  200,
+  notes: 220,
+};
+
+// Grace-period choices (seconds) offered before an overwrite-paste actually
+// deletes an anomaly absent from the new scan. Mirrors the signature pane.
+const OVERWRITE_DELAY_OPTIONS = [0, 5, 10, 30, 60, 120] as const;
+const OVERWRITE_DELAY_DEFAULT = 10;
+function formatDelay(sec: number): string {
+  return sec >= 60 ? `${sec / 60}m` : `${sec}s`;
+}
+
+// Filter chips + type-select options. Reuses the sig-* type colour classes,
+// which already cover combat / ore / gas / unknown.
+const ANOM_TYPE_FILTER_ORDER: AnomType[] = ['combat', 'ore', 'gas', 'unknown'];
+const ANOM_TYPE_OPTIONS: AnomType[] = ['combat', 'gas', 'ore', 'unknown'];
+
+export function AnomalyPane({ systemId }: { systemId: string }) {
+  const { t } = useTranslation();
+  const anomTypeLabel = (type: AnomType) =>
+    type === 'unknown' ? t('anomType.unknown') : ANOM_TYPE_LABELS[type];
+  const activeMapId     = useMapStore((s) => s.activeMapId);
+  const map             = useMapStore((s) => s.map);
+  const currentSystemId = useMapStore((s) => s.currentSystemId);
+  const canEdit         = useCanEditContent();
+  const { isShareMode } = useShareMode();
+
+  const [anoms, setAnoms]         = useState<Anomaly[]>([]);
+  const [selected, setSelected]   = useState<Set<string>>(new Set());
+  const [pendingAction, setPendingAction] = useState<{ message: string; fn: () => void; confirmLabel?: string; showDontAskAgain?: boolean } | null>(null);
+  const [sortCol, setSortCol]     = useState<SortCol | null>('anomId');
+  const [sortDir, setSortDir]     = useState<'asc' | 'desc'>('asc');
+  const [typeFilter, setTypeFilter] = useState<Set<AnomType>>(new Set());
+
+  const toggleTypeFilter = (type: AnomType) => {
+    setTypeFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  };
+
+  const [savedColWidths, setColWidths] = useUserSetting<Partial<Record<ColKey, number>>>(
+    'nexum.anomPane.colWidths',
+    {},
+  );
+  const colWidths = useMemo(
+    () => ({ ...DEFAULT_WIDTHS, ...savedColWidths }) as Record<ColKey, number>,
+    [savedColWidths],
+  );
+
+  const pendingUpdates = useRef<Map<string, Partial<Anomaly>>>(new Map());
+  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const anomsRef       = useRef<Anomaly[]>([]);
+  useEffect(() => { anomsRef.current = anoms; }, [anoms]);
+
+  // Overwrite-on-paste: when on (or Shift held), a paste also removes anomalies
+  // whose ID is absent from the pasted scan. Off by default (additive).
+  const [overwriteOnPaste, setOverwriteOnPaste] = useUserSetting<boolean>(
+    'nexum.anomPane.overwriteOnPaste',
+    false,
+  );
+  const shiftHeldRef = useRef(false);
+
+  const [overwriteDelay, setOverwriteDelay] = useUserSetting<number>(
+    'nexum.anomPane.overwriteDelay',
+    OVERWRITE_DELAY_DEFAULT,
+  );
+
+  // Anomalies pending delayed removal, plus their timers.
+  const [removing, setRemoving] = useState<Set<string>>(new Set());
+  const removalTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => () => {
+    for (const tm of removalTimers.current.values()) clearTimeout(tm);
+    removalTimers.current.clear();
+  }, []);
+
+  useEffect(() => {
+    const onDown = (e: KeyboardEvent) => { if (e.key === 'Shift') shiftHeldRef.current = true; };
+    const onUp   = (e: KeyboardEvent) => { if (e.key === 'Shift') shiftHeldRef.current = false; };
+    const reset  = () => { shiftHeldRef.current = false; };
+    window.addEventListener('keydown', onDown);
+    window.addEventListener('keyup', onUp);
+    window.addEventListener('blur', reset);
+    return () => {
+      window.removeEventListener('keydown', onDown);
+      window.removeEventListener('keyup', onUp);
+      window.removeEventListener('blur', reset);
+    };
+  }, []);
+
+  // Bumped when another client changes this system's anomalies (live sync).
+  const anomRev = useMapStore((s) => s.anomRev[systemId] ?? 0);
+
+  useEffect(() => {
+    if (!activeMapId) return;
+    for (const tm of removalTimers.current.values()) clearTimeout(tm);
+    removalTimers.current.clear();
+    setRemoving(new Set());
+    setAnoms([]);
+    setSelected(new Set());
+
+    // Share viewers don't get anomalies embedded in the payload yet, and the
+    // /api/maps route isn't reachable on the placeholder "shared" mapId — the
+    // panel is hidden in share mode (see SystemPanel), so just bail.
+    if (isShareMode) return;
+
+    api<Anomaly[]>(`/api/maps/${activeMapId}/systems/${systemId}/anomalies`)
+      .then(setAnoms)
+      .catch(() => toast.error(t('anomalies.loadFailed')));
+  }, [activeMapId, systemId, isShareMode]);
+
+  // Live sync: re-fetch in place when a remote client changes this system's
+  // anomalies. Guarded so it doesn't fire on initial mount (rev starts at 0).
+  useEffect(() => {
+    if (!activeMapId || isShareMode || anomRev === 0) return;
+    api<Anomaly[]>(`/api/maps/${activeMapId}/systems/${systemId}/anomalies`)
+      .then(setAnoms)
+      .catch(() => {});
+  }, [anomRev, activeMapId, systemId, isShareMode]);
+
+  const updateAnom = (id: string, updates: Partial<Anomaly>) => {
+    const withTs = { ...updates, updatedAt: new Date().toISOString() };
+    setAnoms((prev) => prev.map((a) => a.id === id ? { ...a, ...withTs } : a));
+
+    pendingUpdates.current.set(id, { ...(pendingUpdates.current.get(id) ?? {}), ...updates });
+    clearTimeout(debounceTimers.current.get(id));
+    debounceTimers.current.set(id, setTimeout(async () => {
+      const payload = pendingUpdates.current.get(id);
+      if (!payload || !activeMapId) return;
+      pendingUpdates.current.delete(id);
+      api(`/api/maps/${activeMapId}/systems/${systemId}/anomalies/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }).catch(() => toast.error(t('anomalies.saveFailed')));
+    }, 500));
+  };
+
+  const clearRemoval = (id: string) => {
+    const tm = removalTimers.current.get(id);
+    if (tm) { clearTimeout(tm); removalTimers.current.delete(id); }
+    setRemoving((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev); next.delete(id); return next;
+    });
+  };
+
+  const deleteAnom = (id: string) => {
+    if (!activeMapId) return;
+    clearRemoval(id);
+    setAnoms((prev) => prev.filter((a) => a.id !== id));
+    setSelected((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    api(`/api/maps/${activeMapId}/systems/${systemId}/anomalies/${id}`, { method: 'DELETE' })
+      .catch(() => toast.error(t('anomalies.deleteFailed')));
+  };
+
+  const scheduleRemoval = (id: string, delaySec: number) => {
+    const existing = removalTimers.current.get(id);
+    if (existing) clearTimeout(existing);
+    if (delaySec <= 0) {
+      removalTimers.current.delete(id);
+      deleteAnom(id);
+      return;
+    }
+    setRemoving((prev) => { const next = new Set(prev); next.add(id); return next; });
+    const tm = setTimeout(() => deleteAnom(id), delaySec * 1000);
+    removalTimers.current.set(id, tm);
+  };
+
+  const processPaste = useCallback(async (parsed: ParsedAnom[], overwrite: boolean, delaySec: number) => {
+    if (!activeMapId) return;
+    const existing = anomsRef.current;
+    const toUpdate: { id: string; updates: Partial<Anomaly> }[] = [];
+    const toCreate: ParsedAnom[] = [];
+
+    for (const p of parsed) {
+      const match = existing.find((a) => a.anomId === p.anomId);
+      if (match) {
+        const updates: Partial<Anomaly> = {};
+        if (p.anomType !== 'unknown') updates.anomType = p.anomType;
+        if (p.name) updates.name = p.name;
+        toUpdate.push({ id: match.id, updates });
+      } else {
+        toCreate.push(p);
+      }
+    }
+
+    // Overwrite mode: anomalies absent from the new scan are flagged for
+    // delayed removal (an anomaly that reappears has its removal cancelled).
+    // Blank/manually-added rows (no ID) are left alone.
+    if (overwrite) {
+      const pastedIds = new Set(parsed.map((p) => p.anomId));
+      for (const a of existing) {
+        if (!a.anomId) continue;
+        if (pastedIds.has(a.anomId)) clearRemoval(a.id);
+        else scheduleRemoval(a.id, delaySec);
+      }
+    }
+
+    for (const { id, updates } of toUpdate) updateAnom(id, updates);
+
+    const created = (await Promise.all(
+      toCreate.map((p) =>
+        api<Anomaly>(
+          `/api/maps/${activeMapId}/systems/${systemId}/anomalies`,
+          { method: 'POST', body: JSON.stringify({ anomId: p.anomId, anomType: p.anomType, name: p.name }) },
+        ).catch(() => null),
+      ),
+    )).filter((a): a is Anomaly => a !== null);
+
+    setAnoms((prev) => [...prev, ...created].sort((a, b) => a.anomId.localeCompare(b.anomId)));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeMapId, systemId]);
+
+  useEffect(() => {
+    if (!activeMapId) return;
+
+    const handlePaste = (e: ClipboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) return;
+
+      const text = e.clipboardData?.getData('text') ?? '';
+      const parsed = parseAnomClipboard(text);
+      if (parsed.length === 0) return;
+
+      e.preventDefault();
+
+      const overwrite = overwriteOnPaste || shiftHeldRef.current;
+      const delaySec = overwriteDelay;
+
+      if (currentSystemId && currentSystemId !== systemId) {
+        const currentName  = map.systems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
+        const selectedName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown';
+        setPendingAction({
+          message: t('anomalies.pasteDifferentSystem', { current: currentName, selected: selectedName }),
+          fn: () => processPaste(parsed, overwrite, delaySec),
+          confirmLabel: t('actions.ok'),
+          showDontAskAgain: false,
+        });
+        return;
+      }
+
+      processPaste(parsed, overwrite, delaySec);
+    };
+
+    window.addEventListener('paste', handlePaste);
+    return () => window.removeEventListener('paste', handlePaste);
+  }, [activeMapId, systemId, currentSystemId, map.systems, processPaste, overwriteOnPaste, overwriteDelay, t]);
+
+  const addAnom = async () => {
+    if (!activeMapId) return;
+    const anom = await api<Anomaly>(
+      `/api/maps/${activeMapId}/systems/${systemId}/anomalies`,
+      { method: 'POST', body: JSON.stringify({}) },
+    );
+    setAnoms((prev) => [...prev, anom]);
+  };
+
+  const confirm = (message: string, action: () => void) => {
+    if (shouldSkipConfirm()) { action(); return; }
+    setPendingAction({ message, fn: action });
+  };
+
+  const deleteSelected = () => confirm(
+    t('anomalies.deleteSelectedConfirm', { count: selected.size }),
+    () => { for (const id of selected) deleteAnom(id); },
+  );
+
+  const setSelectedType = (type: AnomType) => {
+    for (const id of selected) updateAnom(id, { anomType: type });
+  };
+
+  const deleteAll = () => confirm(
+    t('anomalies.deleteAllConfirm', { count: anomsRef.current.length }),
+    () => { for (const a of anomsRef.current) deleteAnom(a.id); },
+  );
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const allChecked = anoms.length > 0 && selected.size === anoms.length;
+  const someChecked = selected.size > 0 && !allChecked;
+  const toggleAll = () => setSelected(allChecked ? new Set() : new Set(anoms.map((a) => a.id)));
+
+  const handleSort = (col: SortCol) => {
+    if (sortCol === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  };
+
+  const sortedAnoms = useMemo(() => {
+    const base = typeFilter.size ? anoms.filter((a) => typeFilter.has(a.anomType)) : anoms;
+    if (!sortCol) return base;
+    return [...base].sort((a, b) => {
+      const av = (a[sortCol] ?? '').toLowerCase();
+      const bv = (b[sortCol] ?? '').toLowerCase();
+      const cmp = av.localeCompare(bv);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [anoms, sortCol, sortDir, typeFilter]);
+
+  const startResize = (col: ColKey, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startX = e.clientX;
+    const startWidth = colWidths[col];
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMove = (ev: MouseEvent) => {
+      const newWidth = Math.max(40, startWidth + ev.clientX - startX);
+      setColWidths((prev) => ({ ...prev, [col]: newWidth }));
+    };
+
+    const onUp = () => {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  };
+
+  const sortInd = (col: SortCol) =>
+    sortCol === col ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+
+  return (
+    <>
+    {pendingAction && (
+      <ConfirmModal
+        message={pendingAction.message}
+        onConfirm={() => { pendingAction.fn(); setPendingAction(null); }}
+        onCancel={() => setPendingAction(null)}
+        confirmLabel={pendingAction.confirmLabel}
+        showDontAskAgain={pendingAction.showDontAskAgain}
+      />
+    )}
+    <div className="sig-pane">
+      {anoms.length === 0 && (
+        <p className="sig-pane__hint">{t('anomalies.pasteHint')}</p>
+      )}
+      {canEdit && (
+        <div className="sig-pane__toolbar">
+          <button className="icon-btn" onClick={addAnom} title={t('anomalies.addAnomaly')}>{t('anomalies.addAnomaly')}</button>
+          <label
+            className={`sig-overwrite-toggle${overwriteOnPaste ? ' sig-overwrite-toggle--active' : ''}`}
+            data-tooltip={t('anomalies.overwriteTooltip')}
+          >
+            <input
+              type="checkbox"
+              className="map-sidebar__toggle-input"
+              checked={overwriteOnPaste}
+              onChange={(e) => setOverwriteOnPaste(e.target.checked)}
+            />
+            <span>{t('anomalies.overwriteToggle')}</span>
+          </label>
+          <select
+            className="sig-toolbar-btn"
+            value={overwriteDelay}
+            onChange={(e) => setOverwriteDelay(Number(e.target.value))}
+            aria-label={t('anomalies.removeDelayLabel')}
+            data-tooltip={t('anomalies.removeDelayTooltip')}
+          >
+            {OVERWRITE_DELAY_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s === 0 ? t('anomalies.removeDelayInstant') : formatDelay(s)}
+              </option>
+            ))}
+          </select>
+          {selected.size > 0 && (
+            <>
+              <select
+                className="sig-toolbar-btn"
+                value=""
+                onChange={(e) => {
+                  if (!e.target.value) return;
+                  setSelectedType(e.target.value as AnomType);
+                  e.target.value = '';
+                }}
+                aria-label={t('anomalies.setTypeAria')}
+              >
+                <option value="">{t('anomalies.setType', { count: selected.size })}</option>
+                {ANOM_TYPE_OPTIONS.map((type) => (
+                  <option key={type} value={type}>{t(`anomType.${type}`)}</option>
+                ))}
+              </select>
+              <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteSelected}>
+                {t('anomalies.deleteSelected', { count: selected.size })}
+              </button>
+            </>
+          )}
+          {anoms.length > 0 && (
+            <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteAll}>
+              {t('anomalies.deleteAll')}
+            </button>
+          )}
+        </div>
+      )}
+
+      {anoms.length > 0 && (
+        <div className="sig-pane__filter" role="group" aria-label={t('anomalies.filterLabel')}>
+          {ANOM_TYPE_FILTER_ORDER.map((type) => (
+            <button
+              key={type}
+              type="button"
+              className={`sig-filter-chip sig-filter-chip--${type}${typeFilter.has(type) ? ' sig-filter-chip--active' : ''}`}
+              aria-pressed={typeFilter.has(type)}
+              onClick={() => toggleTypeFilter(type)}
+            >
+              {t(`anomType.${type}`)}
+            </button>
+          ))}
+          {typeFilter.size > 0 && (
+            <button type="button" className="sig-filter-clear" onClick={() => setTypeFilter(new Set())}>
+              {t('anomalies.filterClear')}
+            </button>
+          )}
+        </div>
+      )}
+
+      {anoms.length === 0 ? (
+        <div className="sig-pane__empty">{t('anomalies.empty')}</div>
+      ) : sortedAnoms.length === 0 ? (
+        <div className="sig-pane__empty">{t('anomalies.noMatchFilter')}</div>
+      ) : (
+        <div className="sig-table-wrap">
+        <table className="sig-table">
+          <colgroup>
+            <col className="sig-col--check" />
+            <col style={{ width: colWidths.id }} />
+            <col style={{ width: colWidths.type }} />
+            <col style={{ width: colWidths.name }} />
+            <col style={{ width: colWidths.notes }} />
+            <col className="sig-col--actions" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  className="sig-checkbox"
+                  checked={allChecked}
+                  ref={(el) => { if (el) el.indeterminate = someChecked; }}
+                  onChange={toggleAll}
+                />
+              </th>
+              <th className="sig-th sig-th--sortable" onClick={() => handleSort('anomId')}>
+                {t('anomalies.colId')}{sortInd('anomId')}
+                <div className="sig-th__resize" onMouseDown={(e) => startResize('id', e)} />
+              </th>
+              <th className="sig-th sig-th--sortable" onClick={() => handleSort('anomType')}>
+                {t('anomalies.colType')}{sortInd('anomType')}
+                <div className="sig-th__resize" onMouseDown={(e) => startResize('type', e)} />
+              </th>
+              <th className="sig-th sig-th--sortable" onClick={() => handleSort('name')}>
+                {t('anomalies.colName')}{sortInd('name')}
+                <div className="sig-th__resize" onMouseDown={(e) => startResize('name', e)} />
+              </th>
+              <th className="sig-th">
+                {t('anomalies.colNotes')}
+                <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
+              </th>
+              <th className="sig-cell--actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {sortedAnoms.map((anom) => (
+              <tr
+                key={anom.id}
+                className={`${selected.has(anom.id) ? 'sig-row--selected' : ''} ${anom.anomType === 'unknown' ? 'sig-row--unknown' : ''} ${removing.has(anom.id) ? 'sig-row--removing' : ''}`}
+                style={removing.has(anom.id) && overwriteDelay > 0 ? { animationDuration: `${overwriteDelay}s` } : undefined}
+              >
+                <td>
+                  <input
+                    type="checkbox"
+                    className="sig-checkbox"
+                    checked={selected.has(anom.id)}
+                    onChange={() => toggleSelect(anom.id)}
+                  />
+                </td>
+                <td>
+                  <input
+                    className="sig-input sig-input--id"
+                    value={anom.anomId}
+                    onChange={(e) => updateAnom(anom.id, { anomId: e.target.value.toUpperCase() })}
+                    placeholder="ABC-123"
+                    maxLength={7}
+                    spellCheck={false}
+                  />
+                </td>
+                <td>
+                  <select
+                    className={`sig-select sig-select--type sig-select--type-${anom.anomType}`}
+                    value={anom.anomType}
+                    onChange={(e) => updateAnom(anom.id, { anomType: e.target.value as AnomType })}
+                  >
+                    {ANOM_TYPE_OPTIONS.map((at) => (
+                      <option key={at} value={at}>{anomTypeLabel(at)}</option>
+                    ))}
+                  </select>
+                </td>
+                <td>
+                  <input
+                    className="sig-input"
+                    value={anom.name}
+                    onChange={(e) => updateAnom(anom.id, { name: e.target.value })}
+                    placeholder={t('anomalies.namePlaceholder')}
+                  />
+                </td>
+                <td className="sig-notes-cell">
+                  <NotesEditor
+                    value={anom.notes}
+                    onChange={(v) => updateAnom(anom.id, { notes: v })}
+                    compact
+                    readOnly={!canEdit}
+                  />
+                </td>
+                <td className="sig-cell--actions">
+                  {canEdit && (
+                    <button
+                      className="icon-btn icon-btn--danger"
+                      onClick={() => deleteAnom(anom.id)}
+                      title={t('actions.delete')}
+                    ><XIcon size={12} weight="bold" /></button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        </div>
+      )}
+    </div>
+    </>
+  );
+}

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -90,6 +90,11 @@ function parseSigClipboard(text: string): ParsedSig[] {
       const parts = line.split('\t');
       const sigId = parts[0]?.trim().toUpperCase() ?? '';
       if (!/^[A-Z]{3}-\d{3}$/.test(sigId)) return [];
+      // Skip cosmic anomalies — they live in the Anomalies pane. The scanner's
+      // group column ("Cosmic Anomaly" vs "Cosmic Signature") lets a single
+      // Ctrl+A/Ctrl+C of the whole window route each row to the right pane.
+      // Rows without a group column (partial/manual pastes) still pass through.
+      if ((parts[1]?.trim().toLowerCase() ?? '') === 'cosmic anomaly') return [];
       const group = parts[2]?.trim() ?? '';
       const sigType = EVE_GROUP_TO_TYPE[group.toLowerCase()] ?? 'unknown';
       const col3 = parts[3]?.trim() ?? '';

--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -12,6 +12,7 @@ import { useMapStore } from '../../store/mapStore';
 import { CLASS_COLORS, CLASS_LABELS, EFFECT_LABELS, EFFECT_MODIFIERS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
 import { DraggableCard } from './DraggableCard';
 import { SignaturePane } from './SignaturePane';
+import { AnomalyPane } from './AnomalyPane';
 import { StructuresPane } from './StructuresPane';
 import { NpcStationsPane } from './NpcStationsPane';
 import { NotesEditor } from './NotesEditor';
@@ -173,6 +174,7 @@ export function SystemPanel() {
   const panelTitle: Record<string, string> = {
     notes:       t('panel.notes'),
     signatures:  t('panel.signatures'),
+    anomalies:   t('panel.anomalies'),
     structures:  t('panel.structures'),
     npcStations: t('panel.npcStations'),
     killboard:   t('panel.killboard'),
@@ -299,6 +301,7 @@ export function SystemPanel() {
       />
     ),
     signatures:  <SignaturePane systemId={sys.id} />,
+    anomalies:   <AnomalyPane systemId={sys.id} />,
     structures:  <StructuresPane systemId={sys.id} />,
     npcStations: <NpcStationsPane eveSystemId={sys.eveSystemId} />,
     killboard:   <KillboardPane eveSystemId={sys.eveSystemId} />,
@@ -674,6 +677,9 @@ export function SystemPanel() {
                 if (id === 'notes')      return shareIncludesNotes;
                 if (id === 'structures') return shareIncludesStructures;
                 if (id === 'signatures') return shareIncludesSigs;
+                // Anomalies aren't embedded in the share payload yet, so the
+                // pane would always be empty for a guest — hide it for now.
+                if (id === 'anomalies')  return false;
                 return true;
               })
               .map((id) => (

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "Statische WHs anzeigen",
     "easyConnect": "Einfaches Verbinden",
     "connectionStyle": "Verbindungsstil",
-    "edgeStyle": { "bezier": "Standard", "straight": "Gerade", "smoothstep": "Stufe" },
+    "edgeStyle": {
+      "bezier": "Standard",
+      "straight": "Gerade",
+      "smoothstep": "Stufe"
+    },
     "connectionThickness": "Verbindungsstärke",
-    "thickness": { "thin": "Dünn", "standard": "Standard", "thick": "Dick", "extra": "Extra dick" },
+    "thickness": {
+      "thin": "Dünn",
+      "standard": "Standard",
+      "thick": "Dick",
+      "extra": "Extra dick"
+    },
     "optimizeConnections": "⟳ Verbindungen optimieren",
     "spreadNodes": "⊞ Knoten verteilen",
     "spreadNodesTooltip": "Systemknoten anpassen, um Überlappungen zu vermeiden",
@@ -510,7 +519,11 @@
     "sizeSmall": "Klein (Fregatte)",
     "rollingCalculator": "Rolling-Rechner",
     "custom": "Benutzerdefiniert",
-    "collapse": { "open": "Offen", "maybe": "Möglicherweise kollabiert", "collapsed": "Kollabiert" },
+    "collapse": {
+      "open": "Offen",
+      "maybe": "Möglicherweise kollabiert",
+      "collapsed": "Kollabiert"
+    },
     "remaining": "{{worst}}–{{best}} übrig · {{used}} verbraucht · max. Sprung {{max}}",
     "useMyShip": "Mein Schiff verwenden",
     "useMyShipTitle": "Kalt = {{ship}} ({{mass}}), heiß = +Prop",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "Notizen",
     "signatures": "Signaturen",
+    "anomalies": "Anomalien",
     "structures": "Strukturen",
     "npcStations": "NPC-Stationen",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "Erz",
     "combat": "Kampf"
   },
+  "anomType": {
+    "unknown": "Unbekannt",
+    "combat": "Kampf",
+    "ore": "Erz",
+    "gas": "Gas"
+  },
   "signatures": {
     "pasteHint": "Du kannst Signaturen direkt aus dem Sondenscanner in EVE kopieren und einfügen. Öffne dazu deinen Sondenscanner. Drücke Strg+A, um alle auszuwählen, dann Strg+C zum Kopieren. Mit Strg+V hier einfügen.",
     "pasteDifferentSystem": "Dein Charakter ist derzeit in {{current}}, aber du fügst Signaturen in {{selected}} ein. Fortfahren?",
@@ -803,6 +823,36 @@
     "colAge": "Alter",
     "colUpdated": "Aktualisiert",
     "namePlaceholder": "Seitenname"
+  },
+  "anomalies": {
+    "pasteHint": "Du kannst Anomalien direkt aus dem Sondenscanner in EVE kopieren und einfügen. Öffne deinen Sondenscanner, drücke Strg+A, um alle auszuwählen, Strg+C zum Kopieren und dann Strg+V, um sie hier einzufügen. Zusammen eingefügte Signaturen und Anomalien werden automatisch ins richtige Panel sortiert.",
+    "pasteDifferentSystem": "Dein Charakter ist derzeit in {{current}}, aber du fügst Anomalien in {{selected}} ein. Fortfahren?",
+    "loadFailed": "Anomalien konnten nicht geladen werden",
+    "saveFailed": "Anomalie konnte nicht gespeichert werden",
+    "deleteFailed": "Anomalie konnte nicht gelöscht werden",
+    "deleteSelectedConfirm_one": "{{count}} ausgewählte Anomalie löschen?",
+    "deleteSelectedConfirm_other": "{{count}} ausgewählte Anomalien löschen?",
+    "deleteAllConfirm_one": "Alle {{count}} Anomalie löschen?",
+    "deleteAllConfirm_other": "Alle {{count}} Anomalien löschen?",
+    "addAnomaly": "Anomalie hinzufügen",
+    "overwriteToggle": "Beim Einfügen überschreiben",
+    "overwriteTooltip": "Wenn aktiv, ersetzt das Einfügen die Liste — Anomalien, die nicht mehr im Scan sind, werden entfernt. Oder halte beim Einfügen Umschalt gedrückt, um nur einmal zu überschreiben.",
+    "removeDelayLabel": "Löschverzögerung",
+    "removeDelayTooltip": "Wie lange eine verschwundene Anomalie (durchgestrichen) sichtbar bleibt, bevor ein Überschreib-Einfügen sie löscht — Zeit, um ihr Lesezeichen im Spiel zu entfernen.",
+    "removeDelayInstant": "Sofort",
+    "filterLabel": "Nach Typ filtern",
+    "filterClear": "Zurücksetzen",
+    "noMatchFilter": "Keine Anomalien entsprechen dem Filter",
+    "setTypeAria": "Typ für ausgewählte Anomalien festlegen",
+    "setType": "Typ festlegen ({{count}})…",
+    "deleteSelected": "Ausgewählte löschen ({{count}})",
+    "deleteAll": "Alle löschen",
+    "empty": "Keine Anomalien — aus dem Sondenscanner einfügen, um zu importieren",
+    "colId": "ID",
+    "colType": "Typ",
+    "colName": "Name",
+    "colNotes": "Notizen",
+    "namePlaceholder": "Anomalie-Name"
   },
   "stats": {
     "title": "Benutzerstatistik",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -604,6 +604,7 @@
   "panel": {
     "notes": "Notes",
     "signatures": "Signatures",
+    "anomalies": "Anomalies",
     "structures": "Structures",
     "npcStations": "NPC Stations",
     "killboard": "zKillboard",
@@ -766,6 +767,12 @@
     "ore": "Ore",
     "combat": "Combat"
   },
+  "anomType": {
+    "unknown": "Unknown",
+    "combat": "Combat",
+    "ore": "Ore",
+    "gas": "Gas"
+  },
   "signatures": {
     "pasteHint": "You can copy and paste signatures directly from the Probe scanner in Eve. To do this, open your probe scanner.  Press control A to select them all, then control C to copy.  Use control V to paste them here",
     "pasteDifferentSystem": "Your character is currently in {{current}}, but you are pasting signatures into {{selected}}. Continue?",
@@ -803,6 +810,36 @@
     "colAge": "Age",
     "colUpdated": "Updated",
     "namePlaceholder": "Site name"
+  },
+  "anomalies": {
+    "pasteHint": "You can copy and paste anomalies directly from the Probe scanner in Eve. Open your probe scanner, press Ctrl+A to select all, Ctrl+C to copy, then Ctrl+V to paste them here. Signatures and anomalies pasted together are sorted into the right panel automatically.",
+    "pasteDifferentSystem": "Your character is currently in {{current}}, but you are pasting anomalies into {{selected}}. Continue?",
+    "loadFailed": "Failed to load anomalies",
+    "saveFailed": "Failed to save anomaly",
+    "deleteFailed": "Failed to delete anomaly",
+    "deleteSelectedConfirm_one": "Delete {{count}} selected anomaly?",
+    "deleteSelectedConfirm_other": "Delete {{count}} selected anomalies?",
+    "deleteAllConfirm_one": "Delete all {{count}} anomaly?",
+    "deleteAllConfirm_other": "Delete all {{count}} anomalies?",
+    "addAnomaly": "Add anomaly",
+    "overwriteToggle": "Overwrite on paste",
+    "overwriteTooltip": "When on, pasting replaces the list — anomalies no longer in the scan are removed. Or hold Shift while pasting to overwrite just once.",
+    "removeDelayLabel": "Removal delay",
+    "removeDelayTooltip": "How long an absent anomaly stays visible (struck through) before an overwrite paste deletes it — time to clear its in-game bookmark.",
+    "removeDelayInstant": "Instant",
+    "filterLabel": "Filter by type",
+    "filterClear": "Clear",
+    "noMatchFilter": "No anomalies match the filter",
+    "setTypeAria": "Set type for selected anomalies",
+    "setType": "Set type ({{count}})…",
+    "deleteSelected": "Delete selected ({{count}})",
+    "deleteAll": "Delete all",
+    "empty": "No anomalies — paste from probe scanner to import",
+    "colId": "ID",
+    "colType": "Type",
+    "colName": "Name",
+    "colNotes": "Notes",
+    "namePlaceholder": "Anomaly name"
   },
   "stats": {
     "title": "User Stats",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "Mostrar WH estáticos",
     "easyConnect": "Conexión fácil",
     "connectionStyle": "Estilo de conexión",
-    "edgeStyle": { "bezier": "Estándar", "straight": "Recta", "smoothstep": "Escalón" },
+    "edgeStyle": {
+      "bezier": "Estándar",
+      "straight": "Recta",
+      "smoothstep": "Escalón"
+    },
     "connectionThickness": "Grosor de las conexiones",
-    "thickness": { "thin": "Fino", "standard": "Estándar", "thick": "Grueso", "extra": "Muy grueso" },
+    "thickness": {
+      "thin": "Fino",
+      "standard": "Estándar",
+      "thick": "Grueso",
+      "extra": "Muy grueso"
+    },
     "optimizeConnections": "⟳ Optimizar conexiones",
     "spreadNodes": "⊞ Separar nodos",
     "spreadNodesTooltip": "Ajustar los nodos de sistema para evitar solapamientos",
@@ -510,7 +519,11 @@
     "sizeSmall": "Pequeño (Fragata)",
     "rollingCalculator": "Calculadora de rolling",
     "custom": "Personalizado",
-    "collapse": { "open": "Abierto", "maybe": "Posiblemente colapsado", "collapsed": "Colapsado" },
+    "collapse": {
+      "open": "Abierto",
+      "maybe": "Posiblemente colapsado",
+      "collapsed": "Colapsado"
+    },
     "remaining": "{{worst}}–{{best}} restante · {{used}} usado · salto máx {{max}}",
     "useMyShip": "Usar mi nave",
     "useMyShipTitle": "Frío = {{ship}} ({{mass}}), caliente = +prop",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "Notas",
     "signatures": "Firmas",
+    "anomalies": "Anomalías",
     "structures": "Estructuras",
     "npcStations": "Estaciones PNJ",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "Mineral",
     "combat": "Combate"
   },
+  "anomType": {
+    "unknown": "Desconocido",
+    "combat": "Combate",
+    "ore": "Mineral",
+    "gas": "Gas"
+  },
   "signatures": {
     "pasteHint": "Puedes copiar y pegar firmas directamente desde el escáner de sondas en EVE. Para ello, abre tu escáner de sondas. Pulsa Ctrl+A para seleccionarlas todas, luego Ctrl+C para copiar. Usa Ctrl+V para pegarlas aquí.",
     "pasteDifferentSystem": "Tu personaje está actualmente en {{current}}, pero estás pegando firmas en {{selected}}. ¿Continuar?",
@@ -803,6 +823,36 @@
     "colAge": "Antigüedad",
     "colUpdated": "Actualizado",
     "namePlaceholder": "Nombre del sitio"
+  },
+  "anomalies": {
+    "pasteHint": "Puedes copiar y pegar anomalías directamente desde el escáner de sondas en EVE. Abre tu escáner de sondas, pulsa Ctrl+A para seleccionarlas todas, Ctrl+C para copiar y luego Ctrl+V para pegarlas aquí. Las firmas y anomalías pegadas juntas se ordenan automáticamente en el panel correcto.",
+    "pasteDifferentSystem": "Tu personaje está actualmente en {{current}}, pero estás pegando anomalías en {{selected}}. ¿Continuar?",
+    "loadFailed": "No se pudieron cargar las anomalías",
+    "saveFailed": "No se pudo guardar la anomalía",
+    "deleteFailed": "No se pudo eliminar la anomalía",
+    "deleteSelectedConfirm_one": "¿Eliminar {{count}} anomalía seleccionada?",
+    "deleteSelectedConfirm_other": "¿Eliminar {{count}} anomalías seleccionadas?",
+    "deleteAllConfirm_one": "¿Eliminar {{count}} anomalía?",
+    "deleteAllConfirm_other": "¿Eliminar las {{count}} anomalías?",
+    "addAnomaly": "Añadir anomalía",
+    "overwriteToggle": "Sobrescribir al pegar",
+    "overwriteTooltip": "Cuando está activo, pegar reemplaza la lista — se eliminan las anomalías que ya no están en el escaneo. O mantén Mayús al pegar para sobrescribir solo una vez.",
+    "removeDelayLabel": "Retardo de eliminación",
+    "removeDelayTooltip": "Cuánto tiempo permanece visible (tachada) una anomalía desaparecida antes de que un pegado en sobrescritura la elimine — tiempo para borrar su marcador en el juego.",
+    "removeDelayInstant": "Inmediato",
+    "filterLabel": "Filtrar por tipo",
+    "filterClear": "Limpiar",
+    "noMatchFilter": "Ninguna anomalía coincide con el filtro",
+    "setTypeAria": "Establecer el tipo de las anomalías seleccionadas",
+    "setType": "Establecer tipo ({{count}})…",
+    "deleteSelected": "Eliminar seleccionadas ({{count}})",
+    "deleteAll": "Eliminar todo",
+    "empty": "No hay anomalías — pega desde el escáner de sondas para importar",
+    "colId": "ID",
+    "colType": "Tipo",
+    "colName": "Nombre",
+    "colNotes": "Notas",
+    "namePlaceholder": "Nombre de la anomalía"
   },
   "stats": {
     "title": "Estadísticas de usuario",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "Afficher les WH statiques",
     "easyConnect": "Connexion facile",
     "connectionStyle": "Style de connexion",
-    "edgeStyle": { "bezier": "Standard", "straight": "Droite", "smoothstep": "Palier" },
+    "edgeStyle": {
+      "bezier": "Standard",
+      "straight": "Droite",
+      "smoothstep": "Palier"
+    },
     "connectionThickness": "Épaisseur des connexions",
-    "thickness": { "thin": "Fine", "standard": "Standard", "thick": "Épaisse", "extra": "Très épaisse" },
+    "thickness": {
+      "thin": "Fine",
+      "standard": "Standard",
+      "thick": "Épaisse",
+      "extra": "Très épaisse"
+    },
     "optimizeConnections": "⟳ Optimiser les connexions",
     "spreadNodes": "⊞ Espacer les nœuds",
     "spreadNodesTooltip": "Ajuster les nœuds de système pour éviter les chevauchements",
@@ -510,7 +519,11 @@
     "sizeSmall": "Petit (Frégate)",
     "rollingCalculator": "Calculateur de rolling",
     "custom": "Personnalisé",
-    "collapse": { "open": "Ouvert", "maybe": "Peut-être effondré", "collapsed": "Effondré" },
+    "collapse": {
+      "open": "Ouvert",
+      "maybe": "Peut-être effondré",
+      "collapsed": "Effondré"
+    },
     "remaining": "{{worst}}–{{best}} restant · {{used}} utilisé · saut max {{max}}",
     "useMyShip": "Utiliser mon vaisseau",
     "useMyShipTitle": "Froid = {{ship}} ({{mass}}), chaud = +prop",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "Notes",
     "signatures": "Signatures",
+    "anomalies": "Anomalies",
     "structures": "Structures",
     "npcStations": "Stations PNJ",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "Minerai",
     "combat": "Combat"
   },
+  "anomType": {
+    "unknown": "Inconnu",
+    "combat": "Combat",
+    "ore": "Minerai",
+    "gas": "Gaz"
+  },
   "signatures": {
     "pasteHint": "Vous pouvez copier-coller des signatures directement depuis le scanner de sondes dans EVE. Pour cela, ouvrez votre scanner de sondes. Appuyez sur Ctrl+A pour tout sélectionner, puis Ctrl+C pour copier. Utilisez Ctrl+V pour les coller ici.",
     "pasteDifferentSystem": "Votre personnage est actuellement dans {{current}}, mais vous collez des signatures dans {{selected}}. Continuer ?",
@@ -803,6 +823,36 @@
     "colAge": "Âge",
     "colUpdated": "Mis à jour",
     "namePlaceholder": "Nom du site"
+  },
+  "anomalies": {
+    "pasteHint": "Vous pouvez copier-coller des anomalies directement depuis le scanner de sondes dans EVE. Ouvrez votre scanner de sondes, appuyez sur Ctrl+A pour tout sélectionner, Ctrl+C pour copier, puis Ctrl+V pour les coller ici. Les signatures et anomalies collées ensemble sont automatiquement triées dans le bon panneau.",
+    "pasteDifferentSystem": "Votre personnage est actuellement dans {{current}}, mais vous collez des anomalies dans {{selected}}. Continuer ?",
+    "loadFailed": "Échec du chargement des anomalies",
+    "saveFailed": "Échec de l'enregistrement de l'anomalie",
+    "deleteFailed": "Échec de la suppression de l'anomalie",
+    "deleteSelectedConfirm_one": "Supprimer {{count}} anomalie sélectionnée ?",
+    "deleteSelectedConfirm_other": "Supprimer {{count}} anomalies sélectionnées ?",
+    "deleteAllConfirm_one": "Supprimer {{count}} anomalie ?",
+    "deleteAllConfirm_other": "Supprimer les {{count}} anomalies ?",
+    "addAnomaly": "Ajouter une anomalie",
+    "overwriteToggle": "Écraser au collage",
+    "overwriteTooltip": "Si activé, le collage remplace la liste — les anomalies absentes du scan sont supprimées. Ou maintenez Maj en collant pour écraser une seule fois.",
+    "removeDelayLabel": "Délai de suppression",
+    "removeDelayTooltip": "Durée pendant laquelle une anomalie disparue reste visible (barrée) avant qu'un collage en écrasement ne la supprime — le temps d'effacer son signet en jeu.",
+    "removeDelayInstant": "Immédiat",
+    "filterLabel": "Filtrer par type",
+    "filterClear": "Effacer",
+    "noMatchFilter": "Aucune anomalie ne correspond au filtre",
+    "setTypeAria": "Définir le type des anomalies sélectionnées",
+    "setType": "Définir le type ({{count}})…",
+    "deleteSelected": "Supprimer la sélection ({{count}})",
+    "deleteAll": "Tout supprimer",
+    "empty": "Aucune anomalie — collez depuis le scanner de sondes pour importer",
+    "colId": "ID",
+    "colType": "Type",
+    "colName": "Nom",
+    "colNotes": "Notes",
+    "namePlaceholder": "Nom de l'anomalie"
   },
   "stats": {
     "title": "Statistiques utilisateur",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "スタティック WH を表示",
     "easyConnect": "簡単接続",
     "connectionStyle": "接続スタイル",
-    "edgeStyle": { "bezier": "標準", "straight": "直線", "smoothstep": "ステップ" },
+    "edgeStyle": {
+      "bezier": "標準",
+      "straight": "直線",
+      "smoothstep": "ステップ"
+    },
     "connectionThickness": "接続の太さ",
-    "thickness": { "thin": "細い", "standard": "標準", "thick": "太い", "extra": "極太" },
+    "thickness": {
+      "thin": "細い",
+      "standard": "標準",
+      "thick": "太い",
+      "extra": "極太"
+    },
     "optimizeConnections": "⟳ 接続を最適化",
     "spreadNodes": "⊞ ノードを広げる",
     "spreadNodesTooltip": "重なりを避けるため星系ノードを調整",
@@ -510,7 +519,11 @@
     "sizeSmall": "小（フリゲート）",
     "rollingCalculator": "ロール計算機",
     "custom": "カスタム",
-    "collapse": { "open": "オープン", "maybe": "崩壊した可能性", "collapsed": "崩壊済み" },
+    "collapse": {
+      "open": "オープン",
+      "maybe": "崩壊した可能性",
+      "collapsed": "崩壊済み"
+    },
     "remaining": "残り {{worst}}–{{best}} · 使用 {{used}} · 最大ジャンプ {{max}}",
     "useMyShip": "自分の艦船を使用",
     "useMyShipTitle": "コールド = {{ship}}（{{mass}}）、ホット = +プロップ",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "メモ",
     "signatures": "シグネチャ",
+    "anomalies": "アノマリー",
     "structures": "ストラクチャ",
     "npcStations": "NPC ステーション",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "鉱石",
     "combat": "コンバット"
   },
+  "anomType": {
+    "unknown": "不明",
+    "combat": "コンバット",
+    "ore": "鉱石",
+    "gas": "ガス"
+  },
   "signatures": {
     "pasteHint": "EVE のプローブスキャナーからシグネチャを直接コピー＆ペーストできます。それには、プローブスキャナーを開いてください。Ctrl+A ですべて選択し、Ctrl+C でコピー。Ctrl+V でここに貼り付けてください。",
     "pasteDifferentSystem": "あなたのキャラクターは現在 {{current}} にいますが、{{selected}} にシグネチャを貼り付けています。続行しますか？",
@@ -803,6 +823,36 @@
     "colAge": "経過",
     "colUpdated": "更新",
     "namePlaceholder": "サイト名"
+  },
+  "anomalies": {
+    "pasteHint": "EVE のプローブスキャナーからアノマリーを直接コピー＆ペーストできます。プローブスキャナーを開き、Ctrl+A ですべて選択、Ctrl+C でコピーし、Ctrl+V でここに貼り付けてください。シグネチャとアノマリーを一緒に貼り付けると、自動的に正しいパネルに振り分けられます。",
+    "pasteDifferentSystem": "あなたのキャラクターは現在 {{current}} にいますが、{{selected}} にアノマリーを貼り付けています。続行しますか？",
+    "loadFailed": "アノマリーの読み込みに失敗しました",
+    "saveFailed": "アノマリーの保存に失敗しました",
+    "deleteFailed": "アノマリーの削除に失敗しました",
+    "deleteSelectedConfirm_one": "選択した {{count}} 件のアノマリーを削除しますか？",
+    "deleteSelectedConfirm_other": "選択した {{count}} 件のアノマリーを削除しますか？",
+    "deleteAllConfirm_one": "{{count}} 件のアノマリーをすべて削除しますか？",
+    "deleteAllConfirm_other": "{{count}} 件のアノマリーをすべて削除しますか？",
+    "addAnomaly": "アノマリーを追加",
+    "overwriteToggle": "貼り付け時に上書き",
+    "overwriteTooltip": "オンにすると、貼り付けでリストを置き換えます — スキャンに存在しなくなったアノマリーは削除されます。または貼り付け時に Shift を押すと一度だけ上書きします。",
+    "removeDelayLabel": "削除までの猶予",
+    "removeDelayTooltip": "消滅したアノマリーが上書き貼り付けで削除されるまで（取り消し線付きで）表示される時間 — ゲーム内ブックマークを整理する時間です。",
+    "removeDelayInstant": "即時",
+    "filterLabel": "タイプで絞り込み",
+    "filterClear": "クリア",
+    "noMatchFilter": "フィルターに一致するアノマリーはありません",
+    "setTypeAria": "選択したアノマリーのタイプを設定",
+    "setType": "タイプを設定（{{count}}）…",
+    "deleteSelected": "選択を削除（{{count}}）",
+    "deleteAll": "すべて削除",
+    "empty": "アノマリーはありません — プローブスキャナーから貼り付けてインポート",
+    "colId": "ID",
+    "colType": "タイプ",
+    "colName": "名前",
+    "colNotes": "メモ",
+    "namePlaceholder": "アノマリー名"
   },
   "stats": {
     "title": "ユーザー統計",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "고정 웜홀 표시",
     "easyConnect": "간편 연결",
     "connectionStyle": "연결 스타일",
-    "edgeStyle": { "bezier": "표준", "straight": "직선", "smoothstep": "계단" },
+    "edgeStyle": {
+      "bezier": "표준",
+      "straight": "직선",
+      "smoothstep": "계단"
+    },
     "connectionThickness": "연결 두께",
-    "thickness": { "thin": "얇게", "standard": "표준", "thick": "굵게", "extra": "매우 굵게" },
+    "thickness": {
+      "thin": "얇게",
+      "standard": "표준",
+      "thick": "굵게",
+      "extra": "매우 굵게"
+    },
     "optimizeConnections": "⟳ 연결 최적화",
     "spreadNodes": "⊞ 노드 펼치기",
     "spreadNodesTooltip": "겹치지 않도록 성계 노드 조정",
@@ -510,7 +519,11 @@
     "sizeSmall": "소형 (프리깃)",
     "rollingCalculator": "롤링 계산기",
     "custom": "사용자 지정",
-    "collapse": { "open": "열림", "maybe": "붕괴되었을 수 있음", "collapsed": "붕괴됨" },
+    "collapse": {
+      "open": "열림",
+      "maybe": "붕괴되었을 수 있음",
+      "collapsed": "붕괴됨"
+    },
     "remaining": "{{worst}}–{{best}} 남음 · {{used}} 사용 · 최대 점프 {{max}}",
     "useMyShip": "내 함선 사용",
     "useMyShipTitle": "콜드 = {{ship}} ({{mass}}), 핫 = +프롭",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "노트",
     "signatures": "시그니처",
+    "anomalies": "어노말리",
     "structures": "구조물",
     "npcStations": "NPC 정거장",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "광석",
     "combat": "전투"
   },
+  "anomType": {
+    "unknown": "알 수 없음",
+    "combat": "전투",
+    "ore": "광석",
+    "gas": "가스"
+  },
   "signatures": {
     "pasteHint": "EVE의 탐사 스캐너에서 직접 시그니처를 복사하여 붙여넣을 수 있습니다. 그러려면 탐사 스캐너를 여세요. Ctrl+A로 모두 선택한 다음 Ctrl+C로 복사하세요. Ctrl+V로 여기에 붙여넣으세요.",
     "pasteDifferentSystem": "당신의 캐릭터는 현재 {{current}}에 있지만, {{selected}}에 시그니처를 붙여넣고 있습니다. 계속할까요?",
@@ -803,6 +823,36 @@
     "colAge": "경과",
     "colUpdated": "업데이트",
     "namePlaceholder": "사이트 이름"
+  },
+  "anomalies": {
+    "pasteHint": "EVE의 탐사 스캐너에서 직접 어노말리를 복사하여 붙여넣을 수 있습니다. 탐사 스캐너를 열고 Ctrl+A로 모두 선택, Ctrl+C로 복사한 다음 Ctrl+V로 여기에 붙여넣으세요. 시그니처와 어노말리를 함께 붙여넣으면 자동으로 올바른 패널로 분류됩니다.",
+    "pasteDifferentSystem": "당신의 캐릭터는 현재 {{current}}에 있지만, {{selected}}에 어노말리를 붙여넣고 있습니다. 계속할까요?",
+    "loadFailed": "어노말리를 불러오지 못했습니다",
+    "saveFailed": "어노말리를 저장하지 못했습니다",
+    "deleteFailed": "어노말리를 삭제하지 못했습니다",
+    "deleteSelectedConfirm_one": "선택한 어노말리 {{count}}개를 삭제할까요?",
+    "deleteSelectedConfirm_other": "선택한 어노말리 {{count}}개를 삭제할까요?",
+    "deleteAllConfirm_one": "{{count}}개 어노말리를 모두 삭제할까요?",
+    "deleteAllConfirm_other": "{{count}}개 어노말리를 모두 삭제할까요?",
+    "addAnomaly": "어노말리 추가",
+    "overwriteToggle": "붙여넣기 시 덮어쓰기",
+    "overwriteTooltip": "켜면 붙여넣기가 목록을 대체합니다 — 스캔에 더 이상 없는 어노말리는 제거됩니다. 또는 붙여넣을 때 Shift를 누르면 한 번만 덮어씁니다.",
+    "removeDelayLabel": "제거 지연",
+    "removeDelayTooltip": "사라진 어노말리가 덮어쓰기 붙여넣기로 삭제되기 전까지 (취소선과 함께) 표시되는 시간 — 게임 내 북마크를 정리할 시간입니다.",
+    "removeDelayInstant": "즉시",
+    "filterLabel": "유형별 필터",
+    "filterClear": "지우기",
+    "noMatchFilter": "필터와 일치하는 어노말리가 없습니다",
+    "setTypeAria": "선택한 어노말리의 유형 설정",
+    "setType": "유형 설정 ({{count}})…",
+    "deleteSelected": "선택 항목 삭제 ({{count}})",
+    "deleteAll": "전체 삭제",
+    "empty": "어노말리 없음 — 탐사 스캐너에서 붙여넣어 가져오세요",
+    "colId": "ID",
+    "colType": "유형",
+    "colName": "이름",
+    "colNotes": "노트",
+    "namePlaceholder": "어노말리 이름"
   },
   "stats": {
     "title": "사용자 통계",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "Mostrar WH estáticos",
     "easyConnect": "Conexão fácil",
     "connectionStyle": "Estilo de conexão",
-    "edgeStyle": { "bezier": "Padrão", "straight": "Reta", "smoothstep": "Degrau" },
+    "edgeStyle": {
+      "bezier": "Padrão",
+      "straight": "Reta",
+      "smoothstep": "Degrau"
+    },
     "connectionThickness": "Espessura das conexões",
-    "thickness": { "thin": "Fina", "standard": "Padrão", "thick": "Grossa", "extra": "Muito grossa" },
+    "thickness": {
+      "thin": "Fina",
+      "standard": "Padrão",
+      "thick": "Grossa",
+      "extra": "Muito grossa"
+    },
     "optimizeConnections": "⟳ Otimizar conexões",
     "spreadNodes": "⊞ Espaçar nós",
     "spreadNodesTooltip": "Ajustar os nós de sistema para evitar sobreposições",
@@ -510,7 +519,11 @@
     "sizeSmall": "Pequeno (Fragata)",
     "rollingCalculator": "Calculadora de rolling",
     "custom": "Personalizado",
-    "collapse": { "open": "Aberto", "maybe": "Possivelmente colapsado", "collapsed": "Colapsado" },
+    "collapse": {
+      "open": "Aberto",
+      "maybe": "Possivelmente colapsado",
+      "collapsed": "Colapsado"
+    },
     "remaining": "{{worst}}–{{best}} restante · {{used}} usado · salto máx {{max}}",
     "useMyShip": "Usar a minha nave",
     "useMyShipTitle": "Frio = {{ship}} ({{mass}}), quente = +prop",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "Notas",
     "signatures": "Assinaturas",
+    "anomalies": "Anomalias",
     "structures": "Estruturas",
     "npcStations": "Estações PNJ",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "Minério",
     "combat": "Combate"
   },
+  "anomType": {
+    "unknown": "Desconhecido",
+    "combat": "Combate",
+    "ore": "Minério",
+    "gas": "Gás"
+  },
   "signatures": {
     "pasteHint": "Podes copiar e colar assinaturas diretamente do scanner de sondas no EVE. Para isso, abre o teu scanner de sondas. Prime Ctrl+A para selecionar todas, depois Ctrl+C para copiar. Usa Ctrl+V para as colar aqui.",
     "pasteDifferentSystem": "A tua personagem está atualmente em {{current}}, mas estás a colar assinaturas em {{selected}}. Continuar?",
@@ -803,6 +823,36 @@
     "colAge": "Idade",
     "colUpdated": "Atualizado",
     "namePlaceholder": "Nome do site"
+  },
+  "anomalies": {
+    "pasteHint": "Podes copiar e colar anomalias diretamente do scanner de sondas no EVE. Abre o teu scanner de sondas, prime Ctrl+A para selecionar todas, Ctrl+C para copiar e depois Ctrl+V para as colar aqui. Assinaturas e anomalias coladas em conjunto são automaticamente organizadas no painel correto.",
+    "pasteDifferentSystem": "A tua personagem está atualmente em {{current}}, mas estás a colar anomalias em {{selected}}. Continuar?",
+    "loadFailed": "Falha ao carregar as anomalias",
+    "saveFailed": "Falha ao guardar a anomalia",
+    "deleteFailed": "Falha ao eliminar a anomalia",
+    "deleteSelectedConfirm_one": "Eliminar {{count}} anomalia selecionada?",
+    "deleteSelectedConfirm_other": "Eliminar {{count}} anomalias selecionadas?",
+    "deleteAllConfirm_one": "Eliminar {{count}} anomalia?",
+    "deleteAllConfirm_other": "Eliminar as {{count}} anomalias?",
+    "addAnomaly": "Adicionar anomalia",
+    "overwriteToggle": "Substituir ao colar",
+    "overwriteTooltip": "Quando ativo, colar substitui a lista — as anomalias que já não estão no scan são removidas. Ou mantenha Shift ao colar para substituir apenas uma vez.",
+    "removeDelayLabel": "Atraso de remoção",
+    "removeDelayTooltip": "Quanto tempo uma anomalia desaparecida permanece visível (riscada) antes de uma colagem em substituição a apagar — tempo para limpar o seu marcador no jogo.",
+    "removeDelayInstant": "Imediato",
+    "filterLabel": "Filtrar por tipo",
+    "filterClear": "Limpar",
+    "noMatchFilter": "Nenhuma anomalia corresponde ao filtro",
+    "setTypeAria": "Definir o tipo das anomalias selecionadas",
+    "setType": "Definir tipo ({{count}})…",
+    "deleteSelected": "Eliminar selecionadas ({{count}})",
+    "deleteAll": "Eliminar tudo",
+    "empty": "Nenhuma anomalia — cola do scanner de sondas para importar",
+    "colId": "ID",
+    "colType": "Tipo",
+    "colName": "Nome",
+    "colNotes": "Notas",
+    "namePlaceholder": "Nome da anomalia"
   },
   "stats": {
     "title": "Estatísticas de utilizador",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -374,9 +374,18 @@
     "showStaticWhs": "Показывать статик-ЧД",
     "easyConnect": "Лёгкое соединение",
     "connectionStyle": "Стиль соединений",
-    "edgeStyle": { "bezier": "Стандартный", "straight": "Прямой", "smoothstep": "Ступенчатый" },
+    "edgeStyle": {
+      "bezier": "Стандартный",
+      "straight": "Прямой",
+      "smoothstep": "Ступенчатый"
+    },
     "connectionThickness": "Толщина соединений",
-    "thickness": { "thin": "Тонкая", "standard": "Стандартная", "thick": "Толстая", "extra": "Очень толстая" },
+    "thickness": {
+      "thin": "Тонкая",
+      "standard": "Стандартная",
+      "thick": "Толстая",
+      "extra": "Очень толстая"
+    },
     "optimizeConnections": "⟳ Оптимизировать соединения",
     "spreadNodes": "⊞ Разнести узлы",
     "spreadNodesTooltip": "Передвинуть узлы систем, чтобы они не перекрывались",
@@ -526,7 +535,11 @@
     "sizeSmall": "Малый (фрегат)",
     "rollingCalculator": "Калькулятор роллинга",
     "custom": "Свой",
-    "collapse": { "open": "Открыта", "maybe": "Возможно, схлопнулась", "collapsed": "Схлопнулась" },
+    "collapse": {
+      "open": "Открыта",
+      "maybe": "Возможно, схлопнулась",
+      "collapsed": "Схлопнулась"
+    },
     "remaining": "осталось {{worst}}–{{best}} · использовано {{used}} · макс. прыжок {{max}}",
     "useMyShip": "Использовать мой корабль",
     "useMyShipTitle": "Холодный = {{ship}} ({{mass}}), горячий = +проп",
@@ -622,6 +635,7 @@
   "panel": {
     "notes": "Заметки",
     "signatures": "Сигнатуры",
+    "anomalies": "Аномалии",
     "structures": "Структуры",
     "npcStations": "Станции NPC",
     "killboard": "zKillboard",
@@ -794,6 +808,12 @@
     "ore": "Руда",
     "combat": "Бой"
   },
+  "anomType": {
+    "unknown": "Неизвестно",
+    "combat": "Бой",
+    "ore": "Руда",
+    "gas": "Газ"
+  },
   "signatures": {
     "pasteHint": "Вы можете копировать и вставлять сигнатуры прямо из Сканера зондов в EVE. Для этого откройте сканер зондов. Нажмите Ctrl+A, чтобы выделить все, затем Ctrl+C, чтобы скопировать. Используйте Ctrl+V, чтобы вставить их сюда",
     "pasteDifferentSystem": "Ваш персонаж сейчас в {{current}}, но вы вставляете сигнатуры в {{selected}}. Продолжить?",
@@ -835,6 +855,40 @@
     "colAge": "Возраст",
     "colUpdated": "Обновлено",
     "namePlaceholder": "Название сайта"
+  },
+  "anomalies": {
+    "pasteHint": "Вы можете копировать и вставлять аномалии прямо из Сканера зондов в EVE. Откройте сканер зондов, нажмите Ctrl+A, чтобы выделить все, Ctrl+C, чтобы скопировать, затем Ctrl+V, чтобы вставить их сюда. Сигнатуры и аномалии, вставленные вместе, автоматически распределяются по нужной панели.",
+    "pasteDifferentSystem": "Ваш персонаж сейчас в {{current}}, но вы вставляете аномалии в {{selected}}. Продолжить?",
+    "loadFailed": "Не удалось загрузить аномалии",
+    "saveFailed": "Не удалось сохранить аномалию",
+    "deleteFailed": "Не удалось удалить аномалию",
+    "deleteSelectedConfirm_one": "Удалить {{count}} выбранную аномалию?",
+    "deleteSelectedConfirm_few": "Удалить {{count}} выбранные аномалии?",
+    "deleteSelectedConfirm_many": "Удалить {{count}} выбранных аномалий?",
+    "deleteSelectedConfirm_other": "Удалить {{count}} выбранных аномалий?",
+    "deleteAllConfirm_one": "Удалить все {{count}} аномалию?",
+    "deleteAllConfirm_few": "Удалить все {{count}} аномалии?",
+    "deleteAllConfirm_many": "Удалить все {{count}} аномалий?",
+    "deleteAllConfirm_other": "Удалить все {{count}} аномалий?",
+    "addAnomaly": "Добавить аномалию",
+    "overwriteToggle": "Перезаписать при вставке",
+    "overwriteTooltip": "Когда включено, вставка заменяет список — аномалии, которых больше нет в скане, удаляются. Или удерживайте Shift при вставке, чтобы перезаписать один раз.",
+    "removeDelayLabel": "Задержка удаления",
+    "removeDelayTooltip": "Сколько исчезнувшая аномалия остаётся видимой (зачёркнутой) до удаления при вставке с перезаписью — время, чтобы убрать её закладку в игре.",
+    "removeDelayInstant": "Сразу",
+    "filterLabel": "Фильтр по типу",
+    "filterClear": "Сбросить",
+    "noMatchFilter": "Нет аномалий, соответствующих фильтру",
+    "setTypeAria": "Задать тип для выбранных аномалий",
+    "setType": "Задать тип ({{count}})…",
+    "deleteSelected": "Удалить выбранные ({{count}})",
+    "deleteAll": "Удалить все",
+    "empty": "Аномалии не отсканированы — вставьте из сканера зондов для импорта",
+    "colId": "ID",
+    "colType": "Тип",
+    "colName": "Название",
+    "colNotes": "Заметки",
+    "namePlaceholder": "Название аномалии"
   },
   "stats": {
     "title": "Статистика пользователя",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -360,9 +360,18 @@
     "showStaticWhs": "显示固定虫洞",
     "easyConnect": "便捷连接",
     "connectionStyle": "连接样式",
-    "edgeStyle": { "bezier": "标准", "straight": "直线", "smoothstep": "折线" },
+    "edgeStyle": {
+      "bezier": "标准",
+      "straight": "直线",
+      "smoothstep": "折线"
+    },
     "connectionThickness": "连接粗细",
-    "thickness": { "thin": "细", "standard": "标准", "thick": "粗", "extra": "超粗" },
+    "thickness": {
+      "thin": "细",
+      "standard": "标准",
+      "thick": "粗",
+      "extra": "超粗"
+    },
     "optimizeConnections": "⟳ 优化连接",
     "spreadNodes": "⊞ 分散节点",
     "spreadNodesTooltip": "调整星系节点以避免重叠",
@@ -510,7 +519,11 @@
     "sizeSmall": "小（护卫舰）",
     "rollingCalculator": "关洞计算器",
     "custom": "自定义",
-    "collapse": { "open": "开放", "maybe": "可能已坍塌", "collapsed": "已坍塌" },
+    "collapse": {
+      "open": "开放",
+      "maybe": "可能已坍塌",
+      "collapsed": "已坍塌"
+    },
     "remaining": "剩余 {{worst}}–{{best}} · 已用 {{used}} · 最大单跳 {{max}}",
     "useMyShip": "使用我的舰船",
     "useMyShipTitle": "冷 = {{ship}}（{{mass}}），热 = +推进",
@@ -604,6 +617,7 @@
   "panel": {
     "notes": "笔记",
     "signatures": "信号",
+    "anomalies": "异常空间",
     "structures": "建筑",
     "npcStations": "NPC 空间站",
     "killboard": "zKillboard",
@@ -766,6 +780,12 @@
     "ore": "矿石",
     "combat": "战斗"
   },
+  "anomType": {
+    "unknown": "未知",
+    "combat": "战斗",
+    "ore": "矿石",
+    "gas": "气云"
+  },
   "signatures": {
     "pasteHint": "你可以直接从 EVE 中的探针扫描器复制并粘贴信号。为此，打开你的探针扫描器。按 Ctrl+A 全选，然后按 Ctrl+C 复制。用 Ctrl+V 粘贴到此处。",
     "pasteDifferentSystem": "你的角色当前在 {{current}}，但你正在将信号粘贴到 {{selected}}。继续吗？",
@@ -803,6 +823,36 @@
     "colAge": "存在时长",
     "colUpdated": "更新时间",
     "namePlaceholder": "站点名称"
+  },
+  "anomalies": {
+    "pasteHint": "你可以直接从 EVE 中的探针扫描器复制并粘贴异常空间。打开你的探针扫描器，按 Ctrl+A 全选，Ctrl+C 复制，然后按 Ctrl+V 粘贴到此处。一起粘贴的信号和异常空间会自动分类到正确的面板。",
+    "pasteDifferentSystem": "你的角色当前在 {{current}}，但你正在将异常空间粘贴到 {{selected}}。继续吗？",
+    "loadFailed": "加载异常空间失败",
+    "saveFailed": "保存异常空间失败",
+    "deleteFailed": "删除异常空间失败",
+    "deleteSelectedConfirm_one": "删除选定的 {{count}} 个异常空间？",
+    "deleteSelectedConfirm_other": "删除选定的 {{count}} 个异常空间？",
+    "deleteAllConfirm_one": "删除全部 {{count}} 个异常空间？",
+    "deleteAllConfirm_other": "删除全部 {{count}} 个异常空间？",
+    "addAnomaly": "添加异常空间",
+    "overwriteToggle": "粘贴时覆盖",
+    "overwriteTooltip": "开启后，粘贴会替换列表——扫描中已不存在的异常空间会被移除。或在粘贴时按住 Shift 仅覆盖一次。",
+    "removeDelayLabel": "移除延迟",
+    "removeDelayTooltip": "已消失的异常空间在覆盖粘贴将其删除前保持可见（带删除线）的时长——便于清理其游戏内书签。",
+    "removeDelayInstant": "立即",
+    "filterLabel": "按类型筛选",
+    "filterClear": "清除",
+    "noMatchFilter": "没有异常空间符合筛选条件",
+    "setTypeAria": "为选定异常空间设置类型",
+    "setType": "设置类型（{{count}}）…",
+    "deleteSelected": "删除选定（{{count}}）",
+    "deleteAll": "全部删除",
+    "empty": "没有异常空间 — 从探针扫描器粘贴以导入",
+    "colId": "ID",
+    "colType": "类型",
+    "colName": "名称",
+    "colNotes": "笔记",
+    "namePlaceholder": "异常空间名称"
   },
   "stats": {
     "title": "用户统计",

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -220,6 +220,7 @@ interface MapStore {
   // and re-fetches when it ticks (sigs/structures live in pane state, not here).
   sigRev: Record<string, number>;
   structRev: Record<string, number>;
+  anomRev: Record<string, number>;
 
   // Realtime: apply an edit pushed from another client (no persist, no undo).
   applyRemote: (event: RemoteEvent) => void;
@@ -237,7 +238,8 @@ export type RemoteEvent =
   | { type: 'map.meta';          name?: string; locked?: boolean }
   | { type: 'map.resync' }
   | { type: 'sig.changed';       systemId: string }
-  | { type: 'structure.changed'; systemId: string };
+  | { type: 'structure.changed'; systemId: string }
+  | { type: 'anom.changed';      systemId: string };
 
 export const useMapStore = create<MapStore>()((set, get) => {
 
@@ -409,7 +411,8 @@ export const useMapStore = create<MapStore>()((set, get) => {
     routeOrigin: null,
     sigRev: {},
     structRev: {},
-    panelOrder: ['activity', 'killboard', 'notes', 'signatures', 'structures', 'npcStations'],
+    anomRev: {},
+    panelOrder: ['activity', 'killboard', 'notes', 'signatures', 'anomalies', 'structures', 'npcStations'],
     undoStack: [],
 
     pushUndo: (cmd) =>
@@ -427,7 +430,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
       // Whitelist of valid panel keys. `standings` was briefly a panel here
       // — kept in the filter so any persisted occurrence is silently
       // dropped on load now that standings live inline in the sov section.
-      const all = ['activity', 'killboard', 'notes', 'signatures', 'structures', 'npcStations'];
+      const all = ['activity', 'killboard', 'notes', 'signatures', 'anomalies', 'structures', 'npcStations'];
       const merged = [
         ...panelOrder.filter((p) => all.includes(p)),
         ...all.filter((p) => !panelOrder.includes(p)),
@@ -983,6 +986,10 @@ export const useMapStore = create<MapStore>()((set, get) => {
         }
         case 'structure.changed': {
           set((s) => ({ structRev: { ...s.structRev, [event.systemId]: (s.structRev[event.systemId] ?? 0) + 1 } }));
+          break;
+        }
+        case 'anom.changed': {
+          set((s) => ({ anomRev: { ...s.anomRev, [event.systemId]: (s.anomRev[event.systemId] ?? 0) + 1 } }));
           break;
         }
       }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -67,6 +67,18 @@ export interface Signature {
   updatedAt: string;
 }
 
+export type AnomType = 'unknown' | 'combat' | 'ore' | 'gas';
+
+export interface Anomaly {
+  id: string;
+  anomId: string;
+  anomType: AnomType;
+  name: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export type StructureType =
   | 'unknown'
   | 'astrahus' | 'fortizar' | 'keepstar'


### PR DESCRIPTION
Adds a separate **Anomalies** panel to the system panel stack, mirroring the Signatures panel's copy-paste workflow — as requested.

## What it does
- **Paste from the probe scanner.** Works exactly like the signature pane. A single Ctrl+A / Ctrl+C of the whole scanner window is routed automatically by the scanner's *group* column — `Cosmic Anomaly` rows go to this pane, `Cosmic Signature` rows go to the signature pane.
- **Overwrite-on-paste checkbox** (+ the same removal-delay grace period) to replace the list on a re-scan.
- **Type filter chips** — Combat / Ore / Gas / Unknown.
- **Columns:** ID, Type, Name, Notes (per the agreed scope; no distance).
- **Live sync** across clients via a new `anom.changed` map event.

## Parser disambiguation (important)
The signature parser previously matched *any* row with a valid sig-ID, which meant a combined scanner paste imported anomalies as combat/ore **signatures**. It now skips `Cosmic Anomaly` rows. Rows without a group column (partial/manual pastes) still flow to the signature pane as before, so existing behaviour is preserved.

## Backend
- `map_anomalies` table + indexes in both `migrate.ts` and `setup-db.ts`.
- `GET/POST/PATCH/DELETE /:mapId/systems/:systemId/anomalies`, mirroring the signature routes' access control: `getMapAccess` / `requireMapContentWrite` / `verifySystemInMap` + map_id-scoped, fully parameterized SQL. No wormhole/K162/ghost-site logic (anomalies never back a connection).
- New table requires a migration — it's created idempotently on boot by `migrate.ts`.

## i18n
`panel.anomalies`, `anomType.*`, and a full `anomalies.*` block added to **all 9 locales**; key parity verified against `en`.

## Notes / scope
- Anomalies are **hidden in share mode** for now — they aren't embedded in the read-only share payload yet, so the pane would be empty for guests. Easy follow-up if you want shared anomalies.
- Existing users get the panel appended to their saved panel order automatically (new default position is right after Signatures).

## Verification
- `tsc --noEmit` clean (server + web)
- `eslint .` → 0 errors
- `vite build` succeeds
- i18n parity: all 9 locales match `en`