### PR TITLE
Ignore local docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ server/data/*.zip
 .claude/
 
 changes.md
+
+# Local-only Compose overrides (e.g. publishing Postgres to the host for yarn-dev)
+docker-compose.override.yml


### PR DESCRIPTION
Adds `docker-compose.override.yml` to `.gitignore`.

It's a **local-only** Compose override (created during the DB-port troubleshooting) that publishes Postgres to the host so a host-run `yarn dev` can reach it at `localhost:5432`. The base `docker-compose.yml` deliberately keeps Postgres internal-only (the dockerised server reaches it over the compose network), so this override must **never** ship — gitignoring it prevents an accidental commit that would expose the DB port in production / other devs' setups.

No code change. Will fold into the next release batch whenever convenient.