### PR TITLE
External read API: account-scoped API keys + /api/v1 (backend)

### DIFF
--- a/external_api_feature.md
+++ b/external_api_feature.md
@@ -1,0 +1,184 @@
+# External Read API & API Keys — Design
+
+## 1. Goal
+
+Let **other tools** read (and later drive) a user's Nexum maps programmatically:
+pull the live chain into a fleet bot, an intel aggregator, a "is home open to
+highsec?" checker, or the user's own scripts. Authenticated with a **long-lived
+API key** the user generates, not a browser session.
+
+This is the *inbound* counterpart to the already-shipped *outbound* Discord
+notifications (see [discord_webhooks_feature.md](./discord_webhooks_feature.md)).
+Discord pushes a curated, corp-scoped slice of intel **out**; this lets approved
+clients pull map state **in**. They are independent features.
+
+## 2. Scope & non-goals
+
+- **v1 = read-only.** `GET` map list, full map, and per-system signatures /
+  connections / structures / anomalies. No writes in v1.
+- **Account-scoped keys** (see §4) — a key acts as one owner, with one bound
+  character for role/corp context.
+- **Reuse existing authorization.** A request authenticated by an API key must
+  see *exactly* what that owner/character sees in the app — no new permission
+  surface. It flows through the existing `getMapAccess()` / role gates in
+  `routes/maps.ts`.
+- **Out of scope (v1):** write/mutate endpoints (phase 3); OAuth-style
+  third-party app authorization; per-endpoint granular scopes beyond a coarse
+  `read` / `events` (room left in the schema, not built); public/unauthenticated
+  data access (the existing share-token endpoint already covers read-only public
+  snapshots — this feature is for *authenticated* programmatic access).
+
+## 3. Relationship to what already exists
+
+- **Auth today** is EVE SSO → Postgres-backed `express-session` cookies; the
+  session carries `userId`, `characterId`, `ownerId`, `role`, `userCorpId`
+  (`session.d.ts`). Map routes are gated by `requireAuth` and `getMapAccess()`
+  (`routes/maps.ts`).
+- **Ownership pivots on `owner_id`** (the `owners` account layer). Personal maps
+  belong to an owner; corp maps to a `corp_id`; explicit grants live in
+  `map_shares`. This is *why* account-scoped keys are the natural fit (§4).
+- **Live events** already exist: the SSE stream at `GET /api/maps/:mapId/events`
+  (`routes/maps.ts:1313`) fed by the central `publishToMap()` seam
+  (`services/mapEvents.ts`). Phase 2 below reuses it directly.
+- **No key system exists yet.** The only `Bearer` usage in the server is the EVE
+  **ESI** access token sent *outbound* to CCP — unrelated.
+
+## 4. Auth model — account-scoped keys with a bound character
+
+A key is scoped to an **owner** (account), not a single map (the
+Wanderer-style map-scoped key would force a parallel auth path and break on
+character switching). But `role` and `corp_id` are **character-level**
+(`users.role`, `users.corp_id`), so each key is **bound to one character** that
+supplies the role/corp context.
+
+A request authenticated by key `K` (owner `O`, bound character `C`) sees:
+- all of `O`'s **personal** maps,
+- all maps explicitly shared to `C` or `C`'s corp via `map_shares`,
+- `C`'s **corp** maps (subject to corp-mode config),
+- acting with **`C`'s role** (admin/full/edit/readonly), optionally *downgraded*
+  by the key's `scope`.
+
+This is precisely what the session already computes — so the key middleware just
+populates the same request fields and **every existing check works unchanged**.
+
+## 5. Data model (migration in `server/src/migrate.ts`)
+
+Idempotent `CREATE TABLE IF NOT EXISTS`, matching the existing migration style.
+
+```sql
+CREATE TABLE IF NOT EXISTS api_tokens (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id         INTEGER     NOT NULL REFERENCES owners(id) ON DELETE CASCADE,
+  -- character whose role/corp this key acts with; NULL if that char is removed
+  context_user_id  INTEGER     REFERENCES users(id) ON DELETE SET NULL,
+  token_hash       TEXT        NOT NULL UNIQUE,   -- sha-256 hex of the raw key
+  token_prefix     TEXT        NOT NULL,          -- first ~8 chars, for display/lookup hint
+  name             TEXT        NOT NULL,          -- user label ("fleet bot")
+  scope            TEXT        NOT NULL DEFAULT 'read',  -- 'read' | 'events' (write later)
+  last_used_at     TIMESTAMPTZ,
+  expires_at       TIMESTAMPTZ,                   -- NULL = no expiry
+  created_by_user_id INTEGER   REFERENCES users(id) ON DELETE SET NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_owner ON api_tokens(owner_id);
+```
+
+**Why hash, not encrypt:** unlike the EVE tokens (`tokenCrypto.ts`, AES-GCM,
+which must be *decrypted* to call ESI), an API key is only ever *compared*. Store
+a one-way **sha-256** of the raw key; a DB leak then exposes no usable keys. The
+raw key is shown to the user **once** at creation and never again. `token_prefix`
+lets the UI show "nxm_3f9a…" in the key list without storing the secret.
+
+Key format: `nxm_<32+ random url-safe bytes>`. Lookup by `token_hash` (unique),
+then constant-time compare as defence in depth.
+
+## 6. Middleware — `apiKeyAuth`
+
+New `server/src/middleware/apiKeyAuth.ts`:
+
+1. Read `Authorization: Bearer <key>`. If absent, `next()` (let session auth or
+   the route's own `requireAuth` handle it — so routes can accept *either*).
+2. `sha256(key)` → `SELECT … FROM api_tokens WHERE token_hash = $1`.
+3. Reject (401) if not found, `expires_at` passed, or `context_user_id` is NULL
+   (bound character was removed → key inert until rebound/rotated).
+4. Load the bound character's `role` + `corp_id`; populate the request with the
+   **same shape the session sets** (`userId = context_user_id`,
+   `ownerId = owner_id`, `role`, `userCorpId`), plus `req.apiScope = scope`.
+5. `UPDATE … SET last_used_at = NOW()` (throttle to ≤1/min per key to avoid a
+   write per request).
+
+Mount it **before** `requireAuth` on `/api/maps` read routes so a Bearer key is
+an alternative to the cookie. `requireMapContentWrite` / `requireMapWrite`
+additionally check `req.apiScope !== 'read'` once writes exist (§9 phase 3).
+
+## 7. Endpoints (v1, read-only)
+
+Reuse the existing map read handlers — they already call `getMapAccess()`, which
+now resolves via the key-populated request. Surfaced under a stable, versioned
+prefix so the programmatic contract is decoupled from the cookie UI routes:
+
+- `GET /api/v1/maps` — maps visible to the key
+- `GET /api/v1/maps/:mapId` — full map (systems + connections)
+- `GET /api/v1/maps/:mapId/systems/:systemId/signatures`
+- `GET /api/v1/maps/:mapId/systems/:systemId/connections` *(or top-level
+  `/maps/:mapId/connections`)*
+- `GET /api/v1/maps/:mapId/systems/:systemId/structures`
+- `GET /api/v1/maps/:mapId/systems/:systemId/anomalies`
+
+Implementation: thin `/api/v1` router that applies `apiKeyAuth` + the existing
+access checks and delegates to the same query logic the session routes use
+(extract shared read helpers if needed). Document the JSON shapes (they already
+exist as the SSE/REST payloads).
+
+**Key-management routes** (cookie-authed, in the app UI — *not* key-authed):
+- `GET    /api/keys` — list the owner's keys (id, name, prefix, scope,
+  last_used_at, expires_at; never the secret)
+- `POST   /api/keys` — create; body `{ name, contextCharacterId, scope?,
+  expiresAt? }`; returns the raw key **once**
+- `DELETE /api/keys/:id` — revoke
+
+## 8. Live events for tools (phase 2)
+
+The SSE endpoint `GET /api/maps/:mapId/events` already streams structured events
+from `publishToMap()`. Add `apiKeyAuth` (scope `events`) as an alternative to the
+session on this route — tools then get the **same** live feed the web client
+uses, for almost no new code. Unlike the Discord feature (which deliberately
+avoids the `publishToMap` bus to skip bulk paths), tapping the full stream is
+correct here: a tool wants everything and filters its own side. Document the
+event taxonomy (`system.add`, `connection.update`, `sig.changed`, …) as the
+public contract; consider freezing the strings behind a shared enum at that
+point.
+
+## 9. Phased rollout
+
+1. Migration (`api_tokens`) + `apiKeyAuth` middleware + key-management routes +
+   a "API keys" section in the user/profile UI (create/list/revoke, show-once).
+2. `/api/v1` read endpoints over the existing access checks; document JSON shapes.
+3. `apiKeyAuth` on the SSE endpoint (scope `events`); publish the event contract.
+4. (Later, on demand) write endpoints — gate on `scope`/role via the existing
+   `requireMapWrite` / `requireMapContentWrite`.
+
+## 10. Rate limiting / safety
+
+- Reuse the existing rate-limiter middleware pattern (the app already has
+  auth/esi/app/public limiters); add a per-key limiter keyed on token id.
+- Keys are secrets: shown once, stored hashed, masked in logs, revocable.
+- Record create/revoke in the existing **audit log** for parity with admin
+  actions.
+- **Blast radius:** an account-scoped key sees all the owner's maps. Mitigations:
+  the `scope` field (read/events only in v1), optional `expires_at`, one-click
+  revoke, and `last_used_at` for spotting stale/leaked keys. A future per-key
+  **map allowlist** column can narrow a key to specific maps if a Wanderer-style
+  single-map key is ever wanted — schema-compatible, not built in v1.
+
+## 11. Notes / risks
+
+- **Single-instance** assumptions elsewhere (SSE/presence/Discord queue) don't
+  affect REST reads. The SSE-for-tools step (phase 2) inherits the same
+  single-process caveat as the existing stream; the documented fix is the same
+  `publishToMap` → Postgres `LISTEN/NOTIFY` swap.
+- **Bound-character churn:** if the bound character is removed from the owner,
+  the key goes inert (`context_user_id` → NULL) rather than silently escalating
+  or acting headless. Surfaced in the key list; user rebinds or revokes.
+- **Demand-gated:** v1 is intentionally read + events only. Writes add real
+  surface and should wait for a concrete consumer that needs them.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -35,6 +35,8 @@ import { startTelemetry } from './services/telemetry.js';
 import { telemetryRouter } from './routes/telemetry.js';
 import { adminRouter, adminReadRouter, reportsRouter } from './routes/admin.js';
 import { standingsRouter } from './routes/standings.js';
