### PR TITLE
Fix: system name hidden behind action buttons when info panel is narrow

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3513,7 +3513,10 @@ div.system-node__easy-handle {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 8px 12px;
+  /* When the panel is narrowed, the action buttons wrap to a second line
+     rather than crushing the system name — the title keeps its own line. */
+  flex-wrap: wrap;
 }
 
 .system-panel__title {
@@ -3524,7 +3527,10 @@ div.system-node__easy-handle {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  flex: 1 1 auto;
+  /* Keep the name readable; once it + the buttons no longer fit, the buttons
+     wrap below instead of the name shrinking to an ellipsis. */
+  min-width: 130px;
 }
 
 .system-panel__actions {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3421,7 +3421,10 @@ div.system-node__easy-handle {
   flex-direction: row;
   align-items: stretch;
   gap: 12px;
-  padding: 0 16px 12px;
+  /* Extra left padding clears the watchlist panel's left-edge tab (a persistent
+     ~38px handle, vertically centred) so it never overlaps the system name /
+     panel content when the panel is tall. */
+  padding: 0 16px 12px 48px;
   overflow: hidden;
   flex-shrink: 0;
   position: relative;


### PR DESCRIPTION
**Bug:** when the system-info panel is resized narrow, the *Set Destination* / *+ Waypoint* (and collapse/close) buttons crush the system name down to an ellipsis (e.g. "I…").

**Cause:** the header is a flex row of `title (flex:1)` + `actions (flex-shrink:0)`. The buttons keep their full width, so the title shrinks to nothing.

**Fix:** the header now `flex-wrap: wrap` and the title has a `min-width` (130px). Once the title + buttons no longer fit on one line, the buttons wrap to a second line instead of the name collapsing — so the system name stays readable at any panel width. No JS / breakpoint constants needed; it's content-driven.

Build green.