### PR TITLE
Make compact mode compact again (drop the min-height floor)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2631,6 +2631,16 @@
   transition: border-color 0.15s, box-shadow 0.15s, opacity 0.2s, filter 0.2s;
   position: relative;
 
+  /* Compact mode hides the region / statics / incursion / insurgency rows but
+     the 4-square min-height floor (added for map-generation spacing) kept the
+     node a fixed 80px tall, leaving empty space below the content. Opt compact
+     nodes out of the floor so they hug their reduced content again — the
+     behaviour before the floor existed. Uniform sizing still wins via its
+     inline min-height when both are on. */
+  &.system-node--compact {
+    min-height: 0;
+  }
+
   &:hover {
     border-color: var(--class-color);
     box-shadow: 0 0 12px color-mix(in srgb, var(--class-color) 30%, transparent);


### PR DESCRIPTION
**Report:** compact mode "isn't overly compact anymore" — nodes keep empty vertical space even with compact on.

## Cause
Compact mode shrinks a node by hiding rows (region, statics, incursion, insurgency) — it has no CSS of its own. Commit `039a386` ("Ensure nodes have a minimum distance… when generating maps") added `min-height: 80px` to `.system-node`. That floor pins every node to a fixed 4-square height, so even after compact mode hides its rows the node stays 80px tall — the empty space below the content. Before that commit there was no min-height, so compact nodes sized to their content.

## Fix
Opt compact nodes out of the floor:

```css
.system-node.system-node--compact { min-height: 0; }
```

Nodes hug their reduced content again — exactly the behaviour before the floor existed. No new fixed size is imposed (just removing the floor for this mode). Uniform-size mode still wins via its inline `min-height` when both are enabled, and non-compact nodes keep the 80px floor for generation spacing.

Built clean. Worth an eyeball in the app — toggle compact and confirm the nodes tighten up with no empty gap.