### PR TITLE
Move watchlist into a dedicated left-docked panel

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1356,6 +1356,75 @@
 }
 
 /* ── Map sidebar ─────────────────────────────────────────── */
+/* ── Watchlist: dedicated left-docked panel ──────────────────────────────── */
+.watchlist-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 340px;
+  transform: translateX(-100%);
+  transition: transform 0.2s ease;
+  background: #0d1117;
+  border-right: 1px solid #1e2740;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+}
+
+.watchlist-panel--open {
+  transform: translateX(0);
+}
+
+/* Tab handle on the panel's right edge — the only bit visible when closed. */
+.watchlist-panel__tab {
+  position: absolute;
+  right: -28px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 28px;
+  min-height: 56px;
+  padding: 6px 0;
+  background: #0d1117;
+  border: 1px solid #1e2740;
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+  color: #c0ccde;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.watchlist-panel__tab:hover {
+  background: #141c2e;
+  color: #c8d0e0;
+}
+
+.watchlist-panel__count {
+  font-size: calc(10px * var(--font-scale, 1));
+  font-weight: 700;
+  color: #6ea0ff;
+  line-height: 1;
+}
+
+.watchlist-panel__content {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 12px;
+  gap: 8px;
+  overflow-y: auto;
+}
+
+.watchlist-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .map-sidebar {
   position: absolute;
   top: 0;
@@ -1777,36 +1846,32 @@
   gap: 6px;
 }
 
+/* One entry per row: marker | name | note | delete. Lives in the wide
+   left-docked panel, so everything fits on a single line. */
 .watchlist__row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 6px;
 }
 
 .watchlist__marker {
   flex-shrink: 0;
-  width: 56px;
+  width: 88px;
   background: #0a0e1a;
   border: 1px solid #1e2740;
   border-radius: 4px;
   padding: 4px 2px;
-  font-size: calc(14px * var(--font-scale, 1));
+  font-size: calc(13px * var(--font-scale, 1));
   outline: none;
   cursor: pointer;
-}
-
-.watchlist__fields {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  flex: 1;
-  min-width: 0;
 }
 
 .watchlist__query-wrap {
   position: relative;
   display: flex;
   align-items: center;
+  flex: 1.1;
+  min-width: 0;
 }
 
 .watchlist__query,
@@ -1823,7 +1888,7 @@
 }
 
 .watchlist__query { padding-right: 18px; }
