### PR TITLE
Release v1.2.5

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -38,6 +38,7 @@ export async function migrate() {
     ALTER TABLE users ADD COLUMN IF NOT EXISTS snap_to_grid  BOOLEAN NOT NULL DEFAULT FALSE;
     ALTER TABLE users ADD COLUMN IF NOT EXISTS show_minimap  BOOLEAN NOT NULL DEFAULT TRUE;
     ALTER TABLE users ADD COLUMN IF NOT EXISTS uniform_size  BOOLEAN NOT NULL DEFAULT TRUE;
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS easy_connect  BOOLEAN NOT NULL DEFAULT FALSE;
 
     -- One-time: uniform_size shipped with a FALSE default originally;
     -- product decision later was that ON should be the out-of-the-box

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -275,8 +275,8 @@ authRouter.get('/callback', async (req, res) => {
     await seedDemoMap(userId);
 
     // Snapshot prefs into the session so /auth/me can answer without a DB call.
-    const prefRows = await db.query<{ compact_mode: boolean; snap_to_grid: boolean; show_minimap: boolean; uniform_size: boolean; show_statics: boolean; connection_thickness: string; route_mode: string; ui_zoom: string; ui_settings: Record<string, unknown>; panel_order: string[] }>(
-      `SELECT compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics, connection_thickness, route_mode, ui_zoom, ui_settings, panel_order FROM users WHERE id = $1`,
+    const prefRows = await db.query<{ compact_mode: boolean; snap_to_grid: boolean; show_minimap: boolean; uniform_size: boolean; show_statics: boolean; easy_connect: boolean; connection_thickness: string; route_mode: string; ui_zoom: string; ui_settings: Record<string, unknown>; panel_order: string[] }>(
+      `SELECT compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics, easy_connect, connection_thickness, route_mode, ui_zoom, ui_settings, panel_order FROM users WHERE id = $1`,
       [userId],
     );
     const p = prefRows.rows[0];
@@ -299,6 +299,7 @@ authRouter.get('/callback', async (req, res) => {
       showMinimap: p?.show_minimap ?? true,
       uniformSize: p?.uniform_size ?? true,
       showStatics: p?.show_statics ?? true,
+      easyConnect: p?.easy_connect ?? false,
       connectionThickness: p?.connection_thickness ?? 'standard',
       routeMode:   p?.route_mode ?? 'shortest',
       uiZoom:      p?.ui_zoom != null ? Number(p.ui_zoom) : 1,
@@ -340,11 +341,11 @@ authRouter.post('/switch-character', async (req, res) => {
     owner_id: number | null; character_id: number; character_name: string; role: string;
     corp_id: number | null; blocked: boolean;
     compact_mode: boolean; snap_to_grid: boolean; show_minimap: boolean; uniform_size: boolean;
-    show_statics: boolean; connection_thickness: string; route_mode: string; ui_zoom: string;
+    show_statics: boolean; easy_connect: boolean; connection_thickness: string; route_mode: string; ui_zoom: string;
     ui_settings: Record<string, unknown>; panel_order: string[];
   }>(
     `SELECT owner_id, character_id, character_name, role, corp_id, blocked,
-            compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics,
+            compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics, easy_connect,
             connection_thickness, route_mode, ui_zoom, ui_settings, panel_order
      FROM users WHERE id = $1`,
     [targetId],
@@ -365,6 +366,7 @@ authRouter.post('/switch-character', async (req, res) => {
     showMinimap: u.show_minimap ?? true,
     uniformSize: u.uniform_size ?? true,
     showStatics: u.show_statics ?? true,
+    easyConnect: u.easy_connect ?? false,
     connectionThickness: u.connection_thickness ?? 'standard',
     routeMode:   u.route_mode ?? 'shortest',
     uiZoom:      u.ui_zoom != null ? Number(u.ui_zoom) : 1,
@@ -409,8 +411,8 @@ authRouter.get('/me', async (req, res) => {
   let prefs = req.session.prefs;
   let role  = req.session.role ?? 'readonly';
   if (!prefs) {
-    const { rows } = await db.query<{ compact_mode: boolean; snap_to_grid: boolean; show_minimap: boolean; uniform_size: boolean; show_statics: boolean; connection_thickness: string; route_mode: string; ui_zoom: string; ui_settings: Record<string, unknown>; panel_order: string[]; role: string }>(
-      `SELECT compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics, connection_thickness, route_mode, ui_zoom, ui_settings, panel_order, role FROM users WHERE id = $1`,
+    const { rows } = await db.query<{ compact_mode: boolean; snap_to_grid: boolean; show_minimap: boolean; uniform_size: boolean; show_statics: boolean; easy_connect: boolean; connection_thickness: string; route_mode: string; ui_zoom: string; ui_settings: Record<string, unknown>; panel_order: string[]; role: string }>(
+      `SELECT compact_mode, snap_to_grid, show_minimap, uniform_size, show_statics, easy_connect, connection_thickness, route_mode, ui_zoom, ui_settings, panel_order, role FROM users WHERE id = $1`,
       [req.session.userId],
     );
     const row = rows[0];
@@ -420,6 +422,7 @@ authRouter.get('/me', async (req, res) => {
       showMinimap: row?.show_minimap ?? true,
       uniformSize: row?.uniform_size ?? true,
       showStatics: row?.show_statics ?? true,
+      easyConnect: row?.easy_connect ?? false,
       connectionThickness: row?.connection_thickness ?? 'standard',
       routeMode:   row?.route_mode ?? 'shortest',
       uiZoom:      row?.ui_zoom != null ? Number(row.ui_zoom) : 1,
@@ -489,6 +492,7 @@ authRouter.get('/me', async (req, res) => {
       // prefs object on disk doesn't carry it, so the literal value would
       // be undefined and the UI would mistakenly read it as "off".
       showStatics:   prefs.showStatics ?? true,
+      easyConnect:   prefs.easyConnect ?? false,
       connectionThickness: prefs.connectionThickness ?? 'standard',
       routeMode:     prefs.routeMode ?? 'shortest',
       uiZoom:        prefs.uiZoom ?? 1,
@@ -505,7 +509,7 @@ const MAX_PANEL_KEY_LEN = 64;
 
 authRouter.patch('/preferences', async (req, res) => {
   if (!req.session.userId) { res.status(401).json({ error: 'Not authenticated' }); return; }
-  const { compactMode, snapToGrid, showMinimap, uniformSize, showStatics, connectionThickness, routeMode, uiZoom, panelOrder } = req.body as { compactMode?: boolean; snapToGrid?: boolean; showMinimap?: boolean; uniformSize?: boolean; showStatics?: boolean; connectionThickness?: string; routeMode?: string; uiZoom?: number; panelOrder?: unknown };
+  const { compactMode, snapToGrid, showMinimap, uniformSize, showStatics, easyConnect, connectionThickness, routeMode, uiZoom, panelOrder } = req.body as { compactMode?: boolean; snapToGrid?: boolean; showMinimap?: boolean; uniformSize?: boolean; showStatics?: boolean; easyConnect?: boolean; connectionThickness?: string; routeMode?: string; uiZoom?: number; panelOrder?: unknown };
   const VALID_THICKNESS = new Set(['thin', 'standard', 'thick', 'extra']);
   const VALID_ROUTE_MODE = new Set(['shortest', 'secure']);
 
@@ -516,6 +520,7 @@ authRouter.patch('/preferences', async (req, res) => {
   if (typeof showMinimap === 'boolean') { sets.push(`show_minimap = $${vals.length + 1}`); vals.push(showMinimap); }
   if (typeof uniformSize === 'boolean') { sets.push(`uniform_size = $${vals.length + 1}`); vals.push(uniformSize); }
   if (typeof showStatics === 'boolean') { sets.push(`show_statics = $${vals.length + 1}`); vals.push(showStatics); }
+  if (typeof easyConnect === 'boolean') { sets.push(`easy_connect = $${vals.length + 1}`); vals.push(easyConnect); }
   if (typeof connectionThickness === 'string' && VALID_THICKNESS.has(connectionThickness)) {
     sets.push(`connection_thickness = $${vals.length + 1}`); vals.push(connectionThickness);
   }
@@ -549,6 +554,7 @@ authRouter.patch('/preferences', async (req, res) => {
     if (typeof showMinimap === 'boolean') req.session.prefs.showMinimap = showMinimap;
     if (typeof uniformSize === 'boolean') req.session.prefs.uniformSize = uniformSize;
     if (typeof showStatics === 'boolean') req.session.prefs.showStatics = showStatics;
+    if (typeof easyConnect === 'boolean') req.session.prefs.easyConnect = easyConnect;
     if (typeof connectionThickness === 'string' && VALID_THICKNESS.has(connectionThickness)) {
       req.session.prefs.connectionThickness = connectionThickness;
     }

--- a/server/src/session.d.ts
+++ b/server/src/session.d.ts
@@ -23,6 +23,7 @@ declare module 'express-session' {
       showMinimap: boolean;
       uniformSize: boolean;
       showStatics: boolean;
+      easyConnect: boolean;
       connectionThickness: string;
       routeMode: string;
       uiZoom: number;

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -73,7 +73,7 @@ function MapApp() {
     if (user) {
       if (hydratedForUserId !== user.id) {
         hydratedForUserId = user.id;
-        applyPreferences({ compactMode: user.compactMode, snapToGrid: user.snapToGrid, showMinimap: user.showMinimap, uniformSize: user.uniformSize, showStatics: user.showStatics, connectionThickness: user.connectionThickness, routeMode: user.routeMode, uiZoom: user.uiZoom, panelOrder: user.panelOrder });
+        applyPreferences({ compactMode: user.compactMode, snapToGrid: user.snapToGrid, showMinimap: user.showMinimap, uniformSize: user.uniformSize, showStatics: user.showStatics, easyConnect: user.easyConnect, connectionThickness: user.connectionThickness, routeMode: user.routeMode, uiZoom: user.uiZoom, panelOrder: user.panelOrder });
         seedUserSettings(user.uiSettings ?? {});
         // Push the now-canonical trackJumps from the hydrated user-settings
         // cache into the map store. (mapStore's init runs before /auth/me

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -39,6 +39,7 @@ export interface AuthUser {
   showMinimap: boolean;
   uniformSize: boolean;
   showStatics: boolean;
+  easyConnect: boolean;
   connectionThickness: string;
   routeMode: string;
   uiZoom: number;

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -184,7 +184,7 @@ interface MapStore {
   undo: () => Promise<void>;
 
   panelOrder: string[];
-  applyPreferences: (prefs: { compactMode: boolean; snapToGrid: boolean; showMinimap: boolean; uniformSize: boolean; showStatics: boolean; connectionThickness: string; routeMode: string; uiZoom: number; panelOrder: string[] }) => void;
+  applyPreferences: (prefs: { compactMode: boolean; snapToGrid: boolean; showMinimap: boolean; uniformSize: boolean; showStatics: boolean; easyConnect: boolean; connectionThickness: string; routeMode: string; uiZoom: number; panelOrder: string[] }) => void;
   setPanelOrder: (order: string[]) => void;
   setShowMinimap: (v: boolean) => void;
   setUniformSize: (v: boolean) => void;
@@ -477,7 +477,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
       await applyUndo(cmd);
     },
 
-    applyPreferences: ({ compactMode, snapToGrid, showMinimap, uniformSize, showStatics, connectionThickness, routeMode, uiZoom, panelOrder }) => {
+    applyPreferences: ({ compactMode, snapToGrid, showMinimap, uniformSize, showStatics, easyConnect, connectionThickness, routeMode, uiZoom, panelOrder }) => {
       // Whitelist of valid panel keys. `standings` was briefly a panel here
       // — kept in the filter so any persisted occurrence is silently
       // dropped on load now that standings live inline in the sov section.
@@ -491,7 +491,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
       const VALID_ROUTE = new Set(['shortest', 'secure']);
       const safeRouteMode = (VALID_ROUTE.has(routeMode) ? routeMode : 'shortest') as 'shortest' | 'secure';
       const safeZoom = Number.isFinite(uiZoom) ? Math.min(1.5, Math.max(0.8, uiZoom)) : 1;
-      set({ compactMode, snapToGrid, showMinimap, uniformSize, showStatics, connectionThickness: safeThickness, routeMode: safeRouteMode, uiZoom: safeZoom, panelOrder: merged });
+      set({ compactMode, snapToGrid, showMinimap, uniformSize, showStatics, easyConnect, connectionThickness: safeThickness, routeMode: safeRouteMode, uiZoom: safeZoom, panelOrder: merged });
     },
 
     setPanelOrder: (order) => {
@@ -708,7 +708,10 @@ export const useMapStore = create<MapStore>()((set, get) => {
       }
     },
 
-    setEasyConnect: (v) => set({ easyConnect: v }),
+    setEasyConnect: (v) => {
+      set({ easyConnect: v });
+      api('/auth/preferences', { method: 'PATCH', body: JSON.stringify({ easyConnect: v }) }).catch(console.error);
+    },
     setMapOptionsOpen: (v) => set({ mapOptionsOpen: v }),
     setEdgeStyle: (v) => set({ edgeStyle: v }),
     requestAutoLayout: () => set({ autoLayoutPending: true }),


### PR DESCRIPTION
Batch \`release\` → \`main\` for **v1.2.5** (patch).

## Changes since v1.2.4
- **Persist Easy Connect** — the Easy Connect System Option now saves and survives a reload like the other toggles (was the only one that didn't) (#243).
- Version bump → \`1.2.5\`.

After this merges, I'll cut the **v1.2.5** GitHub release on \`main\`.