### PR TITLE
Release v1.1.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2631,6 +2631,16 @@
   transition: border-color 0.15s, box-shadow 0.15s, opacity 0.2s, filter 0.2s;
   position: relative;
 
+  /* Compact mode hides the region / statics / incursion / insurgency rows but
+     the 4-square min-height floor (added for map-generation spacing) kept the
+     node a fixed 80px tall, leaving empty space below the content. Opt compact
+     nodes out of the floor so they hug their reduced content again — the
+     behaviour before the floor existed. Uniform sizing still wins via its
+     inline min-height when both are on. */
+  &.system-node--compact {
+    min-height: 0;
+  }
+
   &:hover {
     border-color: var(--class-color);
     box-shadow: 0 0 12px color-mix(in srgb, var(--class-color) 30%, transparent);


### PR DESCRIPTION
Batch `release` → `main` for **v1.1.1** (patch).

## Changes since v1.1.0
- **Compact mode shrinks system nodes again** (#229) — commit `039a386`'s `min-height: 80px` floor (added for map-generation spacing) was overriding compact mode's row-hiding, leaving empty space; compact nodes now hug their content again.
- Version bump: `server/` + `web/` `package.json` → `1.1.1`.

After this merges, I'll cut the **v1.1.1** GitHub release on `main`.