### PR TITLE
Live share link: push updates to the shared map view

### DIFF
--- a/server/src/routes/share.ts
+++ b/server/src/routes/share.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { db } from '../db.js';
+import { onMapEvent } from '../services/mapEvents.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('share');
@@ -88,6 +89,41 @@ export async function lookupShareToken(token: string): Promise<ShareTokenLookup>
     includeStructures: row.includeStructures,
   };
 }
+
+// GET /api/share/:token/events
+// Public live-update stream for a shared map. Authorised by the token only.
+// CRITICAL: this never forwards event payloads — a public client must not see
+// intel the link excludes. Instead every map change becomes a content-free
+// "changed" ping; the client refetches GET /api/share/:token, which already
+// applies all the include-* filters. So all privacy filtering stays in one
+// place and nothing sensitive can leak through an event body.
+shareRouter.get('/:token/events', async (req, res) => {
+  const lookup = await lookupShareToken(req.params.token);
+  if (lookup.status !== 'valid' || !lookup.mapId) {
+    res.status(lookup.status === 'expired' ? 410 : 404).json({ error: lookup.status });
+    return;
+  }
+  const mapId = lookup.mapId;
+
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders?.();
+  res.write(': connected\n\n');
+
+  const heartbeat = setInterval(() => { try { res.write(': ping\n\n'); } catch { /* closed */ } }, 25_000);
+
+  // Presence events (viewer dots, heartbeats) aren't shown in the shared view
+  // and would otherwise trigger a refetch every ~25s — skip them.
+  const unsubscribe = onMapEvent(mapId, (event) => {
+    if (event.type.startsWith('presence')) return;
+    try { res.write('data: {"type":"changed"}\n\n'); } catch { /* closed */ }
+  });
+
+  req.on('close', () => { clearInterval(heartbeat); unsubscribe(); });
+});
 
 // GET /api/share/:token
 // Public, no auth. Returns the read-only map snapshot:

--- a/server/src/services/mapEvents.ts
+++ b/server/src/services/mapEvents.ts
@@ -6,6 +6,14 @@ import type { Response } from 'express';
 // realtime_sync_feature.md.
 const subscribers = new Map<string, Set<Response>>();
 
+// Parallel registry of plain callbacks, keyed by map id. Unlike `subscribers`
+// (which get the raw event written to their SSE response), these receive the
+// event object so the caller can transform it. Used by the public share stream,
+// which must NOT forward event payloads to an unauthenticated client — it turns
+// every event into a content-free "changed" ping instead.
+type MapEventListener = (event: MapEvent) => void;
+const listeners = new Map<string, Set<MapEventListener>>();
+
 export interface MapEvent {
   type: string;            // e.g. 'system.add'
   actor?: string | null;   // originating client id, for echo suppression
@@ -25,15 +33,38 @@ export function subscribeMap(mapId: string, res: Response): () => void {
   };
 }
 
