### PR TITLE
External API: write scope + content write endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Open <http://localhost> and click **Log in with EVE Online**. That's it.
 - **Cross-map sync** — opt-in (Map Controls → *Sync system data across my maps*). When the same EVE system appears on several of your maps, adding or editing its signatures and anomalies on one map copies them to the same system on your others — personal maps sync with your other personal maps, corp maps with the corp's other maps. Non-destructive: missing entries are inserted and blank fields filled, but data you've already entered is never overwritten and nothing is ever deleted (deletes and overwrite-paste removals stay local). Matches by EVE system id, so custom systems are skipped.
 - **Map locking** — admins can freeze a corp map's topology. Systems, connections, and the map name lock for non-admins, but signatures, structures, and per-system notes stay editable so ops can continue while the layout is pinned. The toolbar shows an amber 🔒 chip while the lock is active, and passive location tracking won't auto-add new systems on a locked map.
 - **Role-based access** — `admin` / `full` / `edit` / `readonly`. Roles only restrict corp-map actions; every user owns their personal maps regardless of role. See [Roles](#roles) for the full matrix.
-- **External API** — generate a long-lived API key (🔑 in the toolbar) to read your maps programmatically from your own tools and scripts. Read-only, account-scoped, acts as a chosen character, revocable. See [External API](#external-api).
+- **External API** — generate a long-lived API key (🔑 in the toolbar) to read and drive your maps from your own tools and scripts: read maps, subscribe to a live event stream, and (with a write key) push signatures/anomalies/structures. Account-scoped, acts as a chosen character, role-gated, topology stays human-only, revocable. See [External API](#external-api).
 
 ### System intelligence
 
@@ -207,9 +207,19 @@ Generate a consistent, paste-ready name for a wormhole and drop it straight into
 
 ## External API
 
-Read your maps programmatically — pull the live chain into a fleet bot, an intel aggregator, a "is home open to highsec?" checker, or your own scripts. Authenticated with a long-lived **API key** you generate, instead of a browser session.
+Read **and drive** your maps programmatically — pull the live chain into a fleet bot, auto-import scan results from an intel tool, run a "is home open to highsec?" checker, or your own scripts. Authenticated with a long-lived **API key** you generate, instead of a browser session.
 
-**Generate a key.** Click the 🔑 icon in the toolbar (next to the language switcher). Give it a name, pick which of your characters it **acts as** (the key sees exactly what that character sees — same maps, same role), choose its **access** (*Read only*, or *Read + live events* to also allow the event stream below), and optionally set an expiry. The key is shown **once** at creation — copy it then; it's stored only as a hash and can't be retrieved again. Revoke any key from the same panel and any tool using it loses access immediately.
+**Generate a key.** Click the 🔑 icon in the toolbar (next to the language switcher). Give it a name, pick which of your characters it **acts as** (the key can do exactly what that character can — same maps, same role), choose its **access** (see scopes below), and optionally set an expiry. The key is shown **once** at creation — copy it then; it's stored only as a hash and can't be retrieved again. Revoke any key from the same panel and any tool using it loses access immediately.
+
+**Scopes** (each includes the ones above it):
+
+| Scope | Can |
+|---|---|
+| **Read only** | Read maps, systems, signatures, anomalies, structures |
+| **Read + live events** | …plus subscribe to the live event stream |
+| **Read + write content** | …plus add / edit / delete signatures, anomalies, and structures |
+
+Writes are limited to **per-system content**. Map **topology** (adding/moving systems, drawing connections, rename, lock) is deliberately human-only — no key can change it.
 
 **Authenticate.** Send the key as a Bearer token:
 
@@ -217,7 +227,7 @@ Read your maps programmatically — pull the live chain into a fleet bot, an int
 curl -H "Authorization: Bearer nxm_…" https://yourdomain.com/api/v1/maps
 ```
 
-**Endpoints** (reads; v1 has **no write endpoints**):
+**Read endpoints** (any scope):
 
 | Endpoint | Returns |
 |---|---|
@@ -226,7 +236,17 @@ curl -H "Authorization: Bearer nxm_…" https://yourdomain.com/api/v1/maps
 | `GET /api/v1/maps/:mapId/systems/:systemId/signatures` | Scanned signatures in a system |
 | `GET /api/v1/maps/:mapId/systems/:systemId/anomalies` | Cosmic anomalies in a system |
 | `GET /api/v1/maps/:mapId/systems/:systemId/structures` | Player structures in a system |
-| `GET /api/v1/maps/:mapId/events` | **Live event stream** (SSE) — requires a *Read + live events* key |
+| `GET /api/v1/maps/:mapId/events` | **Live event stream** (SSE) — needs *Read + live events* |
+
+**Write endpoints** (need *Read + write content*; gated by the bound character's role just like the app):
+
+| Endpoint | Does |
+|---|---|
+| `POST/PATCH/DELETE /api/v1/maps/:mapId/systems/:systemId/signatures[/:sigId]` | Add / edit / remove a signature |
+| `POST/PATCH/DELETE /api/v1/maps/:mapId/systems/:systemId/anomalies[/:anomId]` | Add / edit / remove an anomaly |
+| `POST/PATCH/DELETE /api/v1/maps/:mapId/systems/:systemId/structures[/:structureId]` | Add / edit / remove a structure |
+
+Writes go through the exact same path as the app — so they fan out over the [event stream](#live-event-stream), trigger the inbound-K162 Discord notice, and cross-map sync just like a human edit.
 
 ### Live event stream
 
@@ -249,7 +269,7 @@ Each `data:` line is a JSON object with a `type` and a type-specific payload. Th
 
 > Single-process delivery: the stream is served in-memory by one instance, the same as the in-app live sync. A multi-replica deployment would need the documented Postgres `LISTEN/NOTIFY` swap — see the realtime-sync notes.
 
-**Scope and safety.** Keys are **account-scoped** — a key reads everything its account can see, so treat it as a secret. There are no write endpoints; the strongest scope (*events*) still only reads and subscribes. Keys can be given an expiry, record a *last used* time so you can spot a stale or leaked key, and are one-click revocable. Share-link tokens are never returned through the API.
+**Scope and safety.** Keys are **account-scoped** — a key can do everything its account can within its scope, so treat it as a secret. Writes are capped at per-system content (never topology) and are still gated by the bound character's role, so a key acting as a `readonly` corp member can't write a corp map. Keys can be given an expiry, record a *last used* time so you can spot a stale or leaked key, and are one-click revocable. Share-link tokens are never returned through the API.
 
 ---
 

--- a/server/src/middleware/apiKeyAuth.ts
+++ b/server/src/middleware/apiKeyAuth.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { db } from '../db.js';
 import { hashApiKey } from '../utils/apiKeys.js';
-import type { Role } from './authContext.js';
+import type { Role, ApiScope } from './authContext.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('apiKeyAuth');
@@ -26,7 +26,7 @@ export async function apiKeyAuth(req: Request, res: Response, next: NextFunction
     const { rows } = await db.query<{
       id: string; ownerId: number; contextUserId: number | null;
       scope: string; expiresAt: Date | null;
-      role: Role | null; corpId: number | null; characterId: number | null;
+      role: Role | null; corpId: number | null; characterId: number | null; characterName: string | null;
     }>(
       `SELECT t.id,
               t.owner_id          AS "ownerId",
@@ -35,7 +35,8 @@ export async function apiKeyAuth(req: Request, res: Response, next: NextFunction
               t.expires_at        AS "expiresAt",
               u.role,
               u.corp_id           AS "corpId",
-              u.character_id      AS "characterId"
+              u.character_id      AS "characterId",
+              u.character_name    AS "characterName"
          FROM api_tokens t
          LEFT JOIN users u ON u.id = t.context_user_id
         WHERE t.token_hash = $1`,
@@ -53,14 +54,15 @@ export async function apiKeyAuth(req: Request, res: Response, next: NextFunction
       res.status(401).json({ error: 'API key is inactive (bound character removed)' }); return;
     }
 
-    const scope: 'read' | 'events' = row.scope === 'events' ? 'events' : 'read';
+    const scope: ApiScope = row.scope === 'write' ? 'write' : row.scope === 'events' ? 'events' : 'read';
     req.apiAuth = {
-      userId:      row.contextUserId,
-      characterId: row.characterId,
-      ownerId:     row.ownerId,
-      role:        row.role,
-      corpId:      row.corpId,
-      apiScope:    scope,
+      userId:        row.contextUserId,
+      characterId:   row.characterId,
+      characterName: row.characterName,
+      ownerId:       row.ownerId,
+      role:          row.role,
+      corpId:        row.corpId,
+      apiScope:      scope,
     };
 
     // Best-effort, throttled last_used_at bump — never blocks the request.

--- a/server/src/middleware/authContext.ts
+++ b/server/src/middleware/authContext.ts
@@ -8,14 +8,19 @@ import type { Request } from 'express';
 export type Role = 'admin' | 'full' | 'edit' | 'readonly';
 
 export interface AuthUser {
-  userId:      number;          // users.id of the acting (bound) character
-  characterId: number;          // that character's EVE character_id
-  ownerId:     number | null;   // account/owner the maps are scoped to
-  role:        Role;
-  corpId:      number | null;
-  /** Present only for API-key requests; the key's scope ('read' | 'events'). */
-  apiScope?:   'read' | 'events';
+  userId:        number;          // users.id of the acting (bound) character
+  characterId:   number;          // that character's EVE character_id
+  characterName: string | null;   // for actor attribution (e.g. K162 Discord notice)
+  ownerId:       number | null;   // account/owner the maps are scoped to
+  role:          Role;
+  corpId:        number | null;
+  /** Present only for API-key requests; the key's scope. */
+  apiScope?:     ApiScope;
 }
+
+// Linear capability hierarchy: read ⊂ events ⊂ write. A higher scope implies
+// every lower one (a 'write' key can also read and stream).
+export type ApiScope = 'read' | 'events' | 'write';
 
 declare module 'express-serve-static-core' {
   interface Request {
@@ -31,10 +36,11 @@ declare module 'express-serve-static-core' {
 export function authUser(req: Request): AuthUser {
   if (req.apiAuth) return req.apiAuth;
   return {
-    userId:      req.session.userId!,
-    characterId: req.session.characterId!,
-    ownerId:     req.session.ownerId ?? null,
-    role:        req.session.role ?? 'readonly',
-    corpId:      req.session.userCorpId ?? null,
+    userId:        req.session.userId!,
+    characterId:   req.session.characterId!,
+    characterName: req.session.characterName ?? null,
+    ownerId:       req.session.ownerId ?? null,
+    role:          req.session.role ?? 'readonly',
+    corpId:        req.session.userCorpId ?? null,
   };
 }

--- a/server/src/middleware/originGuard.ts
+++ b/server/src/middleware/originGuard.ts
@@ -37,6 +37,18 @@ export function originGuard(allowedOrigin: string) {
       return;
     }
 
+    // Bearer-authenticated API requests are exempt. CSRF relies on *ambient*
+    // credentials (the session cookie a browser attaches automatically); an
+    // API key must be set explicitly by the caller via the Authorization
+    // header, which a malicious cross-site page can neither read nor attach
+    // (and a cross-origin request can't set it without a CORS preflight we
+    // control). So these requests can't be CSRF and legitimately have no
+    // browser Origin. apiKeyAuth still validates the key downstream.
+    if ((req.headers.authorization ?? '').toLowerCase().startsWith('bearer ')) {
+      next();
+      return;
+    }
+
     const origin  = (req.headers.origin  ?? '').replace(/\/+$/, '');
     const referer = req.headers.referer ?? '';
 

--- a/server/src/routes/apiV1.ts
+++ b/server/src/routes/apiV1.ts
@@ -2,20 +2,26 @@ import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { apiKeyAuth } from '../middleware/apiKeyAuth.js';
 import { authUser } from '../middleware/authContext.js';
-import { getMapAccess } from './maps.js';
+import { getMapAccess, requireMapContentWrite, dispatchK162, flushK162, resolveStructureOwnerCorp } from './maps.js';
 import { streamMapEvents } from '../services/mapStream.js';
 import {
   listVisibleMaps, loadFullMap, isSystemInMap,
   loadSystemSignatures, loadSystemAnomalies, loadSystemStructures,
 } from '../services/mapRead.js';
+import {
+  createSignature, updateSignature, deleteSignature,
+  createAnomaly, updateAnomaly, deleteAnomaly,
+  createStructure, updateStructure, deleteStructure,
+} from '../services/mapWrite.js';
 
-// Versioned, stable external read API. Authenticated by an account-scoped API
-// key (Authorization: Bearer nxm_…); a browser session also works, so the same
-// surface is usable from the app during development. Read-only in v1 — writes
-// are a later, scope-gated phase. See external_api_feature.md.
+// Versioned, stable external API. Authenticated by an account-scoped API key
+// (Authorization: Bearer nxm_…); a browser session also works, so the same
+// surface is usable from the app. Reads need any scope; the event stream needs
+// 'events' (or 'write'); content writes need 'write'. Topology stays human-only.
+// See external_api_feature.md.
 //
-// Shapes are deliberately decoupled from the cookie UI routes but currently
-// share the same read loaders (services/mapRead.ts), so they match today and
+// Shapes are deliberately decoupled from the cookie UI routes but share the
+// same read/write services (mapRead.ts / mapWrite.ts), so they match today and
 // can be frozen independently later.
 export const apiV1Router = Router();
 
@@ -88,13 +94,108 @@ apiV1Router.get('/maps/:mapId/systems/:systemId/structures', async (req, res) =>
 // is refused); a logged-in session is also accepted. Document the event
 // taxonomy as the public contract.
 apiV1Router.get('/maps/:mapId/events', async (req, res) => {
-  // Scope gate: 'read' keys can pull snapshots but not subscribe to the stream.
-  // Session requests have no apiAuth and pass through.
-  if (req.apiAuth && req.apiAuth.apiScope !== 'events') {
+  // Scope gate: a plain 'read' key can't subscribe to the stream; 'events' and
+  // 'write' (the higher scope) can. Session requests have no apiAuth and pass.
+  if (req.apiAuth && req.apiAuth.apiScope === 'read') {
     res.status(403).json({ error: "API key needs the 'events' scope" });
     return;
   }
   const { mapId } = req.params;
   if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
   streamMapEvents(req, res, mapId);
+});
+
+// ── Content writes (requires a 'write'-scoped key) ─────────────────────────────
+// Each guards via requireMapContentWrite (which enforces the write scope + the
+// bound character's role) and confirms the system is in the map, then delegates
+// to the same write services the cookie routes use. Topology (systems /
+// connections) is intentionally not exposed — those stay human-only.
+
+// Resolve the write context shared by every handler below.
+function writeActor(req: Request) {
+  return { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null };
+}
+
+// Guard: content-write access + the system belongs to the map. Returns the
+// MapMeta (needed for K162 Discord scoping) or null once a response is sent.
+async function writeScope(req: Request, res: Response) {
+  const { mapId, systemId } = req.params;
+  const access = await requireMapContentWrite(res, mapId, req);
+  if (!access) return null;
+  if (!(await isSystemInMap(systemId, mapId))) { res.status(404).json({ error: 'System not found' }); return null; }
+  return access;
+}
+
+// Signatures
+apiV1Router.post('/maps/:mapId/systems/:systemId/signatures', async (req, res) => {
+  const access = await writeScope(req, res); if (!access) return;
+  const { mapId, systemId } = req.params;
+  const { sigId = '', sigType = 'unknown', name = '', notes = '', whType = '', whLeadsTo = '' } = req.body as Record<string, string>;
+  const row = await createSignature(mapId, systemId, { sigId, sigType, name, notes, whType, whLeadsTo }, writeActor(req));
+  if ((whType ?? '').toUpperCase() === 'K162') dispatchK162(access, row.id, systemId, authUser(req).characterName);
+  res.status(201).json(row);
+});
+
+apiV1Router.patch('/maps/:mapId/systems/:systemId/signatures/:sigId', async (req, res) => {
+  const access = await writeScope(req, res); if (!access) return;
+  const { mapId, systemId, sigId } = req.params;
+  const { dispatchK162: shouldDispatch, flushK162: shouldFlush } =
+    await updateSignature(mapId, systemId, sigId, req.body as Record<string, unknown>, writeActor(req));
+  if (shouldDispatch) dispatchK162(access, sigId, systemId, authUser(req).characterName);
+  if (shouldFlush) flushK162(sigId);
+  res.json({ ok: true });
+});
+
+apiV1Router.delete('/maps/:mapId/systems/:systemId/signatures/:sigId', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId, sigId } = req.params;
+  await deleteSignature(mapId, systemId, sigId, writeActor(req));
+  res.json({ ok: true });
+});
+
+// Anomalies
+apiV1Router.post('/maps/:mapId/systems/:systemId/anomalies', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId } = req.params;
+  const { anomId = '', anomType = 'unknown', name = '', notes = '' } = req.body as Record<string, string>;
+  res.status(201).json(await createAnomaly(mapId, systemId, { anomId, anomType, name, notes }, writeActor(req)));
+});
+
+apiV1Router.patch('/maps/:mapId/systems/:systemId/anomalies/:anomId', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId, anomId } = req.params;
+  await updateAnomaly(mapId, systemId, anomId, req.body as Record<string, unknown>, writeActor(req));
+  res.json({ ok: true });
+});
+
+apiV1Router.delete('/maps/:mapId/systems/:systemId/anomalies/:anomId', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId, anomId } = req.params;
+  await deleteAnomaly(mapId, systemId, anomId, writeActor(req));
+  res.json({ ok: true });
+});
+
+// Structures
+apiV1Router.post('/maps/:mapId/systems/:systemId/structures', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId } = req.params;
+  const { name = '', structureType = 'unknown', ownerCorp = '', notes = '', eveId = null } = req.body as Record<string, string>;
+  const eveIdNum = eveId ? Number(eveId) : null;
+  const ownerCorpId = eveIdNum ? await resolveStructureOwnerCorp(authUser(req).userId, eveIdNum) : null;
+  res.status(201).json(await createStructure(mapId, systemId,
+    { name, structureType, ownerCorp, notes, eveId: eveIdNum, ownerCorpId }, writeActor(req)));
+});
+
+apiV1Router.patch('/maps/:mapId/systems/:systemId/structures/:structureId', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId, structureId } = req.params;
+  await updateStructure(mapId, systemId, structureId, req.body as Record<string, unknown>, writeActor(req));
+  res.json({ ok: true });
+});
+
+apiV1Router.delete('/maps/:mapId/systems/:systemId/structures/:structureId', async (req, res) => {
+  if (!(await writeScope(req, res))) return;
+  const { mapId, systemId, structureId } = req.params;
+  await deleteStructure(mapId, systemId, structureId, writeActor(req));
+  res.json({ ok: true });
 });

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -16,7 +16,7 @@ export const keysRouter = Router();
 keysRouter.use(requireAuth);
 
 const MAX_KEYS_PER_OWNER = 25;
-const VALID_SCOPES = new Set(['read', 'events']);
+const VALID_SCOPES = new Set(['read', 'events', 'write']);
 // api_tokens.id is a uuid; Postgres throws 22P02 on malformed input, so guard
 // the path param up front and treat a bad shape as a clean 404.
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -7,14 +7,17 @@ import { authUser } from '../middleware/authContext.js';
 import { config } from '../config.js';
 import { decryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
-import { recordGhostSiteIfMatch } from '../services/ghostSites.js';
 import { resolveOwnerId } from '../utils/owner.js';
 import { resolveEntityNames } from '../services/entityNames.js';
 import { audit } from '../services/audit.js';
 import { publishToMap } from '../services/mapEvents.js';
 import { streamMapEvents } from '../services/mapStream.js';
 import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures } from '../services/mapRead.js';
-import { syncSignature, syncAnomaly } from '../services/crossMapSync.js';
+import {
+  createSignature, updateSignature, deleteSignature,
+  createAnomaly, updateAnomaly, deleteAnomaly,
+  createStructure, updateStructure, deleteStructure,
+} from '../services/mapWrite.js';
 import { reportPresence } from '../services/presence.js';
 import { notifyDiscord, webhookFor, k162Embed, connectionEmbed } from '../services/discord.js';
 
@@ -45,7 +48,7 @@ async function resolveEveSystemId(
 // structure itself (member of the owning corp or its alliance, or it
 // being a public structure). 403/404 just means "we can't resolve it",
 // not an error.
-async function resolveStructureOwnerCorp(
+export async function resolveStructureOwnerCorp(
   userId: number,
   eveStructureId: number,
 ): Promise<number | null> {
@@ -189,15 +192,17 @@ async function requireMapOwner(res: Response, mapId: string, req: Request): Prom
 //     systems, moving systems, connections, map rename.
 //
 // Both helpers send the appropriate 403/404 and return null on failure.
-async function requireMapContentWrite(res: Response, mapId: string, req: Request): Promise<MapMeta | null> {
+export async function requireMapContentWrite(res: Response, mapId: string, req: Request): Promise<MapMeta | null> {
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return null; }
 
   const acting = authUser(req);
-  // API keys are read-only in v1 — no key scope grants writes yet, so any
-  // key-authenticated mutation is refused here regardless of the character's
-  // role. (Write scopes will gate on acting.apiScope when added.)
-  if (acting.apiScope) { res.status(403).json({ error: 'This API key is read-only' }); return null; }
+  // API-key writes need the 'write' scope; a 'read'/'events' key is refused
+  // here regardless of the bound character's role. A 'write' key then still
+  // passes through the same role check below (it acts as its bound character).
+  if (acting.apiScope && acting.apiScope !== 'write') {
+    res.status(403).json({ error: "This API key cannot write (needs the 'write' scope)" }); return null;
+  }
 
   const role = acting.role;
 
@@ -215,6 +220,11 @@ async function requireMapWrite(res: Response, mapId: string, req: Request): Prom
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return null;
 
+  // Topology (systems/connections/rename) is human-only — even a 'write' key,
+  // which clears requireMapContentWrite above, can't reshape the map.
+  if (authUser(req).apiScope) {
+    res.status(403).json({ error: 'API keys cannot modify map topology' }); return null;
+  }
   if (access.locked && authUser(req).role !== 'admin') {
     res.status(403).json({ error: 'Map is locked' }); return null;
   }
@@ -247,7 +257,7 @@ const K162_DEFER_MS = 10_000;
 interface PendingK162 { timer: ReturnType<typeof setTimeout>; corpId: number | null; actor: string | null; }
 const pendingK162 = new Map<string, PendingK162>();
 
-function dispatchK162(meta: MapMeta, sigId: string, systemId: string, actor: string | null): void {
+export function dispatchK162(meta: MapMeta, sigId: string, systemId: string, actor: string | null): void {
   if (!webhookFor(meta.corpId)) {
     discordLog.info(`K162 detected (system ${systemId}) but not sending — no webhook for corpId=${meta.corpId ?? 'null (personal map; webhooks are corp-maps only)'}`);
     return;
@@ -267,7 +277,7 @@ function dispatchK162(meta: MapMeta, sigId: string, systemId: string, actor: str
 // Send a pending K162 immediately — e.g. once its leads-to has been filled in —
 // instead of waiting out the rest of the defer window. No-op if nothing is
 // pending for this signature. Fires with the original detection's context.
-function flushK162(sigId: string): void {
+export function flushK162(sigId: string): void {
   const p = pendingK162.get(sigId);
   if (!p) return;
   clearTimeout(p.timer);
@@ -1655,23 +1665,13 @@ mapsRouter.post('/:mapId/systems/:systemId/signatures', async (req, res) => {
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
   const { sigId = '', sigType = 'unknown', name = '', notes = '', whType = '', whLeadsTo = '' } = req.body as Record<string, string>;
-  const { rows } = await db.query(
-    `INSERT INTO map_signatures (system_id, sig_id, sig_type, name, notes, wh_type, wh_leads_to, created_by_user_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING id, sig_id AS "sigId", sig_type AS "sigType", name, notes, wh_type AS "whType", wh_leads_to AS "whLeadsTo", created_at AS "createdAt"`,
-    [systemId, sigId, sigType, name, notes, whType, whLeadsTo, req.session.userId],
+  const me = authUser(req);
+  const row = await createSignature(
+    mapId, systemId, { sigId, sigType, name, notes, whType, whLeadsTo },
+    { userId: me.userId, clientId: req.get('x-client-id') ?? null },
   );
-  db.query(
-    `INSERT INTO user_events (user_id, event_type, sig_type) VALUES ($1, 'signature', $2)`,
-    [req.session.userId, sigType],
-  ).catch(console.error);
-  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
-  recordGhostSiteIfMatch(systemId, name);
-  publishToMap(mapId, { type: 'sig.changed', actor: req.get('x-client-id') ?? null, systemId });
-  if (whType) discordLog.info(`sig POST on system ${systemId}: whType="${whType}"`);
-  if ((whType ?? '').toUpperCase() === 'K162') dispatchK162(access, rows[0].id, systemId, req.session.characterName ?? null);
-  syncSignature(mapId, systemId, rows[0].id, req.session.userId);
-  res.status(201).json(rows[0]);
+  if ((whType ?? '').toUpperCase() === 'K162') dispatchK162(access, row.id, systemId, me.characterName);
+  res.status(201).json(row);
 });
 
 mapsRouter.patch('/:mapId/systems/:systemId/signatures/:sigId', async (req, res) => {
@@ -1680,44 +1680,15 @@ mapsRouter.patch('/:mapId/systems/:systemId/signatures/:sigId', async (req, res)
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
 
-  const colMap: Record<string, string> = { sigId: 'sig_id', sigType: 'sig_type', name: 'name', notes: 'notes', whType: 'wh_type', whLeadsTo: 'wh_leads_to' };
   const updates = req.body as Record<string, unknown>;
-
-  // Detect a transition *into* K162 (not a re-save of one already K162) so the
-  // Discord notice fires once, matching the client's inbound-K162 alert.
-  const settingK162 = typeof updates.whType === 'string' && updates.whType.toUpperCase() === 'K162';
-  let prevWasK162 = false;
-  if (settingK162) {
-    const { rows: prev } = await db.query<{ wh_type: string | null }>(
-      `SELECT wh_type FROM map_signatures WHERE id = $1 AND system_id = $2`, [sigId, systemId]);
-    prevWasK162 = (prev[0]?.wh_type ?? '').toUpperCase() === 'K162';
-  }
-  if (typeof updates.whType === 'string') {
-    discordLog.info(`sig PATCH on system ${systemId}: whType="${updates.whType}" (settingK162=${settingK162}, prevWasK162=${prevWasK162})`);
-  }
-
-  const sets: string[] = ['updated_at = NOW()'];
-  const vals: unknown[] = [];
-
-  for (const [key, col] of Object.entries(colMap)) {
-    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
-  }
-
-  await db.query(
-    // map_id scoping is defence-in-depth: verifySystemInMap above already
-    // guarantees systemId is in this map, but enforcing it in SQL too means a
-    // future refactor can't open a cross-map write.
-    `UPDATE map_signatures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND system_id IN (SELECT id FROM map_systems WHERE map_id = $${vals.length + 3})`,
-    [...vals, sigId, systemId, mapId],
+  const me = authUser(req);
+  const { dispatchK162: shouldDispatch, flushK162: shouldFlush } = await updateSignature(
+    mapId, systemId, sigId, updates, { userId: me.userId, clientId: req.get('x-client-id') ?? null },
   );
-  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
-  if (typeof updates.name === 'string') recordGhostSiteIfMatch(systemId, updates.name);
-  publishToMap(mapId, { type: 'sig.changed', actor: req.get('x-client-id') ?? null, systemId });
-  if (settingK162 && !prevWasK162) dispatchK162(access, sigId, systemId, req.session.characterName ?? null);
-  // If the leads-to was just filled in, send any pending K162 now rather than
-  // waiting out the rest of the window — the intel we were waiting for is here.
-  if (typeof updates.whLeadsTo === 'string' && updates.whLeadsTo.trim()) flushK162(sigId);
-  syncSignature(mapId, systemId, sigId, req.session.userId);
+  // Discord notice fires once on a transition into K162; flush any pending
+  // notice the moment the leads-to is known. (Both decided inside updateSignature.)
+  if (shouldDispatch) dispatchK162(access, sigId, systemId, me.characterName);
+  if (shouldFlush) flushK162(sigId);
   res.json({ ok: true });
 });
 
@@ -1726,9 +1697,7 @@ mapsRouter.delete('/:mapId/systems/:systemId/signatures/:sigId', async (req, res
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  await db.query(`DELETE FROM map_signatures WHERE id = $1 AND system_id = $2 AND system_id IN (SELECT id FROM map_systems WHERE map_id = $3)`, [sigId, systemId, mapId]);
-  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
-  publishToMap(mapId, { type: 'sig.changed', actor: req.get('x-client-id') ?? null, systemId });
+  await deleteSignature(mapId, systemId, sigId, { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null });
   res.json({ ok: true });
 });
 
@@ -1785,16 +1754,9 @@ mapsRouter.post('/:mapId/systems/:systemId/anomalies', async (req, res) => {
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
   const { anomId = '', anomType = 'unknown', name = '', notes = '' } = req.body as Record<string, string>;
-  const { rows } = await db.query(
-    `INSERT INTO map_anomalies (system_id, anom_id, anom_type, name, notes, created_by_user_id)
-     VALUES ($1, $2, $3, $4, $5, $6)
-     RETURNING id, anom_id AS "anomId", anom_type AS "anomType", name, notes, created_at AS "createdAt", updated_at AS "updatedAt"`,
-    [systemId, anomId, anomType, name, notes, req.session.userId],
-  );
-  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
-  publishToMap(mapId, { type: 'anom.changed', actor: req.get('x-client-id') ?? null, systemId });
-  syncAnomaly(mapId, systemId, rows[0].id, req.session.userId);
-  res.status(201).json(rows[0]);
+  const row = await createAnomaly(mapId, systemId, { anomId, anomType, name, notes },
+    { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null });
+  res.status(201).json(row);
 });
 
 mapsRouter.patch('/:mapId/systems/:systemId/anomalies/:anomId', async (req, res) => {
@@ -1803,25 +1765,9 @@ mapsRouter.patch('/:mapId/systems/:systemId/anomalies/:anomId', async (req, res)
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
 
-  const colMap: Record<string, string> = { anomId: 'anom_id', anomType: 'anom_type', name: 'name', notes: 'notes' };
   const updates = req.body as Record<string, unknown>;
-
-  const sets: string[] = ['updated_at = NOW()'];
-  const vals: unknown[] = [];
-  for (const [key, col] of Object.entries(colMap)) {
-    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
-  }
-
-  await db.query(
-    // map_id scoping is defence-in-depth: verifySystemInMap above already
-    // guarantees systemId is in this map, but enforcing it in SQL too means a
-    // future refactor can't open a cross-map write.
-    `UPDATE map_anomalies SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND system_id IN (SELECT id FROM map_systems WHERE map_id = $${vals.length + 3})`,
-    [...vals, anomId, systemId, mapId],
-  );
-  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
-  publishToMap(mapId, { type: 'anom.changed', actor: req.get('x-client-id') ?? null, systemId });
-  syncAnomaly(mapId, systemId, anomId, req.session.userId);
+  await updateAnomaly(mapId, systemId, anomId, updates,
+    { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null });
   res.json({ ok: true });
 });
 
@@ -1830,9 +1776,7 @@ mapsRouter.delete('/:mapId/systems/:systemId/anomalies/:anomId', async (req, res
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  await db.query(`DELETE FROM map_anomalies WHERE id = $1 AND system_id = $2 AND system_id IN (SELECT id FROM map_systems WHERE map_id = $3)`, [anomId, systemId, mapId]);
-  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
-  publishToMap(mapId, { type: 'anom.changed', actor: req.get('x-client-id') ?? null, systemId });
+  await deleteAnomaly(mapId, systemId, anomId, { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null });
   res.json({ ok: true });
 });
 
@@ -1853,22 +1797,17 @@ mapsRouter.post('/:mapId/systems/:systemId/structures', async (req, res) => {
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
   const { name = '', structureType = 'unknown', ownerCorp = '', notes = '', eveId = null } = req.body as Record<string, string>;
   const eveIdNum = eveId ? Number(eveId) : null;
+  const me = authUser(req);
 
   // Block briefly on ESI to resolve the owner corp when an eve_id is
   // supplied. If the call fails (private structure / missing scope /
   // bad ID) we just leave owner_corp_id NULL — the row still goes in.
-  const ownerCorpId = eveIdNum && req.session.userId
-    ? await resolveStructureOwnerCorp(req.session.userId, eveIdNum)
-    : null;
+  const ownerCorpId = eveIdNum ? await resolveStructureOwnerCorp(me.userId, eveIdNum) : null;
 
-  const { rows } = await db.query(
-    `INSERT INTO map_structures (system_id, name, structure_type, owner_corp, eve_id, notes, created_by_user_id, owner_corp_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING id, name, structure_type AS "structureType", owner_corp AS "ownerCorp", eve_id AS "eveId", notes, created_at AS "createdAt", owner_corp_id AS "ownerCorpId"`,
-    [systemId, name, structureType, ownerCorp, eveIdNum, notes, req.session.userId, ownerCorpId],
-  );
-  publishToMap(mapId, { type: 'structure.changed', actor: req.get('x-client-id') ?? null, systemId });
-  res.status(201).json(rows[0]);
+  const row = await createStructure(mapId, systemId,
+    { name, structureType, ownerCorp, notes, eveId: eveIdNum, ownerCorpId },
+    { userId: me.userId, clientId: req.get('x-client-id') ?? null });
+  res.status(201).json(row);
 });
 
 mapsRouter.patch('/:mapId/systems/:systemId/structures/:structureId', async (req, res) => {
@@ -1877,21 +1816,9 @@ mapsRouter.patch('/:mapId/systems/:systemId/structures/:structureId', async (req
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
 
-  const colMap: Record<string, string> = { name: 'name', structureType: 'structure_type', ownerCorp: 'owner_corp', eveId: 'eve_id', notes: 'notes' };
   const updates = req.body as Record<string, unknown>;
-  const sets: string[] = ['updated_at = NOW()'];
-  const vals: unknown[] = [];
-
-  for (const [key, col] of Object.entries(colMap)) {
-    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
-  }
-
-  await db.query(
-    // map_id scoping is defence-in-depth (see the signature PATCH above).
-    `UPDATE map_structures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND system_id IN (SELECT id FROM map_systems WHERE map_id = $${vals.length + 3})`,
-    [...vals, structureId, systemId, mapId],
-  );
-  publishToMap(mapId, { type: 'structure.changed', actor: req.get('x-client-id') ?? null, systemId });
+  await updateStructure(mapId, systemId, structureId, updates,
+    { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null });
   res.json({ ok: true });
 });
 
@@ -1900,8 +1827,7 @@ mapsRouter.delete('/:mapId/systems/:systemId/structures/:structureId', async (re
   const access = await requireMapContentWrite(res, mapId, req);
   if (!access) return;
   if (!(await verifySystemInMap(res, systemId, mapId))) return;
-  await db.query(`DELETE FROM map_structures WHERE id = $1 AND system_id = $2 AND system_id IN (SELECT id FROM map_systems WHERE map_id = $3)`, [structureId, systemId, mapId]);
-  publishToMap(mapId, { type: 'structure.changed', actor: req.get('x-client-id') ?? null, systemId });
+  await deleteStructure(mapId, systemId, structureId, { userId: authUser(req).userId, clientId: req.get('x-client-id') ?? null });
   res.json({ ok: true });
 });
 

--- a/server/src/services/mapWrite.ts
+++ b/server/src/services/mapWrite.ts
@@ -1,0 +1,179 @@
+import { db } from '../db.js';
+import { publishToMap } from './mapEvents.js';
+import { syncSignature, syncAnomaly } from './crossMapSync.js';
+import { recordGhostSiteIfMatch } from './ghostSites.js';
+
+// Shared per-system CONTENT writes (signatures, anomalies, structures) — the
+// single source of truth behind both the cookie map routes and the external
+// /api/v1 write routes. The CALLER access-checks the map (requireMapContentWrite)
+// and verifies the system belongs to it first; these run the DB write plus the
+// same side effects (activity bump, cross-map sync, ghost-site recording, SSE
+// broadcast). K162 Discord dispatch and ESI structure-owner resolution stay in
+// the route layer — they need the MapMeta / a blocking ESI call — so each
+// signature/structure function returns just enough for the route to drive them.
+
+export interface WriteActor {
+  /** users.id of the acting character — created_by, activity stats, sync owner. */
+  userId: number;
+  /** x-client-id for SSE echo suppression (null for API-key writes). */
+  clientId: string | null;
+}
+
+const bumpActivity = (systemId: string) =>
+  db.query(`UPDATE map_systems SET last_activity_at = NOW() WHERE id = $1`, [systemId]).catch(console.error);
+
+// map_id scoping in the UPDATE/DELETE WHERE is defence-in-depth: the caller has
+// already confirmed the system is in the map, but enforcing it in SQL too means
+// a future refactor can't open a cross-map write.
+const inThisMap = (n: number) => `system_id IN (SELECT id FROM map_systems WHERE map_id = $${n})`;
+
+// ── Signatures ────────────────────────────────────────────────────────────────
+
+export interface SignatureInput {
+  sigId: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string;
+}
+
+export async function createSignature(mapId: string, systemId: string, d: SignatureInput, actor: WriteActor) {
+  const { rows } = await db.query(
+    `INSERT INTO map_signatures (system_id, sig_id, sig_type, name, notes, wh_type, wh_leads_to, created_by_user_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, sig_id AS "sigId", sig_type AS "sigType", name, notes, wh_type AS "whType", wh_leads_to AS "whLeadsTo", created_at AS "createdAt"`,
+    [systemId, d.sigId, d.sigType, d.name, d.notes, d.whType, d.whLeadsTo, actor.userId],
+  );
+  db.query(`INSERT INTO user_events (user_id, event_type, sig_type) VALUES ($1, 'signature', $2)`,
+    [actor.userId, d.sigType]).catch(console.error);
+  bumpActivity(systemId);
+  recordGhostSiteIfMatch(systemId, d.name);
+  publishToMap(mapId, { type: 'sig.changed', actor: actor.clientId, systemId });
+  syncSignature(mapId, systemId, rows[0].id, actor.userId);
+  return rows[0];
+}
+
+const SIG_COLS: Record<string, string> = {
+  sigId: 'sig_id', sigType: 'sig_type', name: 'name', notes: 'notes', whType: 'wh_type', whLeadsTo: 'wh_leads_to',
+};
+
+// Updates the signature and returns flags the route uses to drive the K162
+// Discord notice: dispatchK162 fires once on a transition *into* K162;
+// flushK162 sends any pending notice now that the leads-to is known.
+export async function updateSignature(
+  mapId: string, systemId: string, sigId: string, updates: Record<string, unknown>, actor: WriteActor,
+): Promise<{ dispatchK162: boolean; flushK162: boolean }> {
+  const settingK162 = typeof updates.whType === 'string' && updates.whType.toUpperCase() === 'K162';
+  let prevWasK162 = false;
+  if (settingK162) {
+    const { rows: prev } = await db.query<{ wh_type: string | null }>(
+      `SELECT wh_type FROM map_signatures WHERE id = $1 AND system_id = $2`, [sigId, systemId]);
+    prevWasK162 = (prev[0]?.wh_type ?? '').toUpperCase() === 'K162';
+  }
+
+  const sets: string[] = ['updated_at = NOW()'];
+  const vals: unknown[] = [];
+  for (const [key, col] of Object.entries(SIG_COLS)) {
+    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
+  }
+  await db.query(
+    `UPDATE map_signatures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND ${inThisMap(vals.length + 3)}`,
+    [...vals, sigId, systemId, mapId],
+  );
+  bumpActivity(systemId);
+  if (typeof updates.name === 'string') recordGhostSiteIfMatch(systemId, updates.name);
+  publishToMap(mapId, { type: 'sig.changed', actor: actor.clientId, systemId });
+  syncSignature(mapId, systemId, sigId, actor.userId);
+  return {
+    dispatchK162: settingK162 && !prevWasK162,
+    flushK162: typeof updates.whLeadsTo === 'string' && updates.whLeadsTo.trim().length > 0,
+  };
+}
+
+export async function deleteSignature(mapId: string, systemId: string, sigId: string, actor: WriteActor): Promise<void> {
+  await db.query(`DELETE FROM map_signatures WHERE id = $1 AND system_id = $2 AND ${inThisMap(3)}`, [sigId, systemId, mapId]);
+  bumpActivity(systemId);
+  publishToMap(mapId, { type: 'sig.changed', actor: actor.clientId, systemId });
+}
+
+// ── Anomalies ─────────────────────────────────────────────────────────────────
+
+export interface AnomalyInput { anomId: string; anomType: string; name: string; notes: string; }
+
+export async function createAnomaly(mapId: string, systemId: string, d: AnomalyInput, actor: WriteActor) {
+  const { rows } = await db.query(
+    `INSERT INTO map_anomalies (system_id, anom_id, anom_type, name, notes, created_by_user_id)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id, anom_id AS "anomId", anom_type AS "anomType", name, notes, created_at AS "createdAt", updated_at AS "updatedAt"`,
+    [systemId, d.anomId, d.anomType, d.name, d.notes, actor.userId],
+  );
+  bumpActivity(systemId);
+  publishToMap(mapId, { type: 'anom.changed', actor: actor.clientId, systemId });
+  syncAnomaly(mapId, systemId, rows[0].id, actor.userId);
+  return rows[0];
+}
+
+const ANOM_COLS: Record<string, string> = { anomId: 'anom_id', anomType: 'anom_type', name: 'name', notes: 'notes' };
+
+export async function updateAnomaly(
+  mapId: string, systemId: string, anomId: string, updates: Record<string, unknown>, actor: WriteActor,
+): Promise<void> {
+  const sets: string[] = ['updated_at = NOW()'];
+  const vals: unknown[] = [];
+  for (const [key, col] of Object.entries(ANOM_COLS)) {
+    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
+  }
+  await db.query(
+    `UPDATE map_anomalies SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND ${inThisMap(vals.length + 3)}`,
+    [...vals, anomId, systemId, mapId],
+  );
+  bumpActivity(systemId);
+  publishToMap(mapId, { type: 'anom.changed', actor: actor.clientId, systemId });
+  syncAnomaly(mapId, systemId, anomId, actor.userId);
+}
+
+export async function deleteAnomaly(mapId: string, systemId: string, anomId: string, actor: WriteActor): Promise<void> {
+  await db.query(`DELETE FROM map_anomalies WHERE id = $1 AND system_id = $2 AND ${inThisMap(3)}`, [anomId, systemId, mapId]);
+  bumpActivity(systemId);
+  publishToMap(mapId, { type: 'anom.changed', actor: actor.clientId, systemId });
+}
+
+// ── Structures ────────────────────────────────────────────────────────────────
+// No activity bump and no cross-map sync — structures don't back staleness or
+// sync (mirrors the cookie routes).
+
+export interface StructureInput {
+  name: string; structureType: string; ownerCorp: string; notes: string;
+  eveId: number | null; ownerCorpId: number | null;
+}
+
+export async function createStructure(mapId: string, systemId: string, d: StructureInput, actor: WriteActor) {
+  const { rows } = await db.query(
+    `INSERT INTO map_structures (system_id, name, structure_type, owner_corp, eve_id, notes, created_by_user_id, owner_corp_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, name, structure_type AS "structureType", owner_corp AS "ownerCorp", eve_id AS "eveId", notes, created_at AS "createdAt", owner_corp_id AS "ownerCorpId"`,
+    [systemId, d.name, d.structureType, d.ownerCorp, d.eveId, d.notes, actor.userId, d.ownerCorpId],
+  );
+  publishToMap(mapId, { type: 'structure.changed', actor: actor.clientId, systemId });
+  return rows[0];
+}
+
+const STRUCT_COLS: Record<string, string> = {
+  name: 'name', structureType: 'structure_type', ownerCorp: 'owner_corp', eveId: 'eve_id', notes: 'notes',
+};
+
+export async function updateStructure(
+  mapId: string, systemId: string, structureId: string, updates: Record<string, unknown>, actor: WriteActor,
+): Promise<void> {
+  const sets: string[] = ['updated_at = NOW()'];
+  const vals: unknown[] = [];
+  for (const [key, col] of Object.entries(STRUCT_COLS)) {
+    if (key in updates) { sets.push(`${col} = $${vals.length + 1}`); vals.push(updates[key]); }
+  }
+  await db.query(
+    `UPDATE map_structures SET ${sets.join(', ')} WHERE id = $${vals.length + 1} AND system_id = $${vals.length + 2} AND ${inThisMap(vals.length + 3)}`,
+    [...vals, structureId, systemId, mapId],
+  );
+  publishToMap(mapId, { type: 'structure.changed', actor: actor.clientId, systemId });
+}
+
+export async function deleteStructure(mapId: string, systemId: string, structureId: string, actor: WriteActor): Promise<void> {
+  await db.query(`DELETE FROM map_structures WHERE id = $1 AND system_id = $2 AND ${inThisMap(3)}`, [structureId, systemId, mapId]);
+  publishToMap(mapId, { type: 'structure.changed', actor: actor.clientId, systemId });
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1868,6 +1868,12 @@
   border: 1px solid rgba(120,200,140,0.3);
 }
 
+.api-keys__scope--write {
+  background: rgba(240,160,80,0.12);
+  color: #e0a050;
+  border: 1px solid rgba(240,160,80,0.3);
+}
+
 .api-keys__meta {
   display: flex;
   flex-direction: column;

--- a/web/src/components/ui/ApiKeysModal.tsx
+++ b/web/src/components/ui/ApiKeysModal.tsx
@@ -15,7 +15,7 @@ interface ApiKey {
   id:                   string;
   name:                 string;
   tokenPrefix:          string;
-  scope:                'read' | 'events';
+  scope:                'read' | 'events' | 'write';
   contextUserId:        number | null;
   contextCharacterName: string | null;
   lastUsedAt:           string | null;
@@ -42,7 +42,7 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
   const [charId, setCharId]       = useState<number | null>(
     () => (characters.find((c) => c.active) ?? characters[0])?.characterId ?? null,
   );
-  const [scope, setScope]         = useState<'read' | 'events'>('read');
+  const [scope, setScope]         = useState<'read' | 'events' | 'write'>('read');
   const [expiryDays, setExpiry]   = useState<number>(0);
   const [creating, setCreating]   = useState(false);
   // The raw secret, surfaced exactly once right after creation.
@@ -159,9 +159,10 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
             </label>
             <label className="field">
               <span>{t('apiKeys.scope')}</span>
-              <select value={scope} onChange={(e) => setScope(e.target.value as 'read' | 'events')}>
+              <select value={scope} onChange={(e) => setScope(e.target.value as 'read' | 'events' | 'write')}>
                 <option value="read">{t('apiKeys.scopeRead')}</option>
                 <option value="events">{t('apiKeys.scopeEvents')}</option>
+                <option value="write">{t('apiKeys.scopeWrite')}</option>
               </select>
             </label>
             <label className="field">
@@ -196,7 +197,9 @@ export function ApiKeysModal({ onClose }: { onClose: () => void }) {
                           <span className="api-keys__name">{k.name}</span>
                           <code className="api-keys__prefix">{k.tokenPrefix}…</code>
                           <span className={`api-keys__scope api-keys__scope--${k.scope}`}>
-                            {k.scope === 'events' ? t('apiKeys.scopeEventsBadge') : t('apiKeys.scopeReadBadge')}
+                            {k.scope === 'write' ? t('apiKeys.scopeWriteBadge')
+                              : k.scope === 'events' ? t('apiKeys.scopeEventsBadge')
+                              : t('apiKeys.scopeReadBadge')}
                           </span>
                           {(expired || inert) && (
                             <span className="api-keys__flag">

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1,15 +1,17 @@
 {
   "apiKeys": {
     "title": "API keys",
-    "hint": "Generate a key to let external tools read your maps via the API. A key acts as the selected character and can only read — never write. \"Read + live events\" keys can also subscribe to the live event stream.",
+    "hint": "Generate a key to let external tools use your maps via the API. A key acts as the selected character — it can do only what that character can. \"Read + live events\" keys can also subscribe to the live event stream; \"Read + write content\" keys can also add and edit signatures, anomalies, and structures (never map topology).",
     "name": "Name",
     "namePlaceholder": "e.g. fleet bot",
     "character": "Acts as",
     "scope": "Access",
     "scopeRead": "Read only",
     "scopeEvents": "Read + live events",
+    "scopeWrite": "Read + write content",
     "scopeReadBadge": "read",
     "scopeEventsBadge": "events",
+    "scopeWriteBadge": "write",
     "expiry": "Expires",
     "expiryNever": "Never",
     "expiryDays": "{{count}} days",


### PR DESCRIPTION
Phase 4 of the external API (design: `external_api_feature.md`). Adds a **`write`** scope so an approved tool can push per-system **content** — signatures, anomalies, structures — through the API. Map **topology** (systems/connections/rename/lock) stays human-only.

## Scope hierarchy
`read ⊂ events ⊂ write` — a higher scope implies the lower ones. Reads need any scope; the event stream needs `events` (or `write`); content writes need `write`.

## Backend
- **Scope plumbing:** `authContext` (`ApiScope` union + `characterName` on `AuthUser` for K162 actor attribution), `apiKeyAuth` (loads `character_name`, coerces `write`), `keys.ts` validation.
- **Gating:** `requireMapContentWrite` lets a `write` key through (then *still* applies the bound character's role — a key acting as a `readonly` corp member can't write a corp map); `requireMapWrite` refuses **any** key, so topology stays human-only.
- **`services/mapWrite.ts`** (new): the 9 content ops with their real side effects — activity bump, cross-map sync, ghost-site recording, SSE broadcast. K162 Discord dispatch + ESI structure-owner resolution stay in the route layer.
- **Single source of truth:** the cookie handlers in `maps.ts` were refactored onto `mapWrite` too (no drift between app and API), sourcing the actor via `authUser` (transparent for cookie clients).
- **`/api/v1` writes:** `POST/PATCH/DELETE` for signatures, anomalies, structures. The event stream now also accepts a `write` key.
- **`originGuard` fix:** exempt Bearer-authenticated requests from the CSRF Origin check. An API key isn't an ambient browser credential (a cross-site page can't read or attach it, and can't set the header without a CORS preflight we control), so those requests can't be CSRF and legitimately have no `Origin`. **Without this, every API write 403'd** — caught in smoke testing.

## Frontend
"Read + write content" option in the key-create form + a `write` badge in the list.

## README
Scopes table, write-endpoints table, and the note that writes go through the same path (so they stream / fire the K162 Discord notice / cross-map sync like a human edit) and that topology is human-only.

## Verification
Smoke-tested end-to-end against a live DB:

| Case | Result |
|---|---|
| `read` key → POST signature | **403** "cannot write (needs write scope)" |
| `events` key → POST signature | **403** (scope hierarchy) |
| `write` key → POST / PATCH / DELETE signature | **201 / 200 / 200**, read-back confirmed |
| `write` key → topology cookie route | **401** (unreachable) |

`tsc` (server + web), `eslint`, `yarn build` clean. The shared `mapWrite` core is exercised by the key-write path; the cookie handlers are thin wrappers over the same functions (and the app exercises them constantly), so I didn't separately drive a session write.