### PR TITLE
Stale revival: any online character revives its system, not just the active one

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1261,7 +1261,7 @@ mapsRouter.post('/:mapId/presence', async (req, res) => {
   const characterName = req.session.characterName;
   if (!characterId || !characterName) { res.status(401).json({ error: 'No character on session' }); return; }
 
-  const body = req.body as { eveSystemId?: unknown; shipTypeId?: unknown };
+  const body = req.body as { eveSystemId?: unknown; shipTypeId?: unknown; presentSystemIds?: unknown };
   reportPresence(mapId, {
     characterId,
     characterName,
@@ -1271,20 +1271,29 @@ mapsRouter.post('/:mapId/presence', async (req, res) => {
 
   // A character physically in a mapped system keeps it "active" so it never
   // shows as stale while occupied — independent of whether any sigs/anoms are
-  // touched. Throttled to the last_activity_at column itself: the UPDATE only
-  // matches (and only then broadcasts) when activity is already older than a few
-  // minutes, so the 25 s presence heartbeat doesn't write/broadcast every tick.
-  // Fire-and-forget — never block the presence ack.
-  if (typeof body.eveSystemId === 'number') {
+  // touched, and independent of which character is the active viewer. The client
+  // sends presentSystemIds = every system one of the account's *online*
+  // characters is in right now (active viewer + any online alt), so a tracked
+  // alt — or an alt flying a different route — revives its own system too. Older
+  // clients send only eveSystemId; fold it in for back-compat.
+  // Throttled at the column: the UPDATE only matches (and only then broadcasts)
+  // systems whose activity is already older than a few minutes, so the 25 s
+  // heartbeat doesn't write/broadcast every tick. Fire-and-forget — never block
+  // the presence ack.
+  const presentIds = new Set<number>();
+  if (Array.isArray(body.presentSystemIds)) {
+    for (const id of body.presentSystemIds) if (typeof id === 'number') presentIds.add(id);
+  }
+  if (typeof body.eveSystemId === 'number') presentIds.add(body.eveSystemId);
+  if (presentIds.size) {
     db.query(
       `UPDATE map_systems SET last_activity_at = NOW()
-         WHERE map_id = $1 AND eve_system_id = $2
+         WHERE map_id = $1 AND eve_system_id = ANY($2::int[])
            AND last_activity_at < NOW() - INTERVAL '5 minutes'
        RETURNING id, last_activity_at`,
-      [mapId, body.eveSystemId],
+      [mapId, [...presentIds]],
     ).then((r) => {
-      const row = r.rows[0] as { id: string; last_activity_at: Date } | undefined;
-      if (row) {
+      for (const row of r.rows as Array<{ id: string; last_activity_at: Date }>) {
         publishToMap(mapId, {
           type: 'system.update',
           actor: null,

--- a/web/src/hooks/useMapPresence.ts
+++ b/web/src/hooks/useMapPresence.ts
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useMapStore } from '../store/mapStore';
 import { useCharacterLocation } from './useCharacterLocation';
+import { useAccountLocations } from './useAccountLocations';
 import { api } from '../api/client';
 
 // Reports the viewer's own location to the active map so the server can fan it
@@ -13,18 +14,41 @@ const HEARTBEAT_MS = 25_000;
 export function useMapPresence(): void {
   const activeMapId = useMapStore((s) => s.activeMapId);
   const location = useCharacterLocation();
+  const accountLocations = useAccountLocations();
   const eveSystemId = location.online && location.system ? location.system.eveSystemId : null;
 
+  // Every system an account character is *physically in right now* — the active
+  // viewer plus any online alt. This is what keeps a system from going stale:
+  // it must be independent of which character is the active viewer, so a tracked
+  // alt (or an alt flying a different route) revives its own system too. Only
+  // online characters count — last-known positions must not keep a system fresh
+  // forever. The active character's eveSystemId is the presence "dot"; these are
+  // purely the staleness signal.
+  const presentSystemIds = useMemo(() => {
+    const ids = new Set<number>();
+    if (eveSystemId != null) ids.add(eveSystemId);
+    for (const c of accountLocations.byChar.values()) {
+      if (c.online) ids.add(c.eveSystemId);
+    }
+    return [...ids];
+  }, [eveSystemId, accountLocations]);
+  // Stable primitive for the effect dep so it doesn't re-subscribe on every poll
+  // when the set of occupied systems hasn't actually changed.
+  const presentKey = presentSystemIds.join(',');
+
   useEffect(() => {
-    if (!activeMapId || eveSystemId == null) return;
+    if (!activeMapId) return;
+    if (eveSystemId == null && presentSystemIds.length === 0) return;
     const report = () => {
       api(`/api/maps/${activeMapId}/presence`, {
         method: 'POST',
-        body: JSON.stringify({ eveSystemId }),
+        body: JSON.stringify({ eveSystemId, presentSystemIds }),
       }).catch(() => { /* presence is best-effort */ });
     };
     report();
     const hb = setInterval(report, HEARTBEAT_MS);
     return () => clearInterval(hb);
-  }, [activeMapId, eveSystemId]);
+    // presentSystemIds tracked via presentKey to avoid array-identity churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeMapId, eveSystemId, presentKey]);
 }


### PR DESCRIPTION
Fixes a user-reported limitation of the stale-system revival: only the **active/main** character revived stale systems. A tracked alt — or two characters flying different routes — left the non-active character's system faded; only systems the main passed through came back.

## Cause
Revival was bumped from the presence heartbeat, which carries only the **active viewer's** location (`useMapPresence` → `useCharacterLocation`). Alt locations are polled separately (`useAccountLocations`) and never fed into the bump.

## Fix
The client already polls every account character's live location with an `online` flag. `useMapPresence` now also sends **`presentSystemIds`** = every system an *online* account character is in right now (active viewer + online alts). The presence handler bumps every mapped system in that set (`eve_system_id = ANY(...)`) and broadcasts a `system.update` per revived system.

- **Online only** — last-known positions are excluded, so an offline alt's old system can't keep itself fresh forever.
- The active `eveSystemId` still drives the presence **dot**; `presentSystemIds` is purely the staleness signal.
- **Back-compat** — older clients send only `eveSystemId`, which is folded into the set.
- Same column-level **5-minute throttle**, so reporting more systems doesn't add DB writes.

## Why presence, not the server location poller
The poller (`LOCATION_POLL_MINUTES`) defaults to **off**, so a poller-based fix wouldn't apply to most deployments. The presence heartbeat is always-on and real-time, and the client already has every character's live location.

## Verification
- `tsc` (server + web), `eslint`, `yarn build` clean.
- Validated the new multi-id bump query against the live DB: both mapped systems in the set were bumped (a bogus id ignored), and an immediate re-run returned 0 rows (throttle holds).
- Not exercised end-to-end through the HTTP presence path (needs a logged-in session + multiple online characters) — worth a real check: log in, have an alt sit in a different chain system, confirm both un-fade.