### PR TITLE
System panel: pin the collapse caret to the top-right corner

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3520,6 +3520,17 @@ div.system-node__easy-handle {
   /* When the panel is narrowed, the action buttons wrap to a second line
      rather than crushing the system name — the title keeps its own line. */
   flex-wrap: wrap;
+  /* Anchor + reserved gutter for the collapse caret, which is pinned to the
+     top-right corner (out of the flex flow) rather than riding with the
+     Set Destination / Waypoint buttons. */
+  position: relative;
+  padding-right: 24px;
+}
+
+.system-panel__collapse {
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .system-panel__title {

--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -347,8 +347,10 @@ export function SystemPanel() {
                 </button>
               </>
             )}
-            <button type="button" className="icon-btn" onClick={toggleInfoCollapsed} title={t('systemPanel.collapseInfo')}>‹</button>
           </div>
+          {/* Collapse caret pinned to the panel's top-right corner, independent
+              of the Set Destination / Waypoint buttons (which wrap below). */}
+          <button type="button" className="icon-btn system-panel__collapse" onClick={toggleInfoCollapsed} title={t('systemPanel.collapseInfo')}>‹</button>
         </div>
 
         <div className="sys-info">


### PR DESCRIPTION
Follow-up to the close-button removal: the remaining **‹ collapse** caret was wrapping onto the second line beside *Set Destination* / *+ Waypoint* instead of sitting in the corner.

Pulled it out of the `system-panel__actions` flex group and absolutely positioned it in the header's **top-right corner** (with a reserved right gutter so nothing runs under it). The Set Destination / Waypoint buttons now wrap below it; the caret always stays in the corner at any panel width.

`tsc` + build green.