### PR TITLE
Harden api() client against empty/204 responses

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -36,6 +36,13 @@ export async function api<T = unknown>(path: string, options?: RequestInit): Pro
     headers: { 'Content-Type': 'application/json', 'X-Client-Id': CLIENT_ID, ...optHeaders },
   });
   if (!res.ok) throw new Error(`API ${path} → ${res.status}`);
+  // A 204 (or otherwise empty) response has no body to parse — calling
+  // res.json() on it throws "Unexpected end of JSON input". Treat no-content
+  // responses as a successful undefined so callers that don't read the body
+  // (DELETEs, etc.) don't surface a bogus error.
+  if (res.status === 204 || res.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
   return res.json() as Promise<T>;
 }
 


### PR DESCRIPTION
Follow-up to the API-key revoke fix. The shared web `api()` client always called `res.json()`, so **any** `204 No Content` (or empty-body) endpoint surfaced as a bogus `Unexpected end of JSON input` error even though the request succeeded — exactly the failure mode the revoke route just hit.

## Change
`web/src/api/client.ts` — after the `res.ok` check, return `undefined` for no-content responses (`204`, or `Content-Length: 0`) instead of trying to parse an empty body. Callers that don't read a return value (DELETEs, etc.) now resolve cleanly; JSON endpoints are unchanged.

This makes the JSON-everywhere convention a soft default rather than a hard requirement, so a future body-less endpoint can't reintroduce this bug.

Lint / `tsc` / `yarn build` clean.