### PR TITLE
Fix: panel dropdowns don't close when you click outside (e.g. on the map)

### DIFF
--- a/web/src/components/ui/ContextMenu.tsx
+++ b/web/src/components/ui/ContextMenu.tsx
@@ -80,6 +80,18 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
+  // Close on a pointer-down anywhere outside the menu — capture phase so it
+  // also fires over the map canvas, which stops pointer propagation in the
+  // bubble phase. The containment check keeps clicks on the menu's own items
+  // (and submenus, which render inside it) from closing it before they run.
+  useEffect(() => {
+    function onDown(e: Event) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    document.addEventListener('pointerdown', onDown, true);
+    return () => document.removeEventListener('pointerdown', onDown, true);
+  }, [onClose]);
+
   return (
     <ul
       ref={ref}

--- a/web/src/components/ui/StructuresPane.tsx
+++ b/web/src/components/ui/StructuresPane.tsx
@@ -115,12 +115,6 @@ export function StructuresPane({ systemId }: { systemId: string }) {
   }, [structRev, activeMapId, systemId, isShareMode]);
 
   useEffect(() => {
-    const close = () => setCtx(null);
-    window.addEventListener('mousedown', close);
-    return () => window.removeEventListener('mousedown', close);
-  }, []);
-
-  useEffect(() => {
     if (!activeMapId) return;
 
     const handlePaste = async (e: ClipboardEvent) => {

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -17,14 +17,18 @@ export function usePopover() {
 
   useEffect(() => {
     if (!open) return;
-    const close = (e: MouseEvent) => {
+    const close = (e: Event) => {
       const target = e.target as Node;
       if (!btnRef.current?.contains(target) && !dropdownRef.current?.contains(target)) {
         setOpen(false);
       }
     };
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
+    // Capture phase so the dropdown closes on a pointer-down ANYWHERE — including
+    // the map canvas, which stops pointer-event propagation in the bubble phase
+    // (a plain bubbling listener never fired for clicks out there). The target
+    // check above keeps clicks inside the button/dropdown from closing it.
+    document.addEventListener('pointerdown', close, true);
+    return () => document.removeEventListener('pointerdown', close, true);
   }, [open]);
 
   return { open, setOpen, pos, btnRef, dropdownRef, openAt };


### PR DESCRIPTION
**Bug:** open a dropdown in the signature pane (wormhole type / leads-to) and click out on the **map** — it stays open. Only clicks inside the dense signature tab closed it. Same for the structures right-click menu.

**Cause:** the outside-click detection used a **bubble-phase** `mousedown`/`pointerdown` listener on `document`/`window`. The React Flow map canvas calls `stopPropagation()` on pointer events, so a click out on the map never reached the listener.

**Fix:** switch to a **capture-phase** `pointerdown` listener (capture fires top-down, before anything can stop propagation), keeping the existing **target-containment check** so clicks inside the dropdown/menu don't close it prematurely.
- `usePopover` (the wormhole-type + leads-to dropdowns) → capture phase.
- `ContextMenu` now self-manages outside-click the same way, so the **structures** right-click menu (and the map right-click menu) close on a click anywhere too. Removed StructuresPane's redundant bubble-phase listener.
- Anomaly/structure **type** pickers are native `<select>`s — those already close on their own.

`tsc` + build green.