### PR TITLE
Fix gate connections being auto-typed as wormholes

### DIFF
--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -114,6 +114,8 @@ export function ConnectionPanel() {
   // clearing to '' — are never overwritten. Already-set K162 may be upgraded.
   useEffect(() => {
     if (!conn || !src || !tgt || !map.id) return;
+    // Jumpgate (stargate) links are never wormholes — never auto-type them.
+    if (conn.connectionType === 'jumpgate') return;
     if (conn.type !== null && conn.type.toUpperCase() !== 'K162') return;
     let cancelled = false;
     Promise.all([

--- a/web/src/utils/whAutoDetect.ts
+++ b/web/src/utils/whAutoDetect.ts
@@ -29,6 +29,10 @@ export function reevaluateConnectionsForSystem(
   const oldLeads = oldSig?.whLeadsTo?.toUpperCase();
 
   for (const conn of map.connections) {
+    // Jumpgate (stargate) connections are never wormholes — skip them so a
+    // sig that leads to a bare class ("HS") can't stamp a WH code onto a gate
+    // link to a same-class neighbour.
+    if (conn.connectionType === 'jumpgate') continue;
     const otherId =
       conn.sourceId === systemId ? conn.targetId :
       conn.targetId === systemId ? conn.sourceId :


### PR DESCRIPTION
## Problem

Gate (jumpgate / stargate) connections were sometimes getting stamped with a wormhole type code — e.g. an `A641` (a HS-to-HS wormhole) appearing on an actual stargate link. It happened intermittently, which made it hard to trigger.

## Cause

Two paths auto-fill a connection's `type` from the signatures on its two endpoint systems:

- `reevaluateConnectionsForSystem` (`web/src/utils/whAutoDetect.ts`) — runs when a sig's WH type / leads-to is edited
- the select effect in `ConnectionPanel.tsx` — runs when a connection is selected

Neither excluded **jumpgate** connections. The sig matcher accepts a leads-to of either a specific system name *or* a bare class (`"HS"`, `"NS"`, `"C2"`, ...). When a sig's leads-to was a bare class, `leadsTo === otherClass` matched **any** same-class neighbour — including one reached by a stargate. So a HS system with an `A641` sig leading to `"HS"` could stamp `A641` onto a gate link to a HS neighbour. The same applies to NS-to-NS, LS-to-LS, etc. — the bug was never specific to A641 or highsec.

## Fix

Skip `connectionType === 'jumpgate'` connections in both auto-detect paths. Gates are stargates and should never receive a wormhole code. The guard keys on the connection being a jumpgate (not on the WH type or system class), so it covers every security class.

## Note

This prevents future mis-typing but does not retroactively clear gate connections already stamped with a bad WH code in saved maps — those stay until cleared by hand. A one-time on-load sweep could be added later if wanted.