### PR TITLE
Fix compact/uniform node-size ratchet on toggle

### DIFF
--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -622,6 +622,12 @@ export const useMapStore = create<MapStore>()((set, get) => {
 
     setCompactMode: (v) => {
       set({ compactMode: v });
+      // Compact mode changes every node's natural size, so the cached
+      // measurements (and the uniform-size max derived from them) are stale.
+      // Without this, uniform mode ratchets up: toggling compact off grows the
+      // nodes, and the inflated min keeps them measuring big when compact comes
+      // back on. Reset forces a clean re-measure of the natural sizes.
+      get().resetUniformSizes();
       api('/auth/preferences', { method: 'PATCH', body: JSON.stringify({ compactMode: v }) }).catch(console.error);
     },
 
@@ -637,6 +643,9 @@ export const useMapStore = create<MapStore>()((set, get) => {
 
     setShowStatics: (v) => {
       set({ showStatics: v });
+      // Same as compact mode: showing/hiding statics changes WH nodes' natural
+      // height (and which nodes count toward the uniform max), so re-measure.
+      get().resetUniformSizes();
       api('/auth/preferences', { method: 'PATCH', body: JSON.stringify({ showStatics: v }) }).catch(console.error);
     },
 


### PR DESCRIPTION
**Bug:** with **Uniform node size** on, toggling compact mode off then back on grows every node by a grid square each cycle (4 → 5 → …), leaving the empty space seen in earlier screenshots.

## Root cause
`SystemNode`'s `ResizeObserver` measures the **same `.system-node` element** that uniform mode applies an inline `min-width`/`min-height` to, and reports the **border-box** (which includes that applied min). So the uniform max can only ratchet **up**:
- Toggle compact **off** → content grows → uniform grows to match.
- Toggle compact **on** → content shrinks, but the still-applied (bigger) min keeps the measured border-box big → uniform never shrinks back.

## Fix
The store already has `resetUniformSizes()` — it unclamps every node for one render, lets the ResizeObserver re-fire with the **natural** sizes, rebuilds the max, and reapplies the clamp. It's already called when font scaling changes natural sizes. `compactMode` and `showStatics` change natural sizes the exact same way but never called it — so `setCompactMode` and `setShowStatics` now do. Each toggle re-measures cleanly, so compact always settles at the compact max regardless of toggle history. Harmless when uniform mode is off (the reset just clears unused measurements).

`tsc` / `eslint` / `yarn build` clean. Worth a quick check: uniform size on → toggle compact off/on a few times → nodes stay the same size.