### PR TITLE
Fix: crash when clicking a connection with a no-destination WH type (e.g. K162)

### DIFF
--- a/web/src/components/ui/WHTypeInfo.tsx
+++ b/web/src/components/ui/WHTypeInfo.tsx
@@ -14,7 +14,8 @@ interface Props {
   children?: ReactNode;
 }
 
-function classKey(raw: string): SystemClass | null {
+function classKey(raw: string | null | undefined): SystemClass | null {
+  if (!raw) return null;
   const up = raw.toUpperCase();
   if (/^C\d+$/.test(up))                                    return up as SystemClass;
   if (up === 'HS' || up === 'LS' || up === 'NS')            return up as SystemClass;
@@ -60,7 +61,7 @@ export function WHTypeInfo({ code, children }: Props) {
           className="wh-type-info__value"
           style={dest ? { color: CLASS_COLORS[dest] } : undefined}
         >
-          {dest ? CLASS_LABELS[dest] : spec.dest.toUpperCase()}
+          {dest ? CLASS_LABELS[dest] : (spec.dest ? spec.dest.toUpperCase() : '?')}
         </span>
       </div>
       <div className="wh-type-info__row">


### PR DESCRIPTION
**Bug:** clicking a connection crashed with `TypeError: Cannot read properties of null (reading 'toUpperCase')` in `WHTypeInfo`.

**Cause:** `classKey(spec.dest)` (and the leads-to fallback) assumed `spec.dest` is a string, but it's `null` for wormhole types with no fixed destination — notably **K162**. The connection panel renders `WHTypeInfo` for the connection's type, so clicking a K162 (or similar) connection threw and the panel white-screened.

**Fix:** `classKey` now guards `null`/`undefined` (returns null), and the "leads to" value falls back to `?` when `spec.dest` is unset. `tsc` + build green.