### PR TITLE
Auto-spread nodes when compact mode is turned off

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -130,6 +130,8 @@ export function MapCanvas() {
   const undo                 = useMapStore((s) => s.undo);
   const autoLayoutPending    = useMapStore((s) => s.autoLayoutPending);
   const clearAutoLayoutPending = useMapStore((s) => s.clearAutoLayoutPending);
+  const requestAutoLayout    = useMapStore((s) => s.requestAutoLayout);
+  const compactMode          = useMapStore((s) => s.compactMode);
   const fitViewPending       = useMapStore((s) => s.fitViewPending);
   const clearFitView         = useMapStore((s) => s.clearFitView);
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
@@ -411,6 +413,21 @@ export function MapCanvas() {
       return () => cancelAnimationFrame(raf);
     }
   }, [selectedSystemId, centerOnSystem]);
+
+  // Turning compact mode OFF grows every node, which can leave them overlapping.
+  // Auto-run the same spread the sidebar button triggers — but only after a
+  // beat, so React Flow has re-measured the now-larger nodes (otherwise overlap
+  // detection runs on the stale, smaller compact sizes). Edit-only, since spread
+  // moves and persists node positions. Fires only on the on→off transition.
+  const prevCompact = useRef(compactMode);
+  useEffect(() => {
+    const was = prevCompact.current;
+    prevCompact.current = compactMode;
+    if (was && !compactMode && canEdit) {
+      const t = setTimeout(() => requestAutoLayout(), 200);
+      return () => clearTimeout(t);
+    }
+  }, [compactMode, canEdit, requestAutoLayout]);
 
   useEffect(() => {
     if (!autoLayoutPending) return;


### PR DESCRIPTION
Turning **compact mode off** grows every node, which can leave them overlapping. This auto-runs the same overlap **spread** the sidebar button triggers, on the compact **on → off** transition — no need to hit the button manually each time.

## Details
- **Waits ~200ms** before spreading so React Flow re-measures the now-larger nodes; otherwise overlap detection would run on the stale, smaller compact sizes and under-spread.
- **Edit-only** (`canEdit`) — spread moves and persists node positions, so it's gated like the manual button; readonly/shared viewers toggling compact won't move anything.
- **No-op when nothing overlaps** — the existing spread filters to actually-moved nodes and pushes no undo if none move, so a well-spaced map is left untouched.
- Fires only on the **on→off** edge (not on→on, not on load), and the move is **undoable** (same batch undo as the manual spread).

Reuses the existing `requestAutoLayout` → `autoLayoutPending` path, so behaviour (snap-to-grid output, undo, live-sync to other viewers) is identical to clicking *Spread nodes*.

`tsc` / `eslint` / `yarn build` clean.

Heads-up worth noting: because compact mode is a *per-user* preference but spread mutates *shared* positions, one viewer toggling compact off will (if there's overlap) rearrange the map for everyone — same as them clicking the spread button, just automatic. Flagging in case that's not desired for corp maps.