+import { keysRouter } from './routes/keys.js';
+import { apiV1Router } from './routes/apiV1.js';
 import { shareRouter } from './routes/share.js';
 import searchRouter from './routes/search.js';
 import { authLimiter, esiLimiter, publicLimiter, appLimiter } from './middleware/rateLimits.js';
@@ -121,6 +123,10 @@ app.use('/api/admin/reports',     appLimiter, reportsRouter);
 app.use('/api/admin',             appLimiter, adminReadRouter);
 app.use('/api/admin',             appLimiter, adminRouter);
 app.use('/api/standings',         appLimiter, standingsRouter);
+app.use('/api/keys',              appLimiter, keysRouter);
+// External read API (Bearer key or session). Reuses the app limiter for now;
+// a per-key limiter (keyed on token id) is a planned safety follow-up.
+app.use('/api/v1',                appLimiter, apiV1Router);
 app.use('/api/search',            esiLimiter, searchRouter);
 
 app.get('/health', (_req, res) => res.json({ ok: true }));

--- a/server/src/middleware/apiKeyAuth.ts
+++ b/server/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,80 @@
+import type { Request, Response, NextFunction } from 'express';
+import { db } from '../db.js';
+import { hashApiKey } from '../utils/apiKeys.js';
+import type { Role } from './authContext.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('apiKeyAuth');
+
+// Throttle the last_used_at write so a chatty client doesn't cause a row write
+// per request — once a minute per key is plenty to spot a stale/leaked key.
+const LAST_USED_THROTTLE_MS = 60_000;
+const lastUsedWrittenAt = new Map<string, number>();
+
+// Resolve an `Authorization: Bearer <key>` into req.apiAuth. If no Bearer
+// header is present this is a no-op (next()) so the route's own requireAuth /
+// session auth still applies — routes can accept either credential. A present
+// but invalid/expired/inert key is a hard 401.
+export async function apiKeyAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const header = req.get('authorization');
+  if (!header || !header.toLowerCase().startsWith('bearer ')) { next(); return; }
+
+  const raw = header.slice(7).trim();
+  if (!raw) { res.status(401).json({ error: 'Invalid API key' }); return; }
+
+  try {
+    const { rows } = await db.query<{
+      id: string; ownerId: number; contextUserId: number | null;
+      scope: string; expiresAt: Date | null;
+      role: Role | null; corpId: number | null; characterId: number | null;
+    }>(
+      `SELECT t.id,
+              t.owner_id          AS "ownerId",
+              t.context_user_id   AS "contextUserId",
+              t.scope,
+              t.expires_at        AS "expiresAt",
+              u.role,
+              u.corp_id           AS "corpId",
+              u.character_id      AS "characterId"
+         FROM api_tokens t
+         LEFT JOIN users u ON u.id = t.context_user_id
+        WHERE t.token_hash = $1`,
+      [hashApiKey(raw)],
+    );
+
+    const row = rows[0];
+    if (!row) { res.status(401).json({ error: 'Invalid API key' }); return; }
+    if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) {
+      res.status(401).json({ error: 'API key expired' }); return;
+    }
+    // Bound character removed from the account → key is inert (not silently
+    // headless). The owner rebinds or revokes it from the key list.
+    if (row.contextUserId == null || row.role == null || row.characterId == null) {
+      res.status(401).json({ error: 'API key is inactive (bound character removed)' }); return;
+    }
+
+    const scope: 'read' | 'events' = row.scope === 'events' ? 'events' : 'read';
+    req.apiAuth = {
+      userId:      row.contextUserId,
+      characterId: row.characterId,
+      ownerId:     row.ownerId,
+      role:        row.role,
+      corpId:      row.corpId,
+      apiScope:    scope,
+    };
+
+    // Best-effort, throttled last_used_at bump — never blocks the request.
+    const now = Date.now();
+    const prev = lastUsedWrittenAt.get(row.id) ?? 0;
+    if (now - prev >= LAST_USED_THROTTLE_MS) {
+      lastUsedWrittenAt.set(row.id, now);
+      db.query(`UPDATE api_tokens SET last_used_at = NOW() WHERE id = $1`, [row.id])
+        .catch((err) => log.warn(`failed to bump last_used_at for key ${row.id}: ${err}`));
+    }
+
+    next();
+  } catch (err) {
+    log.error(`api key auth failed: ${err}`);
+    res.status(500).json({ error: 'Authentication error' });
+  }
+}

