### PR TITLE
Phase 2: live event stream over API keys + events scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Generate a consistent, paste-ready name for a wormhole and drop it straight into
 
 Read your maps programmatically — pull the live chain into a fleet bot, an intel aggregator, a "is home open to highsec?" checker, or your own scripts. Authenticated with a long-lived **API key** you generate, instead of a browser session.
 
-**Generate a key.** Click the 🔑 icon in the toolbar (next to the language switcher). Give it a name, pick which of your characters it **acts as** (the key sees exactly what that character sees — same maps, same role), and optionally set an expiry. The key is shown **once** at creation — copy it then; it's stored only as a hash and can't be retrieved again. Revoke any key from the same panel and any tool using it loses access immediately.
+**Generate a key.** Click the 🔑 icon in the toolbar (next to the language switcher). Give it a name, pick which of your characters it **acts as** (the key sees exactly what that character sees — same maps, same role), choose its **access** (*Read only*, or *Read + live events* to also allow the event stream below), and optionally set an expiry. The key is shown **once** at creation — copy it then; it's stored only as a hash and can't be retrieved again. Revoke any key from the same panel and any tool using it loses access immediately.
 
 **Authenticate.** Send the key as a Bearer token:
 
@@ -217,7 +217,7 @@ Read your maps programmatically — pull the live chain into a fleet bot, an int
 curl -H "Authorization: Bearer nxm_…" https://yourdomain.com/api/v1/maps
 ```
 
-**Endpoints** (v1 is **read-only**):
+**Endpoints** (reads; v1 has **no write endpoints**):
 
 | Endpoint | Returns |
 |---|---|
@@ -226,8 +226,30 @@ curl -H "Authorization: Bearer nxm_…" https://yourdomain.com/api/v1/maps
 | `GET /api/v1/maps/:mapId/systems/:systemId/signatures` | Scanned signatures in a system |
 | `GET /api/v1/maps/:mapId/systems/:systemId/anomalies` | Cosmic anomalies in a system |
 | `GET /api/v1/maps/:mapId/systems/:systemId/structures` | Player structures in a system |
+| `GET /api/v1/maps/:mapId/events` | **Live event stream** (SSE) — requires a *Read + live events* key |
 
-**Scope and safety.** Keys are **account-scoped** — a key reads everything its account can see, so treat it as a secret. It's read-only (no writes in v1), can be given an expiry, records a *last used* time so you can spot a stale or leaked key, and is one-click revocable. Share-link tokens are never returned through the API.
+### Live event stream
+
+`GET /api/v1/maps/:mapId/events` is a [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) stream of the same live edits the web client receives — so a tool can stay in sync without polling. It needs a key with the **Read + live events** scope (a plain read key gets `403`). On connect it sends a `presence.snapshot`, then one JSON event per edit; lines beginning `:` are heartbeat/keep-alive comments.
+
+```bash
+curl -N -H "Authorization: Bearer nxm_…" \
+  https://yourdomain.com/api/v1/maps/<mapId>/events
+```
+
+Each `data:` line is a JSON object with a `type` and a type-specific payload. The published event types (the public contract):
+
+| Type | Meaning |
+|---|---|
+| `system.add` / `system.update` / `system.remove` | A system was added, changed (status, notes, position, activity), or removed |
+| `connection.add` / `connection.update` / `connection.remove` | A connection was drawn, retyped (mass/EOL/type), or deleted |
+| `sig.changed` / `anom.changed` / `structure.changed` | A system's signatures / anomalies / structures changed |
+| `map.meta` / `map.resync` | Map metadata (name, lock) changed / clients should refetch |
+| `presence.snapshot` / `presence.update` / `presence.leave` | Who's viewing the map and where (ephemeral) |
+
+> Single-process delivery: the stream is served in-memory by one instance, the same as the in-app live sync. A multi-replica deployment would need the documented Postgres `LISTEN/NOTIFY` swap — see the realtime-sync notes.
+
+**Scope and safety.** Keys are **account-scoped** — a key reads everything its account can see, so treat it as a secret. There are no write endpoints; the strongest scope (*events*) still only reads and subscribes. Keys can be given an expiry, record a *last used* time so you can spot a stale or leaked key, and are one-click revocable. Share-link tokens are never returned through the API.
 
 ---
 

--- a/server/src/routes/apiV1.ts
+++ b/server/src/routes/apiV1.ts
@@ -3,6 +3,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { apiKeyAuth } from '../middleware/apiKeyAuth.js';
 import { authUser } from '../middleware/authContext.js';
 import { getMapAccess } from './maps.js';
+import { streamMapEvents } from '../services/mapStream.js';
 import {
   listVisibleMaps, loadFullMap, isSystemInMap,
   loadSystemSignatures, loadSystemAnomalies, loadSystemStructures,
@@ -80,4 +81,20 @@ apiV1Router.get('/maps/:mapId/systems/:systemId/anomalies', async (req, res) => 
 apiV1Router.get('/maps/:mapId/systems/:systemId/structures', async (req, res) => {
   if (!(await systemScope(req, res))) return;
   res.json(await loadSystemStructures(req.params.systemId));
+});
+
+// GET /api/v1/maps/:mapId/events — live SSE stream of map edits, the same feed
+// the web client uses. Key clients need the 'events' scope (a plain 'read' key
+// is refused); a logged-in session is also accepted. Document the event
+// taxonomy as the public contract.
+apiV1Router.get('/maps/:mapId/events', async (req, res) => {
+  // Scope gate: 'read' keys can pull snapshots but not subscribe to the stream.
+  // Session requests have no apiAuth and pass through.
+  if (req.apiAuth && req.apiAuth.apiScope !== 'events') {
+    res.status(403).json({ error: "API key needs the 'events' scope" });
+    return;
+  }
+  const { mapId } = req.params;
+  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
+  streamMapEvents(req, res, mapId);
 });

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -143,5 +143,7 @@ keysRouter.delete('/:id', async (req, res) => {
   await audit(req, rows[0].contextUserId, null, 'api_key_revoke', rows[0].name, null)
     .catch((err) => log.warn(`audit api_key_revoke failed: ${err}`));
 
-  res.status(204).end();
+  // Return a JSON body (not 204) — the shared web api() client always parses
+  // the response as JSON, so an empty body would surface as a bogus error.
+  res.json({ ok: true });
 });

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -11,10 +11,11 @@ import { recordGhostSiteIfMatch } from '../services/ghostSites.js';
 import { resolveOwnerId } from '../utils/owner.js';
 import { resolveEntityNames } from '../services/entityNames.js';
 import { audit } from '../services/audit.js';
-import { subscribeMap, publishToMap } from '../services/mapEvents.js';
+import { publishToMap } from '../services/mapEvents.js';
+import { streamMapEvents } from '../services/mapStream.js';
 import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures } from '../services/mapRead.js';
 import { syncSignature, syncAnomaly } from '../services/crossMapSync.js';
-import { reportPresence, removePresence, presenceSnapshot } from '../services/presence.js';
+import { reportPresence } from '../services/presence.js';
 import { notifyDiscord, webhookFor, k162Embed, connectionEmbed } from '../services/discord.js';
 
 const log = createLogger('maps');
@@ -1245,32 +1246,8 @@ mapsRouter.get('/:mapId/events', async (req, res) => {
   const { mapId } = req.params;
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
-
-  res.set({
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache, no-transform',
-    Connection: 'keep-alive',
-  });
-  res.flushHeaders?.();
-  res.write(': connected\n\n');
-
-  const unsubscribe = subscribeMap(mapId, res);
-  // Heartbeat keeps intermediaries from closing an idle stream.
-  const heartbeat = setInterval(() => { try { res.write(': ping\n\n'); } catch { /* closed */ } }, 25_000);
-
-  // Hand the new viewer the current presence roster so it sees who's already
-  // here without waiting for the next heartbeat round.
-  try {
-    res.write(`data: ${JSON.stringify({ type: 'presence.snapshot', viewers: presenceSnapshot(mapId) })}\n\n`);
-  } catch { /* closed */ }
-
-  req.on('close', () => {
-    clearInterval(heartbeat);
-    unsubscribe();
-    // Closing the stream = left the map → drop this viewer's presence (TTL is
-    // the backstop for unclean disconnects / multiple tabs).
-    if (req.session.characterId) removePresence(mapId, req.session.characterId);
-  });
+  // Shared with the API-key stream at /api/v1/maps/:id/events.
+  streamMapEvents(req, res, mapId);
 });
 
 // POST /api/maps/:mapId/presence — a viewer reports its current location.

--- a/server/src/services/mapStream.ts
+++ b/server/src/services/mapStream.ts
@@ -1,0 +1,40 @@
+import type { Request, Response } from 'express';
+import { subscribeMap } from './mapEvents.js';
+import { presenceSnapshot, removePresence } from './presence.js';
+
+// Wire an Express response up as a Server-Sent Events stream of a map's live
+// edits. The CALLER is responsible for access-checking the map first; this just
+// opens the stream. Shared by the cookie route (/api/maps/:id/events) and the
+// API-key route (/api/v1/maps/:id/events) so both behave identically.
+//
+// Safe for headless (API-key) clients: presence is only ever *read* here
+// (the snapshot) and the close-time presence cleanup is guarded on a session
+// character, of which a key client has none.
+export function streamMapEvents(req: Request, res: Response, mapId: string): void {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders?.();
+  res.write(': connected\n\n');
+
+  const unsubscribe = subscribeMap(mapId, res);
+  // Heartbeat keeps intermediaries from closing an idle stream.
+  const heartbeat = setInterval(() => { try { res.write(': ping\n\n'); } catch { /* closed */ } }, 25_000);
+
+  // Hand the new subscriber the current presence roster so it sees who's
+  // already here without waiting for the next heartbeat round.
+  try {
+    res.write(`data: ${JSON.stringify({ type: 'presence.snapshot', viewers: presenceSnapshot(mapId) })}\n\n`);
+  } catch { /* closed */ }
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+    // Closing the stream = left the map → drop this viewer's presence (TTL is
+    // the backstop for unclean disconnects / multiple tabs). No-op for headless
+    // key clients, which never had a session character.
+    if (req.session.characterId) removePresence(mapId, req.session.characterId);
+  });
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1778,14 +1778,13 @@
   font-weight: 600;
 }
 
-.api-keys__reveal-row {
+.api-keys__reveal-actions {
   display: flex;
-  align-items: center;
   gap: 8px;
 }
 
 .api-keys__secret {
-  flex: 1;
+  display: block;
   padding: 6px 8px;
   background: #08090f;
   border: 1px solid #1e2740;
@@ -1793,7 +1792,7 @@
   color: #c8d4f0;
   font-family: monospace;
   font-size: calc(12px * var(--font-scale, 1));
-  word-break: break-all;
+  overflow-wrap: anywhere;
   user-select: all;
 }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1849,6 +1849,26 @@
   flex-shrink: 0;
 }
 
+.api-keys__scope {
+  font-size: calc(10px * var(--font-scale, 1));
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.api-keys__scope--read {
+  background: rgba(100,160,255,0.12);
+  color: #7ab0f0;
+  border: 1px solid rgba(100,160,255,0.3);
+}
+
+.api-keys__scope--events {
+  background: rgba(120,200,140,0.12);
+  color: #6fc98a;
+  border: 1px solid rgba(120,200,140,0.3);
+}
+
 .api-keys__meta {
   display: flex;
   flex-direction: column;

--- a/web/src/components/ui/ApiKeysModal.tsx
+++ b/web/src/components/ui/ApiKeysModal.tsx
@@ -42,6 +42,7 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
   const [charId, setCharId]       = useState<number | null>(
     () => (characters.find((c) => c.active) ?? characters[0])?.characterId ?? null,
   );
+  const [scope, setScope]         = useState<'read' | 'events'>('read');
   const [expiryDays, setExpiry]   = useState<number>(0);
   const [creating, setCreating]   = useState(false);
   // The raw secret, surfaced exactly once right after creation.
@@ -69,7 +70,7 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
         : null;
       const created = await api<{ name: string; key: string }>('/api/keys', {
         method: 'POST',
-        body:   JSON.stringify({ name: name.trim(), contextCharacterId: charId, expiresAt }),
+        body:   JSON.stringify({ name: name.trim(), contextCharacterId: charId, scope, expiresAt }),
       });
       // Re-fetch so the new row carries the canonical shape (bound character
       // name, etc.) the POST response doesn't include.
@@ -157,6 +158,13 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
               </select>
             </label>
             <label className="field">
+              <span>{t('apiKeys.scope')}</span>
+              <select value={scope} onChange={(e) => setScope(e.target.value as 'read' | 'events')}>
+                <option value="read">{t('apiKeys.scopeRead')}</option>
+                <option value="events">{t('apiKeys.scopeEvents')}</option>
+              </select>
+            </label>
+            <label className="field">
               <span>{t('apiKeys.expiry')}</span>
               <select value={expiryDays} onChange={(e) => setExpiry(Number(e.target.value))}>
                 {EXPIRY_OPTIONS.map((d) => (
@@ -187,6 +195,9 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
                         <div className="api-keys__main">
                           <span className="api-keys__name">{k.name}</span>
                           <code className="api-keys__prefix">{k.tokenPrefix}…</code>
+                          <span className={`api-keys__scope api-keys__scope--${k.scope}`}>
+                            {k.scope === 'events' ? t('apiKeys.scopeEventsBadge') : t('apiKeys.scopeReadBadge')}
+                          </span>
                           {(expired || inert) && (
                             <span className="api-keys__flag">
                               {expired ? t('apiKeys.flagExpired') : t('apiKeys.flagInert')}

--- a/web/src/components/ui/ApiKeysModal.tsx
+++ b/web/src/components/ui/ApiKeysModal.tsx
@@ -125,15 +125,15 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
                 <WarningIcon size={14} weight="fill" />
                 {t('apiKeys.copyNow')}
               </div>
-              <div className="api-keys__reveal-row">
-                <code className="api-keys__secret">{newKey.key}</code>
-                <button type="button" className="map-sidebar__action" onClick={() => copyKey(newKey.key)}>
+              <code className="api-keys__secret">{newKey.key}</code>
+              <div className="api-keys__reveal-actions">
+                <button type="button" className="btn btn--primary" onClick={() => copyKey(newKey.key)}>
                   <CopyIcon size={14} weight="regular" /> {t('actions.copy')}
                 </button>
+                <button type="button" className="btn btn--ghost" onClick={() => setNewKey(null)}>
+                  {t('apiKeys.dismiss')}
+                </button>
               </div>
-              <button type="button" className="btn btn--ghost" onClick={() => setNewKey(null)}>
-                {t('apiKeys.dismiss')}
-              </button>
             </div>
           )}
 

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1,10 +1,15 @@
 {
   "apiKeys": {
     "title": "API keys",
-    "hint": "Generate a key to let external tools read your maps via the API. A key acts as the selected character and can only read — never write.",
+    "hint": "Generate a key to let external tools read your maps via the API. A key acts as the selected character and can only read — never write. \"Read + live events\" keys can also subscribe to the live event stream.",
     "name": "Name",
     "namePlaceholder": "e.g. fleet bot",
     "character": "Acts as",
+    "scope": "Access",
+    "scopeRead": "Read only",
+    "scopeEvents": "Read + live events",
+    "scopeReadBadge": "read",
+    "scopeEventsBadge": "events",
     "expiry": "Expires",
     "expiryNever": "Never",
     "expiryDays": "{{count}} days",


### PR DESCRIPTION
Lets external tools subscribe to a map's live edits with an API key — the same SSE feed the web client uses (design: `external_api_feature.md` §8). Completes the external API: reads (Phase 1) + live stream (this).

## Backend
- **`services/mapStream.ts`** (new) — extracts the SSE setup (headers, `subscribeMap`, heartbeat, presence snapshot, close cleanup) into a shared `streamMapEvents()` so the cookie route and the new key route behave identically. Safe for headless key clients: presence is only *read*, and the close-time presence cleanup is guarded on a session character (a key has none).
- **`maps.ts`** — `GET /:mapId/events` now delegates to the helper; the now-unused `subscribeMap`/`presenceSnapshot`/`removePresence` imports were dropped.
- **`apiV1.ts`** — `GET /api/v1/maps/:mapId/events`, gated on the **`events`** scope (a plain `read` key gets `403`; a logged-in session passes through), then `getMapAccess` + stream. Scope hierarchy: an `events` key can also hit the read endpoints.

## Frontend
- **`ApiKeysModal`** — an **Access** selector on create (*Read only* / *Read + live events*), sent as `scope`; plus a scope badge per key in the list. New i18n strings + CSS (font-scale-aware, matching the existing badges).

## README
Documented the live event stream endpoint, the `events` scope, and the published **event taxonomy** as the public contract (`system.*`, `connection.*`, `sig.changed`/`anom.changed`/`structure.changed`, `map.meta`/`map.resync`, `presence.*`).

## Verification
Smoke-tested against a live DB:

| Case | Result |
|---|---|
| `read` key → events stream | **403** `API key needs the 'events' scope` |
| No auth → events stream | **401** |
| `read` key → read endpoints | **200** (still works) |
| `events` key → read endpoints | **200** (scope hierarchy) |
| `events` key → stream | opens; delivers `: connected` + `presence.snapshot`, stays open |

`tsc` (server + web), `eslint`, and `yarn build` all clean.

**Not exercised headlessly:** actual *mutation-event* delivery (e.g. a `system.update` frame), because every write path needs a session — but the key stream subscribes to the exact same in-memory bus as the proven cookie stream via the shared helper, so delivery is structurally identical. Worth a quick browser check: open a tool stream with an `events` key, edit the map in the app, watch the frames arrive.