### PR TITLE
Add Age and Updated columns to the anomalies pane

### DIFF
--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -10,6 +10,7 @@ import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
 import { NotesEditor } from './NotesEditor';
 import { XIcon } from '@phosphor-icons/react';
 import { toast } from './Toaster';
+import { duration, DASH } from '../../i18n/format';
 
 // Cosmic anomalies don't need scanning — the probe scanner lists them at 100%
 // straight away. The scanner's "group" column is "Cosmic Anomaly" (vs "Cosmic
@@ -55,13 +56,15 @@ function parseAnomClipboard(text: string): ParsedAnom[] {
 }
 
 type SortCol = 'anomId' | 'anomType' | 'name' | 'createdAt' | 'updatedAt';
-type ColKey  = 'id' | 'type' | 'name' | 'notes';
+type ColKey  = 'id' | 'type' | 'name' | 'notes' | 'created' | 'updated';
 
 const DEFAULT_WIDTHS: Record<ColKey, number> = {
-  id:    72,
-  type:  108,
-  name:  200,
-  notes: 220,
+  id:      72,
+  type:    108,
+  name:    200,
+  notes:   220,
+  created: 80,
+  updated: 80,
 };
 
 // Grace-period choices (seconds) offered before an overwrite-paste actually
@@ -76,6 +79,42 @@ function formatDelay(sec: number): string {
 // which already cover combat / ore / gas / unknown.
 const ANOM_TYPE_FILTER_ORDER: AnomType[] = ['combat', 'ore', 'gas', 'unknown'];
 const ANOM_TYPE_OPTIONS: AnomType[] = ['combat', 'gas', 'ore', 'unknown'];
+
+// Single module-level 1 s tick shared across every ElapsedCell instance, so the
+// age/updated cells refresh without each pane driving its own per-second state
+// update (which would re-render every row including its MDEditor).
+let tickNow = Date.now();
+const tickSubs = new Set<() => void>();
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+
+function startTickIfNeeded() {
+  if (tickTimer) return;
+  tickTimer = setInterval(() => {
+    tickNow = Date.now();
+    tickSubs.forEach((fn) => fn());
+  }, 1000);
+}
+
+function ElapsedCell({ iso, className }: { iso: string | undefined; className?: string }) {
+  const { t } = useTranslation();
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const fn = () => setTick((n) => n + 1);
+    tickSubs.add(fn);
+    startTickIfNeeded();
+    return () => {
+      tickSubs.delete(fn);
+      if (tickSubs.size === 0 && tickTimer) {
+        clearInterval(tickTimer);
+        tickTimer = null;
+      }
+    };
+  }, []);
+  const text = iso
+    ? duration(t, Math.floor((tickNow - new Date(iso).getTime()) / 1000))
+    : DASH;
+  return <td className={className}>{text}</td>;
+}
 
 export function AnomalyPane({ systemId }: { systemId: string }) {
   const { t } = useTranslation();
@@ -488,6 +527,8 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
             <col style={{ width: colWidths.type }} />
             <col style={{ width: colWidths.name }} />
             <col style={{ width: colWidths.notes }} />
+            <col style={{ width: colWidths.created }} />
+            <col style={{ width: colWidths.updated }} />
             <col className="sig-col--actions" />
           </colgroup>
           <thead>
@@ -516,6 +557,14 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
               <th className="sig-th">
                 {t('anomalies.colNotes')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
+              </th>
+              <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('createdAt')}>
+                {t('anomalies.colAge')}{sortInd('createdAt')}
+                <div className="sig-th__resize" onMouseDown={(e) => startResize('created', e)} />
+              </th>
+              <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('updatedAt')}>
+                {t('anomalies.colUpdated')}{sortInd('updatedAt')}
+                <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
               </th>
               <th className="sig-cell--actions" />
             </tr>
@@ -572,6 +621,8 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
                     readOnly={!canEdit}
                   />
                 </td>
+                <ElapsedCell iso={anom.createdAt} className="sig-td--time" />
+                <ElapsedCell iso={anom.updatedAt} className="sig-td--time sig-td--updated" />
                 <td className="sig-cell--actions">
                   {canEdit && (
                     <button

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -852,6 +852,8 @@
     "colType": "Typ",
     "colName": "Name",
     "colNotes": "Notizen",
+    "colAge": "Alter",
+    "colUpdated": "Aktualisiert",
     "namePlaceholder": "Anomalie-Name"
   },
   "stats": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -839,6 +839,8 @@
     "colType": "Type",
     "colName": "Name",
     "colNotes": "Notes",
+    "colAge": "Age",
+    "colUpdated": "Updated",
     "namePlaceholder": "Anomaly name"
   },
   "stats": {

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -852,6 +852,8 @@
     "colType": "Tipo",
     "colName": "Nombre",
     "colNotes": "Notas",
+    "colAge": "Antigüedad",
+    "colUpdated": "Actualizado",
     "namePlaceholder": "Nombre de la anomalía"
   },
   "stats": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -852,6 +852,8 @@
     "colType": "Type",
     "colName": "Nom",
     "colNotes": "Notes",
+    "colAge": "Âge",
+    "colUpdated": "Mis à jour",
     "namePlaceholder": "Nom de l'anomalie"
   },
   "stats": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -852,6 +852,8 @@
     "colType": "タイプ",
     "colName": "名前",
     "colNotes": "メモ",
+    "colAge": "経過",
+    "colUpdated": "更新",
     "namePlaceholder": "アノマリー名"
   },
   "stats": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -852,6 +852,8 @@
     "colType": "유형",
     "colName": "이름",
     "colNotes": "노트",
+    "colAge": "경과",
+    "colUpdated": "업데이트",
     "namePlaceholder": "어노말리 이름"
   },
   "stats": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -852,6 +852,8 @@
     "colType": "Tipo",
     "colName": "Nome",
     "colNotes": "Notas",
+    "colAge": "Idade",
+    "colUpdated": "Atualizado",
     "namePlaceholder": "Nome da anomalia"
   },
   "stats": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -888,6 +888,8 @@
     "colType": "Тип",
     "colName": "Название",
     "colNotes": "Заметки",
+    "colAge": "Возраст",
+    "colUpdated": "Обновлено",
     "namePlaceholder": "Название аномалии"
   },
   "stats": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -852,6 +852,8 @@
     "colType": "类型",
     "colName": "名称",
     "colNotes": "笔记",
+    "colAge": "存在时长",
+    "colUpdated": "更新时间",
     "namePlaceholder": "异常空间名称"
   },
   "stats": {


### PR DESCRIPTION
Follow-up to #179 — this commit was pushed to that branch *after* it merged, so it's reopened here on top of the current `release`.

Adds **Age** and **Updated** columns to the Anomalies pane, matching the Signatures pane:
- Both columns are sortable.
- Elapsed times refresh live off a single shared 1s tick (one timer per pane, not per-row).
- Backend already returns `createdAt`/`updatedAt` for anomalies, so no API change.
- `anomalies.colAge` / `colUpdated` added to all 9 locales, reusing each language's existing signature labels. Parity verified.

`tsc` clean, `vite build` green.