--- a/server/src/middleware/authContext.ts
+++ b/server/src/middleware/authContext.ts
@@ -1,0 +1,40 @@
+import type { Request } from 'express';
+
+// The minimal identity the map access checks need, resolved from EITHER a
+// browser session (cookie) OR an API key (Bearer). Existing routes read these
+// off req.session directly; getMapAccess + the role gates now go through
+// authUser() so an API-key request — which has no session — resolves to the
+// same fields and every existing check works unchanged.
+export type Role = 'admin' | 'full' | 'edit' | 'readonly';
+
+export interface AuthUser {
+  userId:      number;          // users.id of the acting (bound) character
+  characterId: number;          // that character's EVE character_id
+  ownerId:     number | null;   // account/owner the maps are scoped to
+  role:        Role;
+  corpId:      number | null;
+  /** Present only for API-key requests; the key's scope ('read' | 'events'). */
+  apiScope?:   'read' | 'events';
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    // Set by apiKeyAuth when a valid Bearer key is presented. Absent for
+    // cookie-authenticated requests (those fall back to req.session below).
+    apiAuth?: AuthUser;
+  }
+}
+
+// Resolve the acting identity for a request. Prefers an API-key context when
+// present, otherwise the browser session. Callers that previously read
+// req.session.userId etc. should use this so both auth paths are honoured.
+export function authUser(req: Request): AuthUser {
+  if (req.apiAuth) return req.apiAuth;
+  return {
+    userId:      req.session.userId!,
+    characterId: req.session.characterId!,
+    ownerId:     req.session.ownerId ?? null,
+    role:        req.session.role ?? 'readonly',
+    corpId:      req.session.userCorpId ?? null,
+  };
+}

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -572,6 +572,28 @@ export async function migrate() {
 
     CREATE INDEX IF NOT EXISTS idx_users_owner ON users (owner_id);
     CREATE INDEX IF NOT EXISTS idx_maps_owner  ON maps  (owner_id);
+
+    -- Account-scoped API keys for the external read API. A key acts as one
+    -- owner (account) with one bound character supplying role/corp context, so
+    -- a key request resolves to exactly what that character sees in the app.
+    -- We store a one-way sha-256 of the raw key (only ever compared, never
+    -- decrypted — unlike the AES-GCM EVE tokens); the raw key is shown once at
+    -- creation. See external_api_feature.md.
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      owner_id           INTEGER     NOT NULL REFERENCES owners(id) ON DELETE CASCADE,
+      -- character whose role/corp this key acts with; NULL if that char is removed
+      context_user_id    INTEGER     REFERENCES users(id) ON DELETE SET NULL,
+      token_hash         TEXT        NOT NULL UNIQUE,  -- sha-256 hex of the raw key
+      token_prefix       TEXT        NOT NULL,         -- first chars, for display only
+      name               TEXT        NOT NULL,         -- user label ("fleet bot")
+      scope              TEXT        NOT NULL DEFAULT 'read',  -- 'read' | 'events'
+      last_used_at       TIMESTAMPTZ,
+      expires_at         TIMESTAMPTZ,                  -- NULL = no expiry
+      created_by_user_id INTEGER     REFERENCES users(id) ON DELETE SET NULL,
+      created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_api_tokens_owner ON api_tokens (owner_id);
   `);
 
   await encryptLegacyTokens();

--- a/server/src/routes/apiV1.ts
+++ b/server/src/routes/apiV1.ts
@@ -1,0 +1,83 @@
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { apiKeyAuth } from '../middleware/apiKeyAuth.js';
+import { authUser } from '../middleware/authContext.js';
+import { getMapAccess } from './maps.js';
+import {
+  listVisibleMaps, loadFullMap, isSystemInMap,
+  loadSystemSignatures, loadSystemAnomalies, loadSystemStructures,
+} from '../services/mapRead.js';
+
+// Versioned, stable external read API. Authenticated by an account-scoped API
+// key (Authorization: Bearer nxm_…); a browser session also works, so the same
+// surface is usable from the app during development. Read-only in v1 — writes
+// are a later, scope-gated phase. See external_api_feature.md.
+//
+// Shapes are deliberately decoupled from the cookie UI routes but currently
+// share the same read loaders (services/mapRead.ts), so they match today and
+// can be frozen independently later.
+export const apiV1Router = Router();
+
+// Resolve a Bearer key (if present) into req.apiAuth, then require SOME
+// identity — a valid key or a logged-in session. No credential → 401.
+apiV1Router.use(apiKeyAuth);
+apiV1Router.use((req: Request, res: Response, next: NextFunction) => {
+  if (!req.apiAuth && !req.session.userId) {
+    res.status(401).json({ error: 'API key required' });
+    return;
+  }
+  next();
+});
+
+// GET /api/v1/maps — maps visible to the key's account.
+apiV1Router.get('/maps', async (req, res) => {
+  const me = authUser(req);
+  const maps = await listVisibleMaps({
+    userId:     me.userId,
+    ownerId:    me.ownerId,
+    userCorpId: me.corpId,
+    callerChar: me.characterId,
+  });
+  res.json({ maps });
+});
+
+// GET /api/v1/maps/:mapId — full map (meta + systems + connections). Share-link
+// fields are stripped: they're capability secrets the programmatic API has no
+// reason to leak.
+apiV1Router.get('/maps/:mapId', async (req, res) => {
+  const { mapId } = req.params;
+  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
+  const full = await loadFullMap(mapId);
+  if (!full) { res.status(404).json({ error: 'Map not found' }); return; }
+  const {
+    shareToken: _t, shareExpiresAt: _e,
+    shareIncludeSigs: _s, shareIncludeBridges: _b,
+    shareIncludeNotes: _n, shareIncludeStructures: _st,
+    ...safe
+  } = full as Record<string, unknown>;
+  res.json(safe);
+});
+
+// Per-system intel. Each guards access on the map, then confirms the system
+// belongs to it (cross-map IDOR + malformed-uuid guard) before loading.
+async function systemScope(req: Request, res: Response): Promise<boolean> {
+  const { mapId, systemId } = req.params;
+  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return false; }
+  if (!(await isSystemInMap(systemId, mapId))) { res.status(404).json({ error: 'System not found' }); return false; }
+  return true;
+}
+
+apiV1Router.get('/maps/:mapId/systems/:systemId/signatures', async (req, res) => {
+  if (!(await systemScope(req, res))) return;
+  res.json(await loadSystemSignatures(req.params.systemId));
+});
+
+apiV1Router.get('/maps/:mapId/systems/:systemId/anomalies', async (req, res) => {
+  if (!(await systemScope(req, res))) return;
+  res.json(await loadSystemAnomalies(req.params.systemId));
+});
+
+apiV1Router.get('/maps/:mapId/systems/:systemId/structures', async (req, res) => {
+  if (!(await systemScope(req, res))) return;
+  res.json(await loadSystemStructures(req.params.systemId));
+});

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -1,0 +1,147 @@
+import { Router } from 'express';
+import { db } from '../db.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { resolveOwnerId } from '../utils/owner.js';
+import { generateApiKey } from '../utils/apiKeys.js';
+import { audit } from '../services/audit.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('keys');
+
+// Management API for the user's own external API keys. Cookie/session-authed
+// (NOT key-authed — you can't mint keys with a key). A key is account-scoped:
+// it acts as the caller's owner with one bound character for role/corp context.
+// See external_api_feature.md.
+export const keysRouter = Router();
+keysRouter.use(requireAuth);
+
+const MAX_KEYS_PER_OWNER = 25;
+const VALID_SCOPES = new Set(['read', 'events']);
+// api_tokens.id is a uuid; Postgres throws 22P02 on malformed input, so guard
+// the path param up front and treat a bad shape as a clean 404.
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// GET /api/keys — list the owner's keys. Never returns the secret (only the
+// stored prefix + metadata); the raw key is shown once at creation and never
+// recoverable.
+keysRouter.get('/', async (req, res) => {
+  const ownerId = await resolveOwnerId(req);
+  if (ownerId == null) { res.status(401).json({ error: 'Not authenticated' }); return; }
+
+  const { rows } = await db.query(
+    `SELECT t.id,
+            t.name,
+            t.token_prefix     AS "tokenPrefix",
+            t.scope,
+            t.context_user_id  AS "contextUserId",
+            u.character_name   AS "contextCharacterName",
+            t.last_used_at     AS "lastUsedAt",
+            t.expires_at       AS "expiresAt",
+            t.created_at       AS "createdAt"
+       FROM api_tokens t
+       LEFT JOIN users u ON u.id = t.context_user_id
+      WHERE t.owner_id = $1
+      ORDER BY t.created_at DESC`,
+    [ownerId],
+  );
+  res.json({ keys: rows, maxKeys: MAX_KEYS_PER_OWNER });
+});
+
+// POST /api/keys — create a key bound to one of the account's characters.
+// Body: { name, contextCharacterId, scope?, expiresAt? }. Returns the raw key
+// exactly once.
+keysRouter.post('/', async (req, res) => {
+  const ownerId = await resolveOwnerId(req);
+  if (ownerId == null) { res.status(401).json({ error: 'Not authenticated' }); return; }
+
+  const body = req.body as {
+    name?: unknown; contextCharacterId?: unknown; scope?: unknown; expiresAt?: unknown;
+  };
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!name || name.length > 60) {
+    res.status(400).json({ error: 'A name (1-60 chars) is required' }); return;
+  }
+
+  const scope = body.scope == null ? 'read' : String(body.scope);
+  if (!VALID_SCOPES.has(scope)) {
+    res.status(400).json({ error: 'scope must be "read" or "events"' }); return;
+  }
+
+  // expiresAt is optional; if given it must be a valid future timestamp.
+  let expiresAt: Date | null = null;
+  if (body.expiresAt != null && body.expiresAt !== '') {
+    const d = new Date(String(body.expiresAt));
+    if (Number.isNaN(d.getTime())) { res.status(400).json({ error: 'Invalid expiresAt' }); return; }
+    if (d.getTime() <= Date.now()) { res.status(400).json({ error: 'expiresAt must be in the future' }); return; }
+    expiresAt = d;
+  }
+
+  // The bound character must belong to THIS account — you can only grant a key
+  // the context of a character you own. contextCharacterId is the EVE
+  // character_id; resolve it to the users row and verify ownership.
+  const contextCharacterId = Number(body.contextCharacterId);
+  if (!Number.isInteger(contextCharacterId)) {
+    res.status(400).json({ error: 'contextCharacterId is required' }); return;
+  }
+  const { rows: charRows } = await db.query<{ id: number; ownerId: number | null }>(
+    `SELECT id, owner_id AS "ownerId" FROM users WHERE character_id = $1`,
+    [contextCharacterId],
+  );
+  const ctx = charRows[0];
+  if (!ctx || ctx.ownerId !== ownerId) {
+    res.status(400).json({ error: 'contextCharacterId must be a character on your account' }); return;
+  }
+
+  // Per-account cap — a soft guard against runaway key creation.
+  const { rowCount } = await db.query(`SELECT 1 FROM api_tokens WHERE owner_id = $1`, [ownerId]);
+  if ((rowCount ?? 0) >= MAX_KEYS_PER_OWNER) {
+    res.status(409).json({ error: `Key limit reached (${MAX_KEYS_PER_OWNER})` }); return;
+  }
+
+  const key = generateApiKey();
+  const { rows } = await db.query<{ id: string; createdAt: string }>(
+    `INSERT INTO api_tokens
+       (owner_id, context_user_id, token_hash, token_prefix, name, scope, expires_at, created_by_user_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, created_at AS "createdAt"`,
+    [ownerId, ctx.id, key.hash, key.prefix, name, scope, expiresAt, req.session.userId],
+  );
+  const created = rows[0];
+
+  await audit(req, ctx.id, contextCharacterId, 'api_key_create', null, `${name} (${scope})`)
+    .catch((err) => log.warn(`audit api_key_create failed: ${err}`));
+
+  // The ONLY time the raw key is returned. The client must surface it for copy
+  // and warn it cannot be shown again.
+  res.status(201).json({
+    id: created.id,
+    name,
+    scope,
+    tokenPrefix: key.prefix,
+    expiresAt,
+    createdAt: created.createdAt,
+    key: key.raw,
+  });
+});
+
+// DELETE /api/keys/:id — revoke. Scoped to the owner so you can only delete
+// your own keys.
+keysRouter.delete('/:id', async (req, res) => {
+  const ownerId = await resolveOwnerId(req);
+  if (ownerId == null) { res.status(401).json({ error: 'Not authenticated' }); return; }
+  if (!UUID_RE.test(req.params.id)) { res.status(404).json({ error: 'Key not found' }); return; }
+
+  const { rows } = await db.query<{ id: string; name: string; contextUserId: number | null }>(
+    `DELETE FROM api_tokens
+      WHERE id = $1 AND owner_id = $2
+      RETURNING id, name, context_user_id AS "contextUserId"`,
+    [req.params.id, ownerId],
+  );
+  if (!rows.length) { res.status(404).json({ error: 'Key not found' }); return; }
+
+  await audit(req, rows[0].contextUserId, null, 'api_key_revoke', rows[0].name, null)
+    .catch((err) => log.warn(`audit api_key_revoke failed: ${err}`));
+
+  res.status(204).end();
+});

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -3,6 +3,7 @@ import { esiFetch } from '../utils/esi.js';
 import type { Request, Response } from 'express';
 import { db } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
+import { authUser } from '../middleware/authContext.js';
 import { config } from '../config.js';
 import { decryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
@@ -11,6 +12,7 @@ import { resolveOwnerId } from '../utils/owner.js';
 import { resolveEntityNames } from '../services/entityNames.js';
 import { audit } from '../services/audit.js';
 import { subscribeMap, publishToMap } from '../services/mapEvents.js';
+import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures } from '../services/mapRead.js';
 import { syncSignature, syncAnomaly } from '../services/crossMapSync.js';
 import { reportPresence, removePresence, presenceSnapshot } from '../services/presence.js';
 import { notifyDiscord, webhookFor, k162Embed, connectionEmbed } from '../services/discord.js';
@@ -79,8 +81,8 @@ mapsRouter.use(requireAuth);
 //   - corp_member  : visible via corp membership; role-gated for writes
 //   - shared       : explicit map_shares grant (character or corp) — full edit,
 //                    no role check, but lock + owner-only ops still apply
-type AccessKind = 'owner' | 'corp_member' | 'shared';
-interface MapMeta {
+export type AccessKind = 'owner' | 'corp_member' | 'shared';
+export interface MapMeta {
   userId:     number;
   corpId:     number | null;
   locked:     boolean;
@@ -93,10 +95,13 @@ interface MapMeta {
 // up front keeps that case as a clean 404.
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
-async function getMapAccess(mapId: string, req: Request): Promise<MapMeta | null> {
+export async function getMapAccess(mapId: string, req: Request): Promise<MapMeta | null> {
   if (!UUID_RE.test(mapId)) return null;
-  const userId     = req.session.userId!;
-  const userCorpId = req.session.userCorpId ?? null;
+  // Resolve identity from EITHER the session or an API-key context (req.apiAuth),
+  // so the same access logic serves cookie clients and external API keys.
+  const auth       = authUser(req);
+  const userId     = auth.userId;
+  const userCorpId = auth.corpId;
 
   // Pull map + caller's EVE character id in one round-trip; the latter is
   // needed to match against map_shares.target_character_id.
@@ -187,7 +192,13 @@ async function requireMapContentWrite(res: Response, mapId: string, req: Request
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return null; }
 
-  const role = req.session.role ?? 'readonly';
+  const acting = authUser(req);
+  // API keys are read-only in v1 — no key scope grants writes yet, so any
+  // key-authenticated mutation is refused here regardless of the character's
+  // role. (Write scopes will gate on acting.apiScope when added.)
+  if (acting.apiScope) { res.status(403).json({ error: 'This API key is read-only' }); return null; }
+
+  const role = acting.role;
 
   // Owners and explicit-share recipients always get write access. A share
   // grant is a deliberate invitation by the owner — honouring it shouldn't
@@ -203,7 +214,7 @@ async function requireMapWrite(res: Response, mapId: string, req: Request): Prom
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return null;
 
-  if (access.locked && req.session.role !== 'admin') {
+  if (access.locked && authUser(req).role !== 'admin') {
     res.status(403).json({ error: 'Map is locked' }); return null;
   }
   return access;
@@ -375,49 +386,9 @@ mapsRouter.get('/', async (req, res) => {
   );
   const callerChar = meRows[0]?.characterId ?? null;
 
-  // Corp visibility set: own corp when CORP_MAP_SHARED=false, every listed
-  // corp otherwise. Empty array if corp mode is off entirely.
-  const visibleCorpIds = config.corpMode && config.corpIds.length > 0
-    ? (config.corpMapShared ? config.corpIds : (userCorpId ? [userCorpId] : []))
-    : [];
-
-  // One query, three OR'd visibility clauses:
-  //   1. personal maps owned by this user
-  //   2. corp maps in visibleCorpIds (when corp mode active)
-  //   3. personal maps explicitly shared with this character or their corp
-  // The LEFT JOIN to map_shares + DISTINCT collapses any rows that match
-  // both the corp clause AND a share (which shouldn't happen because shares
-  // are personal-map-only, but the DISTINCT keeps it safe).
-  const { rows } = await db.query<{
-    id: string; name: string; isCorpMap: boolean; sharedWithMe: boolean;
-    locked: boolean; lastActiveAt: string; createdAt: string; updatedAt: string;
-    ownerName: string | null; allowAsMergeSource: boolean; allowAsMergeDestination: boolean;
-  }>(
-    `SELECT DISTINCT
-            m.id,
-            m.name,
-            m.corp_id IS NOT NULL AS "isCorpMap",
-            (m.user_id <> $1 AND m.owner_id IS DISTINCT FROM $5::int
-              AND (m.corp_id IS NULL OR NOT m.corp_id = ANY($2::int[]))
-            ) AS "sharedWithMe",
-            m.locked,
-            ou.character_name             AS "ownerName",
-            m.allow_as_merge_source       AS "allowAsMergeSource",
-            m.allow_as_merge_destination  AS "allowAsMergeDestination",
-            m.last_active_at AS "lastActiveAt",
-            m.created_at     AS "createdAt",
-            m.updated_at     AS "updatedAt"
-       FROM maps m
-       JOIN users ou ON ou.id = m.user_id
-       LEFT JOIN map_shares s ON s.map_id = m.id
-            AND ( s.target_character_id = $3
-               OR ($4::int IS NOT NULL AND s.target_corp_id = $4) )
-      WHERE ((m.owner_id = $5::int OR m.user_id = $1) AND m.corp_id IS NULL)
-         OR m.corp_id = ANY($2::int[])
-         OR (s.id IS NOT NULL AND m.corp_id IS NULL)
-      ORDER BY "sharedWithMe", "isCorpMap", m.name`,
-    [userId, visibleCorpIds, callerChar, userCorpId, ownerId],
-  );
+  // Visibility query (personal + corp + shared) lives in the shared map-read
+  // module so the external /api/v1 list returns the identical set.
+  const rows = await listVisibleMaps({ userId, ownerId, userCorpId, callerChar });
 
   // Count corp maps for the user's own corp (the per-corp limit applies to
   // each corp independently — Corp A's slots are separate from Corp B's).
@@ -1261,53 +1232,10 @@ mapsRouter.get('/:mapId', async (req, res) => {
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
 
-  // Three independent reads — parallelise so total latency is max(t) instead
-  // of sum(t).
-  const [mapRows, systems, connections] = await Promise.all([
-    db.query(
-      `SELECT id, name, corp_id IS NOT NULL AS "isCorpMap", locked,
-              allow_as_merge_source       AS "allowAsMergeSource",
-              allow_as_merge_destination  AS "allowAsMergeDestination",
-              share_token              AS "shareToken",
-              share_expires_at         AS "shareExpiresAt",
-              share_include_sigs       AS "shareIncludeSigs",
-              share_include_bridges    AS "shareIncludeBridges",
-              share_include_notes      AS "shareIncludeNotes",
-              share_include_structures AS "shareIncludeStructures",
-              created_at AS "createdAt", updated_at AS "updatedAt"
-       FROM maps WHERE id = $1`,
-      [mapId],
-    ),
-    db.query(
-      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass",
-              effect, statics, region_name AS "regionName", npc_type AS "npcType",
-              position_x AS x, position_y AS y,
-              status, intel, is_home AS "isHome", locked, notes,
-              (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
-              last_activity_at AS "lastActivityAt"
-       FROM map_systems WHERE map_id = $1`,
-      [mapId],
-    ),
-    db.query(
-      `SELECT id, source_id AS "sourceId", target_id AS "targetId",
-              source_handle AS "sourceHandle", target_handle AS "targetHandle",
-              connection_type AS "connectionType", mass_status AS "massStatus",
-              time_status AS "timeStatus", size, wh_type AS "type",
-              COALESCE(mass_used, 0)::float8 AS "massUsed",
-              eol_at AS "eolAt",
-              created_at AS "createdAt"
-       FROM map_connections WHERE map_id = $1`,
-      [mapId],
-    ),
-  ]);
-
-  if (!mapRows.rows.length) { res.status(404).json({ error: 'Map not found' }); return; }
-
-  res.json({
-    ...mapRows.rows[0],
-    systems: systems.rows.map((s) => ({ ...s, position: { x: s.x, y: s.y } })),
-    connections: connections.rows,
-  });
+  // Full map (meta + systems + connections). Loader is shared with /api/v1.
+  const full = await loadFullMap(mapId);
+  if (!full) { res.status(404).json({ error: 'Map not found' }); return; }
+  res.json(full);
 });
 
 // GET /api/maps/:mapId/events — SSE stream of live edits for this map. Scoped
