### PR TITLE
Release v1.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ server/data/*.zip
 .claude/
 
 changes.md
+
+# Local-only Compose overrides (e.g. publishing Postgres to the host for yarn-dev)
+docker-compose.override.yml

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -634,13 +634,32 @@ reportsRouter.get('/users', async (req, res) => {
       WHERE ${corpSql} AND s.created_by_user_id IS NOT NULL
       GROUP BY s.created_by_user_id
     ),
-    last_corp_struct AS (
-      SELECT st.created_by_user_id AS user_id, MAX(st.created_at) AS ts, COUNT(*)::int AS cnt
-      FROM map_structures st
-      JOIN map_systems sys ON sys.id = st.system_id
-      JOIN maps         m  ON m.id   = sys.map_id
-      WHERE ${corpSql} AND st.created_by_user_id IS NOT NULL
-      GROUP BY st.created_by_user_id
+    -- "Last active" = the most recent time a user did something of value on a
+    -- corp map: added or edited a signature, anomaly, or structure. Combined
+    -- with the user's last system-to-system move (last_known_system_at) in the
+    -- SELECT below. GREATEST(created_at, updated_at) per row catches edits, not
+    -- just the original add.
+    last_active AS (
+      SELECT user_id, MAX(ts) AS ts FROM (
+        SELECT s.created_by_user_id AS user_id, GREATEST(s.created_at, s.updated_at) AS ts
+          FROM reportable_signatures s
+          JOIN map_systems sys ON sys.id = s.system_id
+          JOIN maps         m  ON m.id   = sys.map_id
+          WHERE ${corpSql} AND s.created_by_user_id IS NOT NULL
+        UNION ALL
+        SELECT a.created_by_user_id, GREATEST(a.created_at, a.updated_at)
+          FROM map_anomalies a
+          JOIN map_systems sys ON sys.id = a.system_id
+          JOIN maps         m  ON m.id   = sys.map_id
+          WHERE ${corpSql} AND a.created_by_user_id IS NOT NULL
+        UNION ALL
+        SELECT st.created_by_user_id, GREATEST(st.created_at, st.updated_at)
+          FROM map_structures st
+          JOIN map_systems sys ON sys.id = st.system_id
+          JOIN maps         m  ON m.id   = sys.map_id
+          WHERE ${corpSql} AND st.created_by_user_id IS NOT NULL
+      ) acts
+      GROUP BY user_id
     ),
     sig_breakdown AS (
       -- Count live signatures (not the historical event log) so deletions
@@ -674,8 +693,7 @@ reportsRouter.get('/users', async (req, res) => {
       u.last_known_system_id AS "lastKnownSystemId",
       lks.name               AS "lastKnownSystemName",
       lcs.ts           AS "lastCorpSigAt",
-      lcst.ts          AS "lastCorpStructAt",
-      COALESCE(lcst.cnt, 0) AS "totalCorpStructures",
+      GREATEST(la.ts, u.last_known_system_at) AS "lastActive",
       COALESCE(
         (SELECT cnt FROM corp_system_events
           WHERE user_id = u.id AND event_type = 'system_add'),
@@ -694,7 +712,7 @@ reportsRouter.get('/users', async (req, res) => {
     FROM users u
     LEFT JOIN solar_systems    lks  ON lks.id       = u.last_known_system_id
     LEFT JOIN last_corp_sig    lcs  ON lcs.user_id  = u.id
-    LEFT JOIN last_corp_struct lcst ON lcst.user_id = u.id
+    LEFT JOIN last_active      la   ON la.user_id   = u.id
     ${inclusionWhere}
     ORDER BY u.character_name
   `, params);

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -605,8 +605,7 @@ interface UserReportRow {
   lastKnownSystemId:    number | null;
   lastKnownSystemName:  string | null;
   lastCorpSigAt:        string | null;
-  lastCorpStructAt:     string | null;
-  totalCorpStructures:  number;
+  lastActive:           string | null;
   systemsAdded:         number;
   systemsDeleted:       number;
   sigTypeCounts:        Record<string, number>;
@@ -624,8 +623,8 @@ const SIG_TYPE_ORDER: { key: SigTypeKey; label: string }[] = [
 ];
 
 type UserReportFixedKey =
-  | 'name' | 'corp' | 'alliance' | 'lastLogin' | 'lastKnown' | 'lastCorpSig' | 'lastCorpStruct'
-  | 'sigTotal' | 'structTotal' | 'systemsAdded' | 'systemsDeleted';
+  | 'name' | 'corp' | 'alliance' | 'lastLogin' | 'lastKnown' | 'lastActive' | 'lastCorpSig'
+  | 'sigTotal' | 'systemsAdded' | 'systemsDeleted';
 type UserReportSortKey  = UserReportFixedKey | `sig:${string}`;
 type SortDir = 'asc' | 'desc';
 
@@ -639,10 +638,9 @@ const USER_REPORT_FIXED_ACCESSORS: Record<UserReportFixedKey, (r: UserReportRow)
   alliance:       (r) => r.allianceTicker ?? (r.allianceId !== null ? String(r.allianceId) : ''),
   lastLogin:      (r) => r.lastLogin        ? new Date(r.lastLogin).getTime()        : null,
   lastKnown:      (r) => r.lastKnownSystemName?.toLowerCase() ?? null,
+  lastActive:     (r) => r.lastActive      ? new Date(r.lastActive).getTime()      : null,
   lastCorpSig:    (r) => r.lastCorpSigAt    ? new Date(r.lastCorpSigAt).getTime()    : null,
-  lastCorpStruct: (r) => r.lastCorpStructAt ? new Date(r.lastCorpStructAt).getTime() : null,
   sigTotal:       (r) => Object.values(r.sigTypeCounts).reduce((a, b) => a + b, 0),
-  structTotal:    (r) => r.totalCorpStructures,
   systemsAdded:   (r) => r.systemsAdded,
   systemsDeleted: (r) => r.systemsDeleted,
 };
@@ -725,7 +723,7 @@ function UsersReport() {
       'Character', 'Character ID', 'Corp ticker', 'Corp ID', 'Alliance ticker', 'Alliance ID', 'Role',
       'Last login (ISO)', 'Last known system',
       'Systems added', 'Systems deleted',
-      'Last corp structure (ISO)', 'Total structures',
+      'Last active (ISO)',
       'Last corp signature (ISO)', 'Total signatures',
       ...SIG_TYPE_ORDER.map((st) => st.label),
     ];
@@ -743,8 +741,7 @@ function UsersReport() {
         u.lastKnownSystemName ?? '',
         String(u.systemsAdded),
         String(u.systemsDeleted),
-        u.lastCorpStructAt ?? '',
-        String(u.totalCorpStructures),
+        u.lastActive       ?? '',
         u.lastCorpSigAt    ?? '',
         String(total),
         ...SIG_TYPE_ORDER.map((st) => String(u.sigTypeCounts[st.key] ?? 0)),
@@ -815,8 +812,7 @@ function UsersReport() {
           <SortHeader label={t('admin.reports.users.colLastKnown')}         colKey="lastKnown"      sort={sort} onSort={handleSort} />
           <SortHeader label={t('admin.reports.users.colSystemsAdded')}      colKey="systemsAdded"   sort={sort} onSort={handleSort} />
           <SortHeader label={t('admin.reports.users.colSystemsDeleted')}    colKey="systemsDeleted" sort={sort} onSort={handleSort} />
-          <SortHeader label={t('admin.reports.users.colLastCorpStructure')} colKey="lastCorpStruct" sort={sort} onSort={handleSort} />
-          <SortHeader label={t('admin.reports.users.colTotalStructures')}   colKey="structTotal"    sort={sort} onSort={handleSort} />
+          <SortHeader label={t('admin.reports.users.colLastActive')}        colKey="lastActive"     sort={sort} onSort={handleSort} />
           <SortHeader label={t('admin.reports.users.colLastCorpSignature')} colKey="lastCorpSig"    sort={sort} onSort={handleSort} />
           <SortHeader label={t('admin.reports.users.colTotalSignatures')}   colKey="sigTotal"       sort={sort} onSort={handleSort} />
           {SIG_TYPE_ORDER.map((st) => (
@@ -860,8 +856,7 @@ function UsersReport() {
               <td>{u.lastKnownSystemName ?? '—'}</td>
               <td className="admin-modal__num">{u.systemsAdded   > 0 ? u.systemsAdded   : '—'}</td>
               <td className="admin-modal__num">{u.systemsDeleted > 0 ? u.systemsDeleted : '—'}</td>
-              <td className="admin-modal__when">{u.lastCorpStructAt ? formatRelative(t, u.lastCorpStructAt) : '—'}</td>
-              <td className="admin-modal__num">{u.totalCorpStructures > 0 ? u.totalCorpStructures : '—'}</td>
+              <td className="admin-modal__when">{u.lastActive ? formatRelative(t, u.lastActive) : '—'}</td>
               <td className="admin-modal__when">{u.lastCorpSigAt ? formatRelative(t, u.lastCorpSigAt) : '—'}</td>
               <td className="admin-modal__num">{total > 0 ? total : '—'}</td>
               {SIG_TYPE_ORDER.map((st) => {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -204,8 +204,7 @@
         "colLastKnown": "Last known system",
         "colSystemsAdded": "Systems added",
         "colSystemsDeleted": "Systems deleted",
-        "colLastCorpStructure": "Last corp structure",
-        "colTotalStructures": "Total structures",
+        "colLastActive": "Last active",
         "colLastCorpSignature": "Last corp signature",
         "colTotalSignatures": "Total signatures"
       },


### PR DESCRIPTION
Batch \`release\` → \`main\` for **v1.2.6** (patch).

## Changes since v1.2.5
- **Users report: Last Active** — Reports → Users now shows a single "Last active" column (most recent sig/anom/structure add-or-edit, or last system move) in place of the "Last corp structure" and "Total structures" columns (#246).
- **Chore:** gitignore the local-only `docker-compose.override.yml` (#245).
- Version bump → \`1.2.6\`.

After this merges, I'll cut the **v1.2.6** GitHub release on \`main\`.