### PR TITLE
System panel: remove close button, collapse is the top-right control

### DIFF
--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -348,7 +348,6 @@ export function SystemPanel() {
               </>
             )}
             <button type="button" className="icon-btn" onClick={toggleInfoCollapsed} title={t('systemPanel.collapseInfo')}>‹</button>
-            <button type="button" className="icon-btn" onClick={() => selectSystem(null)} title={t('actions.close')}>✕</button>
           </div>
         </div>
 


### PR DESCRIPTION
Per request: removes the **✕ close** button from the system-info panel header. The **‹ collapse** caret is now the rightmost (top-right) control.

## Heads-up — no more dismiss
The ✕ was the *only* way to deselect/dismiss the panel (there's no Escape or click-away deselect, and the collapse caret only collapses the left info column, it doesn't close the panel). So after this, the panel stays open until you click a different system.

If that's not the intent, I'd suggest pairing this with one of:
- **Esc** to deselect (close the panel), and/or
- click on empty map canvas to deselect.

Say the word and I'll wire up whichever you prefer. `tsc` + build green.