-.watchlist__note { color: #9aa6c4; }
+.watchlist__note { flex: 1; min-width: 0; color: #9aa6c4; }
 
 .watchlist__query:focus,
 .watchlist__note:focus {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1854,14 +1854,23 @@
   gap: 6px;
 }
 
+.watchlist__marker-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+}
+
 .watchlist__marker {
   flex-shrink: 0;
-  width: 88px;
+  width: 82px;
   background: #0a0e1a;
   border: 1px solid #1e2740;
   border-radius: 4px;
   padding: 4px 2px;
-  font-size: calc(13px * var(--font-scale, 1));
+  font-size: calc(12px * var(--font-scale, 1));
+  color: #c8d4f0;
   outline: none;
   cursor: pointer;
 }
@@ -2321,10 +2330,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
   line-height: 1;
   border-radius: 50%;
   background: #0a0e1a;
+  color: var(--watch-color, #6ea0ff);
   border: 1px solid var(--watch-color, #6ea0ff);
   box-shadow: 0 0 6px var(--watch-color, #6ea0ff);
   pointer-events: auto;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { SystemPanel } from './components/ui/SystemPanel';
 import { ConnectionPanel } from './components/ui/ConnectionPanel';
 import { Toolbar } from './components/ui/Toolbar';
 import { MapSidebar } from './components/ui/MapSidebar';
+import { WatchlistPanel } from './components/ui/WatchlistPanel';
 import { Sidebar } from './components/ui/Sidebar';
 import { ProximityOptInModal } from './components/ui/ProximityOptInModal';
 import { CommandPaletteModal } from './components/ui/CommandPaletteModal';
@@ -93,6 +94,7 @@ function MapApp() {
           <Sidebar />
           <div className="layout__main">
             <MapCanvas />
+            <WatchlistPanel />
             <MapSidebar />
             {selectedSystemId && <SystemPanel />}
             {selectedConnectionId && <ConnectionPanel />}

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -250,7 +250,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
           data-tooltip={watchTip}
           aria-label={watchTip}
         >
-          {watchDef.glyph}
+          <watchDef.Icon size={11} weight="fill" />
         </span>
       )}
 

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -26,7 +26,6 @@ import { ChainExitsSection } from "./ChainExitsSection";
 import { MapSharesSection } from "./MapSharesSection";
 import { MergeMapModal } from "./MergeMapModal";
 import { CustomIntelBlock } from "./CustomIntelBlock";
-import { WatchlistBlock } from "./WatchlistBlock";
 import { useIsMapOwner } from "../../hooks/useIsMapOwner";
 import type { WormholeMap } from "../../types";
 
@@ -102,7 +101,6 @@ type SectionId =
   | "wormholeBookmarks"
   | "mapControls"
   | "systemOptions"
-  | "watchlist"
   | "connections"
   | "route"
   | "chainExits"
@@ -725,13 +723,6 @@ export function MapSidebar() {
           </div>
 
           <CustomIntelBlock />
-        </CollapsibleSection>
-
-        <CollapsibleSection
-          title={t("mapSidebar.sections.watchlist")}
-          {...sectionProps("watchlist")}
-        >
-          <WatchlistBlock />
         </CollapsibleSection>
 
         <CollapsibleSection

--- a/web/src/components/ui/WatchlistBlock.tsx
+++ b/web/src/components/ui/WatchlistBlock.tsx
@@ -60,17 +60,22 @@ export function WatchlistBlock() {
             const onMap = it.query.trim() !== '' && presentNames.has(it.query.trim().toLowerCase());
             return (
               <div key={it.id} className="watchlist__row">
+                {/* Vendored icon swatch (shows the chosen marker) sits beside a
+                    text-only <select> — an <option> can't host an SVG, so the
+                    icon lives outside the control. */}
+                <span className="watchlist__marker-icon" style={{ color: def.color }} title={t(`watchMarker.${it.marker}`)}>
+                  <def.Icon size={16} weight="fill" />
+                </span>
                 <select
                   className="watchlist__marker"
                   value={it.marker}
                   onChange={(e) => updateItem(it.id, { marker: e.target.value as WatchMarkerKind })}
                   title={t(`watchMarker.${it.marker}`)}
-                  style={{ color: def.color }}
                   aria-label={t('watchlist.markerAria')}
                 >
                   {WATCH_MARKERS.map((m) => (
                     <option key={m.kind} value={m.kind}>
-                      {m.glyph} {t(`watchMarker.${m.kind}`)}
+                      {t(`watchMarker.${m.kind}`)}
                     </option>
                   ))}
                 </select>

--- a/web/src/components/ui/WatchlistBlock.tsx
+++ b/web/src/components/ui/WatchlistBlock.tsx
@@ -74,36 +74,34 @@ export function WatchlistBlock() {
                     </option>
                   ))}
                 </select>
-                <div className="watchlist__fields">
-                  <div className="watchlist__query-wrap">
-                    <input
-                      type="text"
-                      className="watchlist__query"
-                      value={it.query}
-                      maxLength={48}
-                      onChange={(e) => updateItem(it.id, { query: e.target.value })}
-                      placeholder={t('watchlist.queryPlaceholder')}
-                      spellCheck={false}
-                      ref={(el) => {
-                        if (el && autoFocusId === it.id) {
-                          el.focus();
-                          setAutoFocusId(null);
-                        }
-                      }}
-                    />
-                    {onMap && (
-                      <span className="watchlist__onmap" title={t('watchlist.onMap')} aria-label={t('watchlist.onMap')} />
-                    )}
-                  </div>
+                <div className="watchlist__query-wrap">
                   <input
                     type="text"
-                    className="watchlist__note"
-                    value={it.note}
-                    maxLength={120}
-                    onChange={(e) => updateItem(it.id, { note: e.target.value })}
-                    placeholder={t('watchlist.notePlaceholder')}
+                    className="watchlist__query"
+                    value={it.query}
+                    maxLength={48}
+                    onChange={(e) => updateItem(it.id, { query: e.target.value })}
+                    placeholder={t('watchlist.queryPlaceholder')}
+                    spellCheck={false}
+                    ref={(el) => {
+                      if (el && autoFocusId === it.id) {
+                        el.focus();
+                        setAutoFocusId(null);
+                      }
+                    }}
                   />
+                  {onMap && (
+                    <span className="watchlist__onmap" title={t('watchlist.onMap')} aria-label={t('watchlist.onMap')} />
+                  )}
                 </div>
+                <input
+                  type="text"
+                  className="watchlist__note"
+                  value={it.note}
+                  maxLength={120}
+                  onChange={(e) => updateItem(it.id, { note: e.target.value })}
+                  placeholder={t('watchlist.notePlaceholder')}
+                />
                 <button
                   type="button"
                   className="watchlist__remove"

--- a/web/src/components/ui/WatchlistPanel.tsx
+++ b/web/src/components/ui/WatchlistPanel.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next';
+import { CaretLeftIcon, CaretRightIcon, BinocularsIcon } from '@phosphor-icons/react';
+import { useUserSetting } from '../../hooks/useUserSetting';
+import { useWatchlist } from '../../hooks/useWatchlist';
+import { WatchlistBlock } from './WatchlistBlock';
+
+// Dedicated left-docked watchlist panel. Slides in from the left edge of the
+// map area; a tab handle on its right edge toggles it. Open state is per-user
+// so it follows the operator across devices. Kept separate from the right-hand
+// map-options sidebar because a hunting list wants room and wants to stay open
+// while you map.
+export function WatchlistPanel() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useUserSetting<boolean>('nexum.watchlist.panelOpen', false);
+  const [items] = useWatchlist();
+  const title = t('mapSidebar.sections.watchlist');
+
+  return (
+    <div className={`watchlist-panel${open ? ' watchlist-panel--open' : ''}`}>
+      <button
+        type="button"
+        className="watchlist-panel__tab"
+        onClick={() => setOpen(!open)}
+        title={title}
+        aria-expanded={open}
+      >
+        {open ? (
+          <CaretLeftIcon size={14} weight="bold" />
+        ) : (
+          <>
+            <BinocularsIcon size={16} weight="bold" />
+            {items.length > 0 && <span className="watchlist-panel__count">{items.length}</span>}
+          </>
+        )}
+      </button>
+
+      <div className="watchlist-panel__content">
+        <div className="watchlist-panel__header">
+          <span className="map-sidebar__section-title">{title}</span>
+          <button
+            type="button"
+            className="icon-btn"
+            onClick={() => setOpen(false)}
+            title={t('actions.close')}
+            aria-label={t('actions.close')}
+          >
+            <CaretRightIcon size={14} weight="bold" />
+          </button>
+        </div>
+        <WatchlistBlock />
+      </div>
+    </div>
+  );
+}

--- a/web/src/data/watchMarkers.ts
+++ b/web/src/data/watchMarkers.ts
@@ -1,22 +1,24 @@
+import { type Icon, TargetIcon, MagnetIcon, SkullIcon, HandshakeIcon, EyeIcon } from '@phosphor-icons/react';
 import type { WatchMarkerKind } from '../types';
 
-// The fixed set of watchlist markers. Deliberately separate from the custom
-// intel tags (those are per-system "what I found"; these are "what I'm hunting
-// for"). Each marker carries a glyph (rendered on the node + in the panel), a
-// ring colour for the node highlight, and an i18n label key under watchMarker.*.
+// The single source of truth for watchlist markers. Deliberately separate from
+// the custom intel tags (those are per-system "what I found"; these are "what
+// I'm hunting for"). Each marker maps to a vendored Phosphor icon (NOT an
+// emoji — emoji render per-OS/browser) plus a highlight colour. Both the
+// watchlist panel and the map node read from here, so there's one definition.
 export interface WatchMarkerDef {
   kind:  WatchMarkerKind;
-  glyph: string;   // emoji/unicode shown on the node corner + the picker
-  color: string;   // highlight ring colour (CSS var --watch-color)
+  Icon:  Icon;
+  color: string;   // highlight ring colour (CSS var --watch-color) + icon tint
 }
 
 // Order is the picker order, most-hunted first.
 export const WATCH_MARKERS: WatchMarkerDef[] = [
-  { kind: 'target',   glyph: '\u{1F3AF}', color: '#6ea0ff' }, // 🎯 looking for / target
-  { kind: 'honeypot', glyph: '\u{1F36F}', color: '#e0a64e' }, // 🍯 honeypot / bait
-  { kind: 'avoid',    glyph: '☠️', color: '#e0556e' }, // ☠️ avoid at all costs
-  { kind: 'friendly', glyph: '\u{1F91D}', color: '#4ade80' }, // 🤝 friendly / staging
-  { kind: 'watch',    glyph: '\u{1F441}️', color: '#67e8f9' }, // 👁️ keep an eye on
+  { kind: 'target',   Icon: TargetIcon,    color: '#6ea0ff' }, // looking for / target
+  { kind: 'honeypot', Icon: MagnetIcon,    color: '#e0a64e' }, // honeypot / bait (lures them in)
+  { kind: 'avoid',    Icon: SkullIcon,     color: '#e0556e' }, // avoid at all costs
+  { kind: 'friendly', Icon: HandshakeIcon, color: '#4ade80' }, // friendly / staging
+  { kind: 'watch',    Icon: EyeIcon,       color: '#67e8f9' }, // keep an eye on
 ];
 
 const BY_KIND = new Map<WatchMarkerKind, WatchMarkerDef>(WATCH_MARKERS.map((m) => [m.kind, m]));


### PR DESCRIPTION
Follow-up to #185. You flagged the watchlist was cramped in the 250px right-hand map-options sidebar (the marker dropdown clipped to "Tar", the name field cut off) — and you'd originally asked for a left-side panel. This moves it there.

## Changes
- **New `WatchlistPanel`** docked on the **left** edge of the map. Slides in/out via a tab handle on its right edge — the handle shows a binoculars icon + the entry count when collapsed. Open/closed state persists per-user (`nexum.watchlist.panelOpen`).
- **Wider (340px)** so each entry sits on one comfortable row: *marker | name | note | delete*. Flattened the entry layout from the old stacked version.
- **Removed** the watchlist section from the right-hand map-options sidebar.

Everything else (matching, highlight ring + glyph on nodes, chime-on-appear, the per-user list) is unchanged — only the panel's home moved.

No new translation keys: the panel reuses the existing `Watchlist` label and `actions.close`.

`tsc` clean, `eslint .` 0 errors, `vite build` green.