### PR TITLE
Fix preferences resetting when returning to the map

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,13 @@ import { useIdleLock } from './hooks/useIdleLock';
 import { LockScreen } from './components/ui/LockScreen';
 import './App.css';
 
+// Which signed-in user we've already hydrated prefs/settings for. MapApp
+// unmounts when you navigate away (e.g. to /admin) and re-mounts on return;
+// hydration must happen once per login, NOT on every mount, or the re-mount
+// would re-seed from the stale login-time user object and wipe any preference
+// changed in-session. Module-scoped so it survives MapApp unmount/remount.
+let hydratedForUserId: number | null = null;
+
 function MapApp() {
   const { user } = useAuth();
   const mapId               = useMapStore((s) => s.map.id);
@@ -59,13 +66,23 @@ function MapApp() {
   const userId = user?.id;
 
   useEffect(() => {
+    // Seed prefs/settings from the login-time user ONCE per signed-in user.
+    // Re-running on a MapApp re-mount (navigating to /admin and back) would
+    // re-apply the stale login-time values and clobber anything the user
+    // changed in-session — the reported "options reset on return" bug.
     if (user) {
-      applyPreferences({ compactMode: user.compactMode, snapToGrid: user.snapToGrid, showMinimap: user.showMinimap, uniformSize: user.uniformSize, showStatics: user.showStatics, connectionThickness: user.connectionThickness, routeMode: user.routeMode, uiZoom: user.uiZoom, panelOrder: user.panelOrder });
-      seedUserSettings(user.uiSettings ?? {});
-      // Push the now-canonical trackJumps from the hydrated user-settings
-      // cache into the map store. (mapStore's init runs before /auth/me
-      // resolves, so it pulled from localStorage only.)
-      useMapStore.setState({ trackJumps: readUserSetting<boolean>('nexum.trackJumps', true) });
+      if (hydratedForUserId !== user.id) {
+        hydratedForUserId = user.id;
+        applyPreferences({ compactMode: user.compactMode, snapToGrid: user.snapToGrid, showMinimap: user.showMinimap, uniformSize: user.uniformSize, showStatics: user.showStatics, connectionThickness: user.connectionThickness, routeMode: user.routeMode, uiZoom: user.uiZoom, panelOrder: user.panelOrder });
+        seedUserSettings(user.uiSettings ?? {});
+        // Push the now-canonical trackJumps from the hydrated user-settings
+        // cache into the map store. (mapStore's init runs before /auth/me
+        // resolves, so it pulled from localStorage only.)
+        useMapStore.setState({ trackJumps: readUserSetting<boolean>('nexum.trackJumps', true) });
+      }
+    } else {
+      // Logged out — allow the next login (even the same user) to re-hydrate.
+      hydratedForUserId = null;
     }
     loadMaps();
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
**Bug:** set System Options (e.g. all off), navigate to `/admin/users`, return to the map — the options are reset.

## Root cause
`MapApp`'s mount effect re-seeds prefs from the **login-time `user` object** on **every mount**:
```ts
applyPreferences({ compactMode: user.compactMode, ... });
seedUserSettings(user.uiSettings ?? {});
```
Navigating to `/admin` unmounts `MapApp`; returning re-mounts it, so the effect re-applies the **stale login snapshot** and clobbers anything changed in-session. The `[userId]` dep only makes it once-per-login *within one mounted instance* — a fresh mount runs it again. This affected the System Options preference columns (compact / uniform / show-statics) **and every `ui_settings`-backed pref** (notification toggles, proximity/stale thresholds, etc.).

## Fix
Guard hydration with a module-scoped `hydratedForUserId` so prefs/settings seed **once per signed-in user**, not per mount; reset it on logout so the next login re-hydrates. The in-memory store + settings cache (which already hold the user's latest changes, synced to the server by the setters) are left untouched on re-mount.

No cross-device regression — navigation never re-fetched `/auth/me`, so the `user` object was always the login snapshot regardless.

`tsc` / `eslint` / `yarn build` clean. Manual check: change some System Options + a notification toggle → go to /admin → return → settings preserved.

## Separate, smaller gap (not fixed here)
`setEasyConnect` doesn't persist at all (no `/auth/preferences` write), so Easy Connect resets on a full reload (it survives navigation via the store). It's not part of this navigation-revert bug — flagging it; happy to fix separately (needs a server column + migration).