@@ -1732,12 +1660,7 @@ mapsRouter.get('/:mapId/systems/:systemId/signatures', async (req, res) => {
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  const { rows } = await db.query(
-    `SELECT id, sig_id AS "sigId", sig_type AS "sigType", name, notes, wh_type AS "whType", wh_leads_to AS "whLeadsTo", created_at AS "createdAt"
-     FROM map_signatures WHERE system_id = $1 ORDER BY created_at`,
-    [systemId],
-  );
-  res.json(rows);
+  res.json(await loadSystemSignatures(systemId));
 });
 
 mapsRouter.post('/:mapId/systems/:systemId/signatures', async (req, res) => {
@@ -1867,12 +1790,7 @@ mapsRouter.get('/:mapId/systems/:systemId/anomalies', async (req, res) => {
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  const { rows } = await db.query(
-    `SELECT id, anom_id AS "anomId", anom_type AS "anomType", name, notes, created_at AS "createdAt", updated_at AS "updatedAt"
-     FROM map_anomalies WHERE system_id = $1 ORDER BY created_at`,
-    [systemId],
-  );
-  res.json(rows);
+  res.json(await loadSystemAnomalies(systemId));
 });
 
 mapsRouter.post('/:mapId/systems/:systemId/anomalies', async (req, res) => {
@@ -1939,12 +1857,7 @@ mapsRouter.get('/:mapId/systems/:systemId/structures', async (req, res) => {
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  const { rows } = await db.query(
-    `SELECT id, name, structure_type AS "structureType", owner_corp AS "ownerCorp", eve_id AS "eveId", notes, created_at AS "createdAt", owner_corp_id AS "ownerCorpId"
-     FROM map_structures WHERE system_id = $1 ORDER BY created_at`,
-    [systemId],
-  );
-  res.json(rows);
+  res.json(await loadSystemStructures(systemId));
 });
 
 mapsRouter.post('/:mapId/systems/:systemId/structures', async (req, res) => {

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -1,0 +1,145 @@
+import { db } from '../db.js';
+import { config } from '../config.js';
+
+// Shared map READ queries — the single source of truth behind both the
+// cookie-authed map routes and the external /api/v1 key-authed routes. Pure
+// data loaders: no req/res, no access checks (callers gate with getMapAccess
+// first). Keeping these here means the two surfaces can never drift in shape.
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export interface VisibleMapsParams {
+  userId:     number;
+  ownerId:    number | null;
+  userCorpId: number | null;
+  callerChar: number | null;
+}
+
+// The list of maps visible to an account: personal (owner) maps, corp maps in
+// the configured corp set, and personal maps explicitly shared with the
+// character or their corp. Identical query to GET /api/maps.
+export async function listVisibleMaps(p: VisibleMapsParams) {
+  const visibleCorpIds = config.corpMode && config.corpIds.length > 0
+    ? (config.corpMapShared ? config.corpIds : (p.userCorpId ? [p.userCorpId] : []))
+    : [];
+  // -1 is an impossible owner id so the ownership clause matches nothing rather
+  // than everything when ownerId is unknown.
+  const ownerId = p.ownerId ?? -1;
+  const { rows } = await db.query(
+    `SELECT DISTINCT
+            m.id,
+            m.name,
+            m.corp_id IS NOT NULL AS "isCorpMap",
+            (m.user_id <> $1 AND m.owner_id IS DISTINCT FROM $5::int
+              AND (m.corp_id IS NULL OR NOT m.corp_id = ANY($2::int[]))
+            ) AS "sharedWithMe",
+            m.locked,
+            ou.character_name             AS "ownerName",
+            m.allow_as_merge_source       AS "allowAsMergeSource",
+            m.allow_as_merge_destination  AS "allowAsMergeDestination",
+            m.last_active_at AS "lastActiveAt",
+            m.created_at     AS "createdAt",
+            m.updated_at     AS "updatedAt"
+       FROM maps m
+       JOIN users ou ON ou.id = m.user_id
+       LEFT JOIN map_shares s ON s.map_id = m.id
+            AND ( s.target_character_id = $3
+               OR ($4::int IS NOT NULL AND s.target_corp_id = $4) )
+      WHERE ((m.owner_id = $5::int OR m.user_id = $1) AND m.corp_id IS NULL)
+         OR m.corp_id = ANY($2::int[])
+         OR (s.id IS NOT NULL AND m.corp_id IS NULL)
+      ORDER BY "sharedWithMe", "isCorpMap", m.name`,
+    [p.userId, visibleCorpIds, p.callerChar, p.userCorpId, ownerId],
+  );
+  return rows;
+}
+
+// Full map: meta + systems (with {x,y} folded into position) + connections.
+// Returns null if the map row vanished between the access check and this load.
+export async function loadFullMap(mapId: string) {
+  const [mapRows, systems, connections] = await Promise.all([
+    db.query(
+      `SELECT id, name, corp_id IS NOT NULL AS "isCorpMap", locked,
+              allow_as_merge_source       AS "allowAsMergeSource",
+              allow_as_merge_destination  AS "allowAsMergeDestination",
+              share_token              AS "shareToken",
+              share_expires_at         AS "shareExpiresAt",
+              share_include_sigs       AS "shareIncludeSigs",
+              share_include_bridges    AS "shareIncludeBridges",
+              share_include_notes      AS "shareIncludeNotes",
+              share_include_structures AS "shareIncludeStructures",
+              created_at AS "createdAt", updated_at AS "updatedAt"
+       FROM maps WHERE id = $1`,
+      [mapId],
+    ),
+    db.query(
+      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass",
+              effect, statics, region_name AS "regionName", npc_type AS "npcType",
+              position_x AS x, position_y AS y,
+              status, intel, is_home AS "isHome", locked, notes,
+              (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
+              last_activity_at AS "lastActivityAt"
+       FROM map_systems WHERE map_id = $1`,
+      [mapId],
+    ),
+    db.query(
+      `SELECT id, source_id AS "sourceId", target_id AS "targetId",
+              source_handle AS "sourceHandle", target_handle AS "targetHandle",
+              connection_type AS "connectionType", mass_status AS "massStatus",
+              time_status AS "timeStatus", size, wh_type AS "type",
+              COALESCE(mass_used, 0)::float8 AS "massUsed",
+              eol_at AS "eolAt",
+              created_at AS "createdAt"
+       FROM map_connections WHERE map_id = $1`,
+      [mapId],
+    ),
+  ]);
+
+  if (!mapRows.rows.length) return null;
+  return {
+    ...mapRows.rows[0],
+    systems: systems.rows.map((s) => ({ ...s, position: { x: s.x, y: s.y } })),
+    connections: connections.rows,
+  };
+}
+
+// Confirms a system UUID belongs to the map — guards cross-map IDOR and the
+// malformed-uuid 22P02 crash. Pure boolean (no res side effects).
+export async function isSystemInMap(systemId: string, mapId: string): Promise<boolean> {
+  if (!UUID_RE.test(systemId)) return false;
+  const { rowCount } = await db.query(
+    `SELECT 1 FROM map_systems WHERE id = $1 AND map_id = $2`,
+    [systemId, mapId],
+  );
+  return !!rowCount;
+}
+
+export async function loadSystemSignatures(systemId: string) {
+  const { rows } = await db.query(
+    `SELECT id, sig_id AS "sigId", sig_type AS "sigType", name, notes,
+            wh_type AS "whType", wh_leads_to AS "whLeadsTo", created_at AS "createdAt"
+       FROM map_signatures WHERE system_id = $1 ORDER BY created_at`,
+    [systemId],
+  );
+  return rows;
+}
+
+export async function loadSystemAnomalies(systemId: string) {
+  const { rows } = await db.query(
+    `SELECT id, anom_id AS "anomId", anom_type AS "anomType", name, notes,
+            created_at AS "createdAt", updated_at AS "updatedAt"
+       FROM map_anomalies WHERE system_id = $1 ORDER BY created_at`,
+    [systemId],
+  );
+  return rows;
+}
+
+export async function loadSystemStructures(systemId: string) {
+  const { rows } = await db.query(
+    `SELECT id, name, structure_type AS "structureType", owner_corp AS "ownerCorp",
+            eve_id AS "eveId", notes, created_at AS "createdAt", owner_corp_id AS "ownerCorpId"
+       FROM map_structures WHERE system_id = $1 ORDER BY created_at`,
+    [systemId],
+  );
+  return rows;
+}

--- a/server/src/utils/apiKeys.ts
+++ b/server/src/utils/apiKeys.ts
@@ -1,0 +1,40 @@
+import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
+
+// External API keys. Unlike the EVE OAuth tokens (encrypted at rest so they can
+// be decrypted and replayed to ESI — see tokenCrypto.ts), an API key is only
+// ever *compared*: we store a one-way sha-256 of it and throw the raw value
+// away after showing it once. A DB leak then exposes no usable keys.
+
+const PREFIX     = 'nxm_';
+const PREFIX_LEN = 12;          // chars of the raw key surfaced for display ("nxm_3f9a…")
+const KEY_BYTES  = 32;          // 256 bits of entropy, url-safe base64 (~43 chars)
+
+export interface GeneratedKey {
+  raw:    string;   // full secret, shown to the user exactly once
+  hash:   string;   // sha-256 hex stored in api_tokens.token_hash
+  prefix: string;   // leading chars stored in api_tokens.token_prefix for the list UI
+}
+
+// base64url without padding — compact, copy-paste safe, no '+' '/' '=' to escape.
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function hashApiKey(raw: string): string {
+  return createHash('sha256').update(raw, 'utf8').digest('hex');
+}
+
+export function generateApiKey(): GeneratedKey {
+  const raw = PREFIX + base64url(randomBytes(KEY_BYTES));
+  return { raw, hash: hashApiKey(raw), prefix: raw.slice(0, PREFIX_LEN) };
+}
+
+// Constant-time compare of two sha-256 hex digests. Lookup is by the unique
+// token_hash column; this is defence-in-depth against timing oracles on the
+// off chance a non-indexed compare path is ever added.
+export function hashesEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}


### PR DESCRIPTION
Phase 1 **backend** for the inbound external API (design: `external_api_feature.md`, included). Lets approved tools read a user's maps with a long-lived Bearer key instead of a browser session. The **frontend key-management UI lands separately** — this PR is the server foundation + read endpoints.

## What it does
A key is **account-scoped** (acts as one owner) with **one bound character** for role/corp context, so a key sees *exactly* what that character sees in the app — it flows through the existing `getMapAccess()` / role gates, no parallel permission surface. **Read-only in v1.**

## Changes
- **`migrate.ts`** — `api_tokens` table (owner-scoped, bound `context_user_id`, sha-256 `token_hash`, scope, expiry). Idempotent; runs on boot like every migration — no deploy step.
- **`utils/apiKeys.ts`** — `nxm_` key generation (256-bit base64url), sha-256 hashing (hashed, never encrypted — only ever compared, unlike the AES-GCM ESI tokens), constant-time compare.
- **`middleware/authContext.ts`** — `AuthUser` + `authUser(req)` + `req.apiAuth`. Existing gates read `req.session` directly; `authUser()` resolves from a key context **or** the session, so the same checks serve both and cookie behaviour is unchanged.
- **`middleware/apiKeyAuth.ts`** — resolves `Authorization: Bearer <key>` → `req.apiAuth`; no-op without a Bearer header (routes accept either credential); 401 on invalid/expired/inert (bound char removed); throttled `last_used_at` bump (≤1/min/key, fire-and-forget).
- **`routes/keys.ts`** — cookie-authed `GET/POST/DELETE /api/keys` (list never returns the secret; create returns the raw key once; bound char must be on the account; per-account cap; audit-logged).
- **`routes/apiV1.ts`** — `GET /api/v1/maps`, full map (share-link secrets stripped), and per-system `signatures`/`anomalies`/`structures`.
- **`services/mapRead.ts`** — read queries extracted as shared loaders; **the existing cookie map routes now use them too**, so v1 and the UI return identical shapes from one source (no drift, no duplicated SQL). Cookie responses are byte-identical.
- **`maps.ts` / `index.ts`** — `getMapAccess` + role gates resolve via `authUser`; any key-authed mutation is refused; both routers mounted.

## Verification
Smoke-tested end-to-end against a live DB:

| Case | Result |
|---|---|
| No / bogus key | 401 |
| Valid key → list & full map | 200 |
| Full map | share-link secrets stripped |
| Per-system signatures / anomalies / structures | 200 |
| System-not-in-map / malformed system or map UUID | 404 (no `22P02` crash) |
| Expired / inactive (bound char removed) key | 401 |
| `GET /api/keys` without session | 401 |
| `last_used_at` bump | fires for used key only |

Migration applied cleanly; refactored cookie routes loaded a 128-system map through the shared loader.

## Not in this PR
- Frontend API-keys section (create/list/revoke, show-once) — separate.
- README docs for the feature — will land with the FE, when key creation is user-reachable.
- Phase 2: Bearer auth on the SSE `/events` stream; write scopes.