### PR TITLE
Release v1.2.2

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2675,10 +2675,14 @@
      the 4-square min-height floor (added for map-generation spacing) kept the
      node a fixed 80px tall, leaving empty space below the content. Opt compact
      nodes out of the floor so they hug their reduced content again — the
-     behaviour before the floor existed. Uniform sizing still wins via its
-     inline min-height when both are on. */
+     behaviour before the floor existed. Also drop the width floor by 2 grid
+     squares (160px → 120px, i.e. 8 → 6 squares) so compact nodes are narrower
+     too; still a snap-grid multiple, and content wider than that still grows
+     the node. Uniform sizing still wins via its inline min-width/height when
+     both modes are on. */
   &.system-node--compact {
     min-height: 0;
+    min-width: 120px;
   }
 
   &:hover {


### PR DESCRIPTION
Batch \`release\` → \`main\` for **v1.2.2** (patch).

## Changes since v1.2.1
- **Compact mode** narrows system nodes by 2 grid squares (`min-width` 160px → 120px) (#235).
- Version bump: \`server/\` + \`web/\` \`package.json\` → \`1.2.2\`.

After this merges, I'll cut the **v1.2.2** GitHub release on \`main\`.