-// Push an event to every client currently viewing this map. No-op when nobody
-// is subscribed, so mutation routes can fire-and-forget cheaply.
+// Register a transform callback for a map's events. Returns an unsubscribe fn.
+// The callback gets the event object (not an SSE frame), so the caller decides
+// what, if anything, to forward.
+export function onMapEvent(mapId: string, fn: MapEventListener): () => void {
+  let set = listeners.get(mapId);
+  if (!set) { set = new Set(); listeners.set(mapId, set); }
+  set.add(fn);
+  return () => {
+    const s = listeners.get(mapId);
+    if (!s) return;
+    s.delete(fn);
+    if (s.size === 0) listeners.delete(mapId);
+  };
+}
+
+// Push an event to every client currently viewing this map, and to every
+// registered callback listener. Cheap no-op when neither exists, so mutation
+// routes can fire-and-forget.
 export function publishToMap(mapId: string, event: MapEvent): void {
   const set = subscribers.get(mapId);
-  if (!set || set.size === 0) return;
-  // Default (unnamed) SSE message — the client dispatches on event.type via a
-  // single onmessage handler rather than one listener per event name.
-  const frame = `data: ${JSON.stringify(event)}\n\n`;
-  for (const res of set) {
-    try { res.write(frame); } catch { /* dead connection; req close handler cleans it up */ }
+  if (set && set.size > 0) {
+    // Default (unnamed) SSE message — the client dispatches on event.type via a
+    // single onmessage handler rather than one listener per event name.
+    const frame = `data: ${JSON.stringify(event)}\n\n`;
+    for (const res of set) {
+      try { res.write(frame); } catch { /* dead connection; req close handler cleans it up */ }
+    }
+  }
+  const ls = listeners.get(mapId);
+  if (ls && ls.size > 0) {
+    for (const fn of ls) {
+      try { fn(event); } catch { /* a listener must never break the publish */ }
+    }
   }
 }

--- a/web/src/components/ui/SharedMapView.tsx
+++ b/web/src/components/ui/SharedMapView.tsx
@@ -56,24 +56,24 @@ export function SharedMapView({ token }: { token: string }) {
   const { t } = useTranslation();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
 
-  // Hydrate the map store directly from the share payload. The store's
+  // Hydrate the map store directly from the share payload, then keep it live:
+  // subscribe to the public change-ping stream and refetch the (already
+  // category-filtered) snapshot whenever the owner edits the map. The store's
   // public actions all write back to the server, which would fail in share
-  // mode — but reading state is fine, and MapCanvas / SystemPanel select
-  // from the store the same way they would in normal use.
+  // mode — but reading state is fine, and MapCanvas / SystemPanel select from
+  // the store the same way they would in normal use.
   useEffect(() => {
     let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(`/api/share/${encodeURIComponent(token)}`);
-        const body = await res.json().catch(() => ({}));
-        if (cancelled) return;
+    let es: EventSource | null = null;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
 
-        if (res.status === 410) { setState({ kind: 'expired',   payload: body as ExpiredPayload }); return; }
-        if (res.status === 404) { setState({ kind: 'not_found' }); return; }
-        if (!res.ok)             { setState({ kind: 'not_found' }); return; }
-
-        const payload = body as SharePayload;
-        useMapStore.setState({
+    function applyToStore(payload: SharePayload, isInitial: boolean) {
+      useMapStore.setState((prev) => {
+        // On a live refetch, keep the viewer's open system panel if that system
+        // still exists; drop it if it was removed.
+        const keepSel =
+          !isInitial && !!prev.selectedSystemId && payload.systems.some((s) => s.id === prev.selectedSystemId);
+        return {
           map: {
             id:                     'shared',
             name:                   payload.mapName,
@@ -81,7 +81,7 @@ export function SharedMapView({ token }: { token: string }) {
             locked:                 true,
             systems:                payload.systems,
             connections:            payload.connections,
-            createdAt:              new Date().toISOString(),
+            createdAt:              isInitial ? new Date().toISOString() : prev.map.createdAt,
             updatedAt:              payload.expiresAt,
             // Carry the link's category flags onto the map so panels
             // (SystemPanel tab filter, StructuresPane, NotesEditor) can
@@ -91,18 +91,49 @@ export function SharedMapView({ token }: { token: string }) {
             shareIncludeNotes:      payload.includeNotes,
             shareIncludeStructures: payload.includeStructures,
           },
-          activeMapId:        'shared',
-          selectedSystemId:   null,
-          selectedConnectionId: null,
-          currentSystemId:    null,
-          undoStack:          [],
-        });
+          activeMapId:          'shared',
+          selectedSystemId:     keepSel ? prev.selectedSystemId : null,
+          ...(isInitial ? { selectedConnectionId: null, currentSystemId: null, undoStack: [] } : {}),
+        };
+      });
+    }
+
+    async function load(isInitial: boolean) {
+      try {
+        const res = await fetch(`/api/share/${encodeURIComponent(token)}`);
+        const body = await res.json().catch(() => ({}));
+        if (cancelled) return;
+
+        if (res.status === 410) { setState({ kind: 'expired', payload: body as ExpiredPayload }); es?.close(); return; }
+        if (res.status === 404 || !res.ok) { setState({ kind: 'not_found' }); es?.close(); return; }
+
+        const payload = body as SharePayload;
+        applyToStore(payload, isInitial);
         setState({ kind: 'valid', payload });
+        if (isInitial) openStream();
       } catch {
-        if (!cancelled) setState({ kind: 'not_found' });
+        // A failed live refetch is transient — keep showing the last snapshot.
+        if (isInitial && !cancelled) setState({ kind: 'not_found' });
       }
-    })();
-    return () => { cancelled = true; };
+    }
+
+    function openStream() {
+      if (cancelled) return;
+      es = new EventSource(`/api/share/${encodeURIComponent(token)}/events`);
+      es.onmessage = () => {
+        // Coalesce bursts (a paste of many sigs, a merge) into one refetch.
+        if (debounce) clearTimeout(debounce);
+        debounce = setTimeout(() => { void load(false); }, 600);
+      };
+      // EventSource reconnects on its own after a drop; nothing to do on error.
+    }
+
+    void load(true);
+    return () => {
+      cancelled = true;
+      if (debounce) clearTimeout(debounce);
+      es?.close();
+    };
   }, [token]);
 
   if (state.kind === 'loading') {


### PR DESCRIPTION
**Bug:** the public **Live Map Broadcast** view (`/#/share/<token>`) loaded the snapshot once and never subscribed to anything — so it never updated live, for systems or anything else (the reporter noticed it adding systems).

## Fix
Make the shared view live, **without ever sending it intel the link excludes.**

- **`mapEvents.ts`** — add a callback subscription (`onMapEvent`) alongside the existing SSE-response subscribers, and fire callbacks from `publishToMap` even when no owner is holding an SSE response open.
- **`share.ts`** — new `GET /api/share/:token/events`: a token-authorised SSE stream that emits a **content-free `{"type":"changed"}` ping** on each non-presence event. It never forwards event payloads.
- **`SharedMapView`** — subscribe to that stream and, on a ping, **debounced-refetch** the snapshot (`GET /api/share/:token`) and re-hydrate the store, preserving the viewer's open system panel.

## Why ping + refetch (privacy)
All the `includeSigs/bridges/notes/structures` filtering already lives in the snapshot endpoint. By sending only a "something changed" signal and refetching the *filtered* snapshot, a public client can **never** receive excluded sigs/notes/structures/bridges — there's no payload to leak. It also makes the *whole* view live (systems, connections, sigs, structures, bulk merges), not just systems. Presence events are skipped so heartbeats don't trigger needless refetches.

## Verification
Smoke-tested end-to-end against a live DB:
- Open the share events stream → `: connected`.
- Edit the map (POST a signature via a write key) → stream emits exactly `data: {"type":"changed"}` — **no payload**.
- Refetched snapshot contains the new sig.
- Bad token → 404.

`tsc` (server + web), `eslint`, `yarn build` clean. Worth a quick browser check: open a share link in another window, edit the owner map, watch it update.