### PR TITLE
Clear system stale state when a character is present

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1363,6 +1363,33 @@ mapsRouter.post('/:mapId/presence', async (req, res) => {
     eveSystemId: typeof body.eveSystemId === 'number' ? body.eveSystemId : null,
     shipTypeId:  typeof body.shipTypeId  === 'number' ? body.shipTypeId  : null,
   }, req.get('x-client-id') ?? null);
+
+  // A character physically in a mapped system keeps it "active" so it never
+  // shows as stale while occupied — independent of whether any sigs/anoms are
+  // touched. Throttled to the last_activity_at column itself: the UPDATE only
+  // matches (and only then broadcasts) when activity is already older than a few
+  // minutes, so the 25 s presence heartbeat doesn't write/broadcast every tick.
+  // Fire-and-forget — never block the presence ack.
+  if (typeof body.eveSystemId === 'number') {
+    db.query(
+      `UPDATE map_systems SET last_activity_at = NOW()
+         WHERE map_id = $1 AND eve_system_id = $2
+           AND last_activity_at < NOW() - INTERVAL '5 minutes'
+       RETURNING id, last_activity_at`,
+      [mapId, body.eveSystemId],
+    ).then((r) => {
+      const row = r.rows[0] as { id: string; last_activity_at: Date } | undefined;
+      if (row) {
+        publishToMap(mapId, {
+          type: 'system.update',
+          actor: null,
+          id: row.id,
+          updates: { lastActivityAt: new Date(row.last_activity_at).toISOString() },
+        });
+      }
+    }).catch(() => { /* best-effort: a failed activity bump must not break presence */ });
+  }
+
   res.status(204).end();
 });
 


### PR DESCRIPTION
## What

A stale (faded) system now clears as soon as a character is present in it — no need to add a signature or anomaly.

## Why

Staleness is driven by \`map_systems.last_activity_at\`, which was only bumped by signature/anomaly/system edits. Simply visiting a system did nothing, so an occupied hole could still show faded.

## How

In the \`POST /:mapId/presence\` handler, when a character reports being physically in a mapped system, bump that system's \`last_activity_at = NOW()\` and broadcast a \`system.update\` carrying \`lastActivityAt\` so the node un-fades live for everyone viewing.

- **Throttled at the column**: the \`UPDATE\` only matches (and only then broadcasts) when activity is already older than 5 minutes, so the 25s presence heartbeat doesn't write/broadcast every tick.
- **Broadcasts only on real change** (\`RETURNING\` row only when the UPDATE matched).
- **Fire-and-forget**: a failed bump never breaks the presence ack.
- **Persisted**: ages normally from the last visit after the character leaves.

## Notes

- Clears within one heartbeat (~25s of entering), riding the existing presence cadence.
- Any present character counts (incl. readonly corp members) — a body in the hole is a legitimate "active" signal.
- Requires presence to be reporting a location; if location is unknown there's nothing to match.