### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "0.1.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
Aligns `server/` and `web/` `package.json` to **1.1.0** ahead of cutting the `v1.1.0` release tag (first release where the manifests are kept in sync — they'd drifted to 0.1.0 / 0.0.0).

Covers everything merged since `v1.0.0`:
- **External API** — read, live event stream, and write scopes + key-management UI (#216, #217, #219, #225)
- **Fixes** — stale-system revival incl. alts (#210, #222), tracked-character location cadence (#223), live drag-optimised connections (#212), qs security bump (#214), `api()` 204 handling (#221), key-modal bugs

After this merges to `release` and then `release`→`main`, I'll cut the **v1.1.0** GitHub release on `main`.