### PR TITLE
Release v1.2.4

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,13 @@ import { useIdleLock } from './hooks/useIdleLock';
 import { LockScreen } from './components/ui/LockScreen';
 import './App.css';
 
+// Which signed-in user we've already hydrated prefs/settings for. MapApp
+// unmounts when you navigate away (e.g. to /admin) and re-mounts on return;
+// hydration must happen once per login, NOT on every mount, or the re-mount
+// would re-seed from the stale login-time user object and wipe any preference
+// changed in-session. Module-scoped so it survives MapApp unmount/remount.
+let hydratedForUserId: number | null = null;
+
 function MapApp() {
   const { user } = useAuth();
   const mapId               = useMapStore((s) => s.map.id);
@@ -59,13 +66,23 @@ function MapApp() {
   const userId = user?.id;
 
   useEffect(() => {
+    // Seed prefs/settings from the login-time user ONCE per signed-in user.
+    // Re-running on a MapApp re-mount (navigating to /admin and back) would
+    // re-apply the stale login-time values and clobber anything the user
+    // changed in-session — the reported "options reset on return" bug.
     if (user) {
-      applyPreferences({ compactMode: user.compactMode, snapToGrid: user.snapToGrid, showMinimap: user.showMinimap, uniformSize: user.uniformSize, showStatics: user.showStatics, connectionThickness: user.connectionThickness, routeMode: user.routeMode, uiZoom: user.uiZoom, panelOrder: user.panelOrder });
-      seedUserSettings(user.uiSettings ?? {});
-      // Push the now-canonical trackJumps from the hydrated user-settings
-      // cache into the map store. (mapStore's init runs before /auth/me
-      // resolves, so it pulled from localStorage only.)
-      useMapStore.setState({ trackJumps: readUserSetting<boolean>('nexum.trackJumps', true) });
+      if (hydratedForUserId !== user.id) {
+        hydratedForUserId = user.id;
+        applyPreferences({ compactMode: user.compactMode, snapToGrid: user.snapToGrid, showMinimap: user.showMinimap, uniformSize: user.uniformSize, showStatics: user.showStatics, connectionThickness: user.connectionThickness, routeMode: user.routeMode, uiZoom: user.uiZoom, panelOrder: user.panelOrder });
+        seedUserSettings(user.uiSettings ?? {});
+        // Push the now-canonical trackJumps from the hydrated user-settings
+        // cache into the map store. (mapStore's init runs before /auth/me
+        // resolves, so it pulled from localStorage only.)
+        useMapStore.setState({ trackJumps: readUserSetting<boolean>('nexum.trackJumps', true) });
+      }
+    } else {
+      // Logged out — allow the next login (even the same user) to re-hydrate.
+      hydratedForUserId = null;
     }
     loadMaps();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -130,6 +130,8 @@ export function MapCanvas() {
   const undo                 = useMapStore((s) => s.undo);
   const autoLayoutPending    = useMapStore((s) => s.autoLayoutPending);
   const clearAutoLayoutPending = useMapStore((s) => s.clearAutoLayoutPending);
+  const requestAutoLayout    = useMapStore((s) => s.requestAutoLayout);
+  const compactMode          = useMapStore((s) => s.compactMode);
   const fitViewPending       = useMapStore((s) => s.fitViewPending);
   const clearFitView         = useMapStore((s) => s.clearFitView);
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
@@ -411,6 +413,21 @@ export function MapCanvas() {
       return () => cancelAnimationFrame(raf);
     }
   }, [selectedSystemId, centerOnSystem]);
+
+  // Turning compact mode OFF grows every node, which can leave them overlapping.
+  // Auto-run the same spread the sidebar button triggers — but only after a
+  // beat, so React Flow has re-measured the now-larger nodes (otherwise overlap
+  // detection runs on the stale, smaller compact sizes). Edit-only, since spread
+  // moves and persists node positions. Fires only on the on→off transition.
+  const prevCompact = useRef(compactMode);
+  useEffect(() => {
+    const was = prevCompact.current;
+    prevCompact.current = compactMode;
+    if (was && !compactMode && canEdit) {
+      const t = setTimeout(() => requestAutoLayout(), 200);
+      return () => clearTimeout(t);
+    }
+  }, [compactMode, canEdit, requestAutoLayout]);
 
   useEffect(() => {
     if (!autoLayoutPending) return;


### PR DESCRIPTION
Batch \`release\` → \`main\` for **v1.2.4** (patch).

## Changes since v1.2.3
- **Auto-spread on compact-off** — turning compact mode off auto-runs the overlap spread so the now-larger nodes don't collide (no-op when nothing overlaps; edit-only; undoable) (#240).
- Version bump → \`1.2.4\`.

After this merges, I'll cut the **v1.2.4** GitHub release on \`main\`.