### PR TITLE
Bump qs to 6.15.2 (Dependabot security fix)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,9 @@
     "seed-demo": "tsx scripts/seed-demo.ts",
     "extract-wormholes": "tsx scripts/extract-wormholes.ts"
   },
+  "resolutions": {
+    "qs": "^6.15.2"
+  },
   "dependencies": {
     "cheerio": "^1.2.0",
     "connect-pg-simple": "^10.0.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1009,17 +1009,10 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-qs@~6.14.0:
-  version "6.14.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
-  dependencies:
-    side-channel "^1.1.0"
-
-qs@~6.15.1:
-  version "6.15.1"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz"
-  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+qs@^6.15.2, qs@~6.14.0, qs@~6.15.1:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## What

Forces the transitive `qs` dependency to the patched **6.15.2** via a yarn `resolution`.

## Why

Dependabot flagged `qs.stringify` throwing a synchronous `TypeError` on an array containing `null`/`undefined` when called with `arrayFormat: 'comma'` **and** `encodeValuesOnly: true` (affected `>=6.11.1 <=6.15.1`, patched in `6.15.2`). `skipNulls` / `strictNullHandling` never get a chance to run.

It reaches us transitively through express/body-parser, which pulled two copies:
- `qs@~6.14.0` -> `6.14.2`
- `qs@~6.15.1` -> `6.15.1`

both inside the vulnerable band.

## How

Added `"resolutions": { "qs": "^6.15.2" }` to `server/package.json` and ran `yarn install`. Both ranges now dedupe to a single `qs@6.15.2` entry in `yarn.lock`. Server typechecks clean; audit reports 0 vulnerabilities.

Note: we don't call `qs.stringify` with that option combo ourselves, so real-world exposure was low — but it's a clean, low-risk transitive bump.