### PR TITLE
Speed up tracked-character location updates (30s -> 10s)

### DIFF
--- a/web/src/hooks/useAccountLocations.ts
+++ b/web/src/hooks/useAccountLocations.ts
@@ -26,7 +26,11 @@ interface RawResponse {
   }>;
 }
 
-const POLL_MS = 30_000;
+// Matches the active character's location cadence (useCharacterLocation) so a
+// tracked alt's dot keeps up gate-to-gate instead of lagging ~30 s behind. The
+// endpoint already fans out to ESI per character, and ESI caches location, so a
+// 10 s cadence is in line with what the main character already does.
+const POLL_MS = 10_000;
 const EMPTY: AccountLocations = { bySystem: new Map(), byChar: new Map() };
 
 let moduleCache: { data: AccountLocations; fetchedAt: number } | null = null;


### PR DESCRIPTION
User report: tracked/alt characters' positions update slowly (20+ s) — gate-burning, you land on the next gate before the dot moves. The main character is fine (~3-5 s).

## Cause
Alt positions come from `useAccountLocations`, which polled every **30 s** (worst-case ~30 s lag). The active character (`useCharacterLocation`) polls every **10 s** — the cadence the user finds acceptable.

## Fix
`web/src/hooks/useAccountLocations.ts` — drop `POLL_MS` from `30_000` to `10_000` to match the main character. The `/api/character/account-locations` endpoint already fans out to ESI per character, and ESI caches location reads, so this is in line with what the main-character poll already does — no new endpoint or shape change.

## Trade-off
~3× more frequent alt-location polls. Each is a cheap, ESI-cached read and the module-level cache keeps it to one poll per tab regardless of how many components consume it, so the extra load is modest and proportional to alt count. If a deployment with very alt-heavy accounts ever wanted to dial it back, it's a single constant.

`tsc` / `eslint` / `yarn build` clean. (Pre-existing set-state-in-effect warning in the file is untouched.)