### PR TITLE
Wormhole type reference chart (whtype.info-style modal)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -8032,3 +8032,101 @@ select.sig-toolbar-btn option {
   position: relative;
   height: 240px;
 }
+
+/* ── Wormhole type chart (whtype.info-style reference) ─────── */
+.modal.whchart {
+  width: 94vw;
+  max-width: 1180px;
+}
+
+.whchart__body {
+  position: relative;
+  display: flex;
+  gap: 10px;
+  height: 72vh;
+  overflow: hidden;
+}
+
+/* SVG line overlay sits above the columns; never eats pointer events. */
+.whchart__lines {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.whchart__col {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.whchart__col--codes { flex: 0 0 84px; }
+.whchart__col--narrow { flex: 0 0 110px; }
+
+.whchart__col-head {
+  font-size: calc(11px * var(--font-scale, 1));
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6b7a99;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #1e2740;
+  margin-bottom: 4px;
+}
+
+.whchart__cell {
+  font-size: calc(12px * var(--font-scale, 1));
+  color: #5a6886;
+  padding: 2px 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.1s;
+}
+
+/* Highlighted target rows for the active code. */
+.whchart__cell--on {
+  color: #c8d4f0;
+  font-weight: 600;
+}
+
+.whchart__codes {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.whchart__code {
+  font-family: monospace;
+  font-size: calc(12px * var(--font-scale, 1));
+  color: #8a96b4;
+  padding: 1px 4px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.whchart__code:hover { background: #141c2e; color: #c8d4f0; }
+
+.whchart__code--active {
+  background: rgba(91,155,255,0.16);
+  color: #fff;
+  font-weight: 700;
+}
+
+.whchart__search {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 2px 5px;
+  background: #0a0e1a;
+  border: 1px solid #1e2740;
+  border-radius: 4px;
+  color: #c8d4f0;
+  font-size: calc(11px * var(--font-scale, 1));
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -8086,8 +8086,8 @@ select.sig-toolbar-btn option {
   padding-bottom: 4px;
   border-bottom: 1px solid #1e2740;
   margin-bottom: 4px;
-  /* Opaque (matches the modal) so connectors tuck behind the labels. */
-  background: #0d1117;
+  /* Solid chip, distinctly darker than the modal, so connectors tuck behind. */
+  background: #070a10;
 }
 
 .whchart__cell {
@@ -8098,9 +8098,9 @@ select.sig-toolbar-btn option {
   overflow: hidden;
   text-overflow: ellipsis;
   transition: color 0.1s;
-  /* Opaque so transiting lines are occluded by the cell box rather than drawn
-     over the glyphs — the lines only show through the gaps between cells. */
-  background: #0d1117;
+  /* Solid chip (darker than the modal) so transiting lines are occluded by the
+     cell box rather than drawn over the glyphs — lines only show in the gaps. */
+  background: #070a10;
 }
 
 /* Highlighted target rows for the active code. */
@@ -8124,8 +8124,8 @@ select.sig-toolbar-btn option {
   border-radius: 3px;
   cursor: pointer;
   break-inside: avoid;
-  /* Opaque so connectors tuck behind the codes, showing only in the gaps. */
-  background: #0d1117;
+  /* Solid chip (darker than the modal) so connectors tuck behind the codes. */
+  background: #070a10;
 }
 
 .whchart__code:hover { background: #141c2e; color: #c8d4f0; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -8049,6 +8049,9 @@ select.sig-toolbar-btn option {
   height: auto;
   max-height: 80vh;
   overflow: hidden;
+  /* Own stacking context so the SVG (z-index 0) reliably sits behind the
+     columns (z-index 1) — i.e. connector lines render under the labels. */
+  isolation: isolate;
 }
 
 /* SVG line overlay sits BEHIND the column text (z-index 0); columns are lifted

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -8042,6 +8042,9 @@ select.sig-toolbar-btn option {
 .whchart__body {
   position: relative;
   display: flex;
+  /* .modal__body defaults to column — force row so the attribute columns sit
+     side-by-side instead of stacking under the (full-width) code list. */
+  flex-direction: row;
   gap: 10px;
   height: 72vh;
   overflow: hidden;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -8046,18 +8046,20 @@ select.sig-toolbar-btn option {
      side-by-side instead of stacking under the (full-width) code list. */
   flex-direction: row;
   gap: 10px;
-  height: 72vh;
+  height: auto;
+  max-height: 80vh;
   overflow: hidden;
 }
 
-/* SVG line overlay sits above the columns; never eats pointer events. */
+/* SVG line overlay sits BEHIND the column text (z-index 0); columns are lifted
+   to z-index 1 so the connectors read as running under the labels. */
 .whchart__lines {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
-  z-index: 2;
+  z-index: 0;
 }
 
 .whchart__col {
@@ -8066,9 +8068,11 @@ select.sig-toolbar-btn option {
   gap: 2px;
   flex: 1;
   min-width: 0;
+  position: relative;
+  z-index: 1;
 }
 
-.whchart__col--codes { flex: 0 0 84px; }
+.whchart__col--codes { flex: 0 0 200px; }
 .whchart__col--narrow { flex: 0 0 110px; }
 
 .whchart__col-head {
@@ -8097,12 +8101,11 @@ select.sig-toolbar-btn option {
   font-weight: 600;
 }
 
+/* Codes flow top-to-bottom down each column (alphabetical within a column),
+   balanced across 4 columns so all ~101 fit without a scroll. */
 .whchart__codes {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  overflow-y: auto;
-  flex: 1;
+  column-count: 4;
+  column-gap: 6px;
 }
 
 .whchart__code {
@@ -8112,6 +8115,7 @@ select.sig-toolbar-btn option {
   padding: 1px 4px;
   border-radius: 3px;
   cursor: pointer;
+  break-inside: avoid;
 }
 
 .whchart__code:hover { background: #141c2e; color: #c8d4f0; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -8086,6 +8086,8 @@ select.sig-toolbar-btn option {
   padding-bottom: 4px;
   border-bottom: 1px solid #1e2740;
   margin-bottom: 4px;
+  /* Opaque (matches the modal) so connectors tuck behind the labels. */
+  background: #0d1117;
 }
 
 .whchart__cell {
@@ -8096,6 +8098,9 @@ select.sig-toolbar-btn option {
   overflow: hidden;
   text-overflow: ellipsis;
   transition: color 0.1s;
+  /* Opaque so transiting lines are occluded by the cell box rather than drawn
+     over the glyphs — the lines only show through the gaps between cells. */
+  background: #0d1117;
 }
 
 /* Highlighted target rows for the active code. */
@@ -8119,6 +8124,8 @@ select.sig-toolbar-btn option {
   border-radius: 3px;
   cursor: pointer;
   break-inside: avoid;
+  /* Opaque so connectors tuck behind the codes, showing only in the gaps. */
+  background: #0d1117;
 }
 
 .whchart__code:hover { background: #141c2e; color: #c8d4f0; }

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -19,7 +19,6 @@ import {
 } from "../../hooks/useMinimapPosition";
 import { useUserSetting } from "../../hooks/useUserSetting";
 import { NOTIFY } from "../../utils/notificationPrefs";
-import { WhTypeChartModal } from "./WhTypeChartModal";
 import { useResettableState } from "../../hooks/useResettableState";
 import { DEFAULT_BOOKMARK_FORMAT, BOOKMARK_TOKENS } from "../../utils/signatureBookmark";
 import { toPng } from "html-to-image";
@@ -546,7 +545,6 @@ export function MapSidebar() {
   // Preferences live in a Settings dialog (gear button) rather than crowding
   // the sidebar; the sidebar keeps only the live mapping tools.
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [whChartOpen, setWhChartOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<"display" | "signatures" | "shortcuts">("display");
   const notifPermission = useNotificationPermission();
   const { user } = useAuth();
@@ -825,14 +823,6 @@ export function MapSidebar() {
             </select>
           </div>
 
-          <button
-            className="map-sidebar__action"
-            onClick={() => setWhChartOpen(true)}
-            data-tooltip={t("whChart.tooltip")}
-          >
-            {t("whChart.open")}
-          </button>
-
           {!hideTopologyTools && (
             <>
               <button
@@ -1103,8 +1093,6 @@ export function MapSidebar() {
           e.target.value = "";
         }}
       />
-
-      {whChartOpen && <WhTypeChartModal onClose={() => setWhChartOpen(false)} />}
 
       {settingsOpen && createPortal(
         <div className="settings-modal__overlay" onClick={() => setSettingsOpen(false)}>

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../hooks/useMinimapPosition";
 import { useUserSetting } from "../../hooks/useUserSetting";
 import { NOTIFY } from "../../utils/notificationPrefs";
+import { WhTypeChartModal } from "./WhTypeChartModal";
 import { useResettableState } from "../../hooks/useResettableState";
 import { DEFAULT_BOOKMARK_FORMAT, BOOKMARK_TOKENS } from "../../utils/signatureBookmark";
 import { toPng } from "html-to-image";
@@ -545,6 +546,7 @@ export function MapSidebar() {
   // Preferences live in a Settings dialog (gear button) rather than crowding
   // the sidebar; the sidebar keeps only the live mapping tools.
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [whChartOpen, setWhChartOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<"display" | "signatures" | "shortcuts">("display");
   const notifPermission = useNotificationPermission();
   const { user } = useAuth();
@@ -823,6 +825,14 @@ export function MapSidebar() {
             </select>
           </div>
 
+          <button
+            className="map-sidebar__action"
+            onClick={() => setWhChartOpen(true)}
+            data-tooltip={t("whChart.tooltip")}
+          >
+            {t("whChart.open")}
+          </button>
+
           {!hideTopologyTools && (
             <>
               <button
@@ -1093,6 +1103,8 @@ export function MapSidebar() {
           e.target.value = "";
         }}
       />
+
+      {whChartOpen && <WhTypeChartModal onClose={() => setWhChartOpen(false)} />}
 
       {settingsOpen && createPortal(
         <div className="settings-modal__overlay" onClick={() => setSettingsOpen(false)}>

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -16,12 +16,13 @@ import { ApiKeysModal } from './ApiKeysModal';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { CharacterSwitcher } from './CharacterSwitcher';
 import { HeatmapMenu } from './HeatmapMenu';
+import { WhTypeChartModal } from './WhTypeChartModal';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
-  KeyIcon,
+  KeyIcon, GraphIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { charPortrait, typeIcon } from '../../utils/eveImages';
@@ -228,6 +229,7 @@ export function Toolbar() {
   const [showStats, setShowStats] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [showKeys, setShowKeys] = useState(false);
+  const [showWhChart, setShowWhChart] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
 
   async function handleDeleteMap() {
@@ -381,6 +383,15 @@ export function Toolbar() {
         <QuestionIcon size={18} weight="regular" />
       </a>
 
+      <button
+        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+        onClick={() => setShowWhChart(true)}
+        data-tooltip={t('whChart.tooltip')}
+        aria-label={t('whChart.title')}
+      >
+        <GraphIcon size={18} weight="regular" />
+      </button>
+
       <HeatmapMenu />
 
       <button
@@ -528,6 +539,7 @@ export function Toolbar() {
     {showStats && <UserStatsModal onClose={() => setShowStats(false)} />}
     {showCreate && <CreateMapModal onClose={() => setShowCreate(false)} />}
     {showKeys && <ApiKeysModal onClose={() => setShowKeys(false)} />}
+    {showWhChart && <WhTypeChartModal onClose={() => setShowWhChart(false)} />}
     {deleteConfirm && (
       <ConfirmModal
         message={t('toolbar.deleteMapConfirm', { name: mapName })}

--- a/web/src/components/ui/WhTypeChartModal.tsx
+++ b/web/src/components/ui/WhTypeChartModal.tsx
@@ -1,0 +1,190 @@
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { XIcon } from '@phosphor-icons/react';
+import { CLASS_COLORS } from '../../data/wormholes';
+import type { SystemClass } from '../../types';
+import {
+  WH_CHART, RESPAWN_ORDER, SPAWN_ORDER, LEADS_ORDER, SHIP_ORDER, MASS_ORDER, LIFE_ORDER,
+  type WhChartEntry,
+} from '../../data/whTypeChart';
+
+// A Nexum take on whtype.info: pick a wormhole code and lines light up its
+// spawn / leads-to / ship size / total mass / lifetime across the columns.
+
+interface Line { d: string; color: string; }
+
+// Map a spawn/leads label to a class colour where one exists, for the row text.
+function labelColor(label: string): string | undefined {
+  const m: Record<string, SystemClass> = {
+    'Class 1': 'C1', 'Class 2': 'C2', 'Class 3': 'C3', 'Class 4': 'C4', 'Class 5': 'C5', 'Class 6': 'C6',
+    'HighSec': 'HS', 'LowSec': 'LS', 'NullSec': 'NS', 'Class 12 - Thera': 'Thera', 'Class 13 - Shattered': 'C13',
+    'Pochven ▲ Trig space': 'Pochven',
+    C1: 'C1', C2: 'C2', C3: 'C3', C4: 'C4', C5: 'C5', C6: 'C6', HS: 'HS', LS: 'LS', NS: 'NS',
+    Thera: 'Thera', C13: 'C13', Pochven: 'Pochven',
+  };
+  const key = m[label];
+  return key ? CLASS_COLORS[key] : undefined;
+}
+
+// Colour for a whole code's line bundle — by its destination class so the eye
+// can follow it. Drifter / special dests fall back to a neutral accent.
+function lineColorFor(entry: WhChartEntry): string {
+  return labelColor(entry.leads_to[0] ?? '') ?? '#5b9bff';
+}
+
+export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const [active, setActive] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const codeListRef = useRef<HTMLDivElement | null>(null);
+  // key -> row element, for measuring line endpoints.
+  const rows = useRef<Map<string, HTMLElement>>(new Map());
+  const setRow = (key: string) => (el: HTMLElement | null) => {
+    if (el) rows.current.set(key, el); else rows.current.delete(key);
+  };
+
+  const entry = useMemo(() => WH_CHART.find((w) => w.wormhole === active) ?? null, [active]);
+
+  const codes = useMemo(() => {
+    const q = search.trim().toUpperCase();
+    return WH_CHART.filter((w) => !q || w.wormhole.toUpperCase().includes(q));
+  }, [search]);
+
+  // Which column rows the active code touches (for highlighting).
+  const activeTargets = useMemo(() => {
+    const s = new Set<string>();
+    if (!entry) return s;
+    entry.respawn.forEach((r) => s.add(`respawn:${r}`));
+    entry.spawn_in.forEach((v) => s.add(`spawn:${v}`));
+    entry.leads_to.forEach((v) => s.add(`leads:${v}`));
+    if (entry.ship_size)  s.add(`ship:${entry.ship_size}`);
+    if (entry.total_mass) s.add(`mass:${entry.total_mass}`);
+    if (entry.life_time)  s.add(`life:${entry.life_time}`);
+    return s;
+  }, [entry]);
+
+  const [lines, setLines] = useState<Line[]>([]);
+
+  // Recompute the connecting lines whenever the active code changes (and when
+  // the code list scrolls or the window resizes, so the source endpoint tracks
+  // the hovered row).
+  useLayoutEffect(() => {
+    function recompute() {
+      const body = bodyRef.current;
+      const src = active ? rows.current.get(`code:${active}`) : null;
+      if (!body || !src || !entry) { setLines([]); return; }
+      const base = body.getBoundingClientRect();
+      const rel = (el: HTMLElement) => {
+        const r = el.getBoundingClientRect();
+        return { x: r.left - base.left, y: r.top - base.top + r.height / 2 };
+      };
+      const sr = src.getBoundingClientRect();
+      // Clamp the source Y to the visible code-list band so a scrolled-away
+      // code doesn't shoot a line off into space.
+      const list = codeListRef.current?.getBoundingClientRect();
+      let sy = sr.top - base.top + sr.height / 2;
+      if (list) sy = Math.max(list.top - base.top, Math.min(list.bottom - base.top, sy));
+      const sx = sr.right - base.left;
+      const color = lineColorFor(entry);
+      const out: Line[] = [];
+      for (const key of activeTargets) {
+        const el = rows.current.get(key);
+        if (!el) continue;
+        const { x: tx, y: ty } = rel(el);
+        const dx = Math.max(40, (tx - sx) * 0.45);
+        out.push({ d: `M ${sx},${sy} C ${sx + dx},${sy} ${tx - dx},${ty} ${tx},${ty}`, color });
+      }
+      setLines(out);
+    }
+    recompute();
+    const list = codeListRef.current;
+    list?.addEventListener('scroll', recompute);
+    window.addEventListener('resize', recompute);
+    return () => { list?.removeEventListener('scroll', recompute); window.removeEventListener('resize', recompute); };
+  }, [active, entry, activeTargets]);
+
+  const col = (
+    title: string,
+    keyPrefix: string,
+    values: readonly string[],
+    opts?: { colorize?: boolean; className?: string },
+  ) => (
+    <div className={`whchart__col ${opts?.className ?? ''}`}>
+      <div className="whchart__col-head">{title}</div>
+      {values.map((v) => {
+        const key = `${keyPrefix}:${v}`;
+        const on = activeTargets.has(key);
+        const c = opts?.colorize ? labelColor(v) : undefined;
+        return (
+          <div
+            key={key}
+            ref={setRow(key)}
+            className={`whchart__cell${on ? ' whchart__cell--on' : ''}`}
+            style={on && c ? { color: c } : c && !on ? { color: c, opacity: 0.55 } : undefined}
+          >
+            {v}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  return createPortal(
+    <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal whchart" role="dialog" aria-modal="true">
+        <div className="modal__header">
+          <h2 className="modal__title">{t('whChart.title')}</h2>
+          <button className="icon-btn" onClick={onClose} aria-label={t('actions.close')}>
+            <XIcon size={16} weight="bold" />
+          </button>
+        </div>
+
+        <div className="modal__body whchart__body" ref={bodyRef}>
+          <svg className="whchart__lines" aria-hidden="true">
+            {lines.map((l, i) => (
+              <path key={i} d={l.d} fill="none" stroke={l.color} strokeWidth={1.5} opacity={0.85} />
+            ))}
+          </svg>
+
+          {/* Codes */}
+          <div className="whchart__col whchart__col--codes">
+            <div className="whchart__col-head">
+              {t('whChart.colWormholes')}
+              <input
+                className="whchart__search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t('whChart.searchPlaceholder')}
+                spellCheck={false}
+              />
+            </div>
+            <div className="whchart__codes" ref={codeListRef}>
+              {codes.map((w) => (
+                <div
+                  key={w.wormhole}
+                  ref={setRow(`code:${w.wormhole}`)}
+                  className={`whchart__code${active === w.wormhole ? ' whchart__code--active' : ''}`}
+                  onMouseEnter={() => setActive(w.wormhole)}
+                  onClick={() => setActive((cur) => (cur === w.wormhole ? null : w.wormhole))}
+                >
+                  {w.wormhole}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {col(t('whChart.colRespawn'),  'respawn', RESPAWN_ORDER, { className: 'whchart__col--narrow' })}
+          {col(t('whChart.colSpawnIn'),  'spawn',   SPAWN_ORDER,   { colorize: true })}
+          {col(t('whChart.colLeadsTo'),  'leads',   LEADS_ORDER,   { colorize: true })}
+          {col(t('whChart.colShipSize'), 'ship',    SHIP_ORDER)}
+          {col(t('whChart.colTotalMass'),'mass',    MASS_ORDER)}
+          {col(t('whChart.colLifetime'), 'life',    LIFE_ORDER, { className: 'whchart__col--narrow' })}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/ui/WhTypeChartModal.tsx
+++ b/web/src/components/ui/WhTypeChartModal.tsx
@@ -173,7 +173,10 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
             key={key}
             ref={setRow(key)}
             className={`whchart__cell whchart__cell--hit${on ? ' whchart__cell--on' : ''}`}
-            style={on && c ? { color: c } : c && !on ? { color: c, opacity: 0.55 } : undefined}
+            // Dim non-highlighted colour via text alpha (#rrggbb + 8c ≈ 0.55),
+            // NOT element opacity — opacity would make the cell box translucent
+            // too and let connector lines show through it.
+            style={on && c ? { color: c } : c && !on ? { color: `${c}8c` } : undefined}
             onMouseEnter={() => hover({ kind: 'attr', col: keyPrefix, val: v })}
             onClick={() => toggle({ kind: 'attr', col: keyPrefix, val: v }, sameAttr(keyPrefix, v))}
           >

--- a/web/src/components/ui/WhTypeChartModal.tsx
+++ b/web/src/components/ui/WhTypeChartModal.tsx
@@ -6,13 +6,21 @@ import { CLASS_COLORS } from '../../data/wormholes';
 import type { SystemClass } from '../../types';
 import {
   WH_CHART, RESPAWN_ORDER, SPAWN_ORDER, LEADS_ORDER, SHIP_ORDER, MASS_ORDER, LIFE_ORDER,
-  type WhChartEntry,
+  type WhChartEntry, type Respawn,
 } from '../../data/whTypeChart';
 
-// A Nexum take on whtype.info: pick a wormhole code and lines light up its
-// spawn / leads-to / ship size / total mass / lifetime across the columns.
+// A Nexum take on whtype.info: hover ANY cell — a wormhole code OR an attribute
+// value — and lines connect a code to its values (or a value to every code that
+// has it), with the matching cells highlighted.
 
 interface Line { d: string; color: string; }
+
+// Selection is either a wormhole code, or a value in one of the attribute
+// columns (identified by its column prefix + value).
+type Active =
+  | { kind: 'code'; code: string }
+  | { kind: 'attr'; col: string; val: string }
+  | null;
 
 // Map a spawn/leads label to a class colour where one exists, for the row text.
 function labelColor(label: string): string | undefined {
@@ -27,75 +35,114 @@ function labelColor(label: string): string | undefined {
   return key ? CLASS_COLORS[key] : undefined;
 }
 
-// Colour for a whole code's line bundle — by its destination class so the eye
-// can follow it. Drifter / special dests fall back to a neutral accent.
-function lineColorFor(entry: WhChartEntry): string {
-  return labelColor(entry.leads_to[0] ?? '') ?? '#5b9bff';
+const ACCENT = '#5b9bff';
+function codeLineColor(entry: WhChartEntry): string {
+  return labelColor(entry.leads_to[0] ?? '') ?? ACCENT;
+}
+
+// Does an entry occupy this attribute column's value?
+function entryHasAttr(e: WhChartEntry, col: string, val: string): boolean {
+  switch (col) {
+    case 'respawn': return e.respawn.includes(val as Respawn);
+    case 'spawn':   return e.spawn_in.includes(val);
+    case 'leads':   return e.leads_to.includes(val);
+    case 'ship':    return e.ship_size === val;
+    case 'mass':    return e.total_mass === val;
+    case 'life':    return e.life_time === val;
+    default:        return false;
+  }
+}
+
+// The attribute keys an entry connects to.
+function attrKeysFor(e: WhChartEntry): string[] {
+  return [
+    ...e.respawn.map((r) => `respawn:${r}`),
+    ...e.spawn_in.map((v) => `spawn:${v}`),
+    ...e.leads_to.map((v) => `leads:${v}`),
+    ...(e.ship_size  ? [`ship:${e.ship_size}`]  : []),
+    ...(e.total_mass ? [`mass:${e.total_mass}`] : []),
+    ...(e.life_time  ? [`life:${e.life_time}`]  : []),
+  ];
 }
 
 export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
-  const [active, setActive] = useState<string | null>(null);
+  const [active, setActive] = useState<Active>(null);
+  // Pinned (clicked) selections persist on mouse-out so you can read the
+  // highlighted result; hovering only previews while nothing is pinned.
+  const [pinned, setPinned] = useState(false);
   const [search, setSearch] = useState('');
+
+  const hover = (a: Active) => { if (!pinned) setActive(a); };
+  const toggle = (a: Active, isSame: boolean) => {
+    if (isSame && pinned) { setActive(null); setPinned(false); }
+    else { setActive(a); setPinned(true); }
+  };
 
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const codeListRef = useRef<HTMLDivElement | null>(null);
-  // key -> row element, for measuring line endpoints.
   const rows = useRef<Map<string, HTMLElement>>(new Map());
   const setRow = (key: string) => (el: HTMLElement | null) => {
     if (el) rows.current.set(key, el); else rows.current.delete(key);
   };
-
-  const entry = useMemo(() => WH_CHART.find((w) => w.wormhole === active) ?? null, [active]);
 
   const codes = useMemo(() => {
     const q = search.trim().toUpperCase();
     return WH_CHART.filter((w) => !q || w.wormhole.toUpperCase().includes(q));
   }, [search]);
 
-  // Which column rows the active code touches (for highlighting).
-  const activeTargets = useMemo(() => {
-    const s = new Set<string>();
-    if (!entry) return s;
-    entry.respawn.forEach((r) => s.add(`respawn:${r}`));
-    entry.spawn_in.forEach((v) => s.add(`spawn:${v}`));
-    entry.leads_to.forEach((v) => s.add(`leads:${v}`));
-    if (entry.ship_size)  s.add(`ship:${entry.ship_size}`);
-    if (entry.total_mass) s.add(`mass:${entry.total_mass}`);
-    if (entry.life_time)  s.add(`life:${entry.life_time}`);
-    return s;
-  }, [entry]);
+  // From the active selection, compute the connection pairs (each = a code row
+  // to an attribute-value row), the highlight set, and the line colour. Works
+  // both directions: a code → its values, or a value → every code that has it.
+  const { pairs, highlight, lineColor } = useMemo(() => {
+    const pairs: Array<{ code: string; attrKey: string }> = [];
+    const hl = new Set<string>();
+    let color = ACCENT;
+    if (active?.kind === 'code') {
+      const e = WH_CHART.find((w) => w.wormhole === active.code);
+      if (e) {
+        color = codeLineColor(e);
+        hl.add(`code:${e.wormhole}`);
+        for (const k of attrKeysFor(e)) { hl.add(k); pairs.push({ code: e.wormhole, attrKey: k }); }
+      }
+    } else if (active?.kind === 'attr') {
+      const attrKey = `${active.col}:${active.val}`;
+      hl.add(attrKey);
+      color = labelColor(active.val) ?? ACCENT;
+      for (const e of WH_CHART) {
+        if (entryHasAttr(e, active.col, active.val)) {
+          hl.add(`code:${e.wormhole}`);
+          pairs.push({ code: e.wormhole, attrKey });
+        }
+      }
+    }
+    return { pairs, highlight: hl, lineColor: color };
+  }, [active]);
 
   const [lines, setLines] = useState<Line[]>([]);
 
-  // Recompute the connecting lines whenever the active code changes (and when
-  // the code list scrolls or the window resizes, so the source endpoint tracks
-  // the hovered row).
   useLayoutEffect(() => {
     function recompute() {
       const body = bodyRef.current;
-      const src = active ? rows.current.get(`code:${active}`) : null;
-      if (!body || !src || !entry) { setLines([]); return; }
+      if (!body || pairs.length === 0) { setLines([]); return; }
       const base = body.getBoundingClientRect();
-      const rel = (el: HTMLElement) => {
-        const r = el.getBoundingClientRect();
-        return { x: r.left - base.left, y: r.top - base.top + r.height / 2 };
-      };
-      const sr = src.getBoundingClientRect();
-      // Clamp the source Y to the visible code-list band so a scrolled-away
-      // code doesn't shoot a line off into space.
       const list = codeListRef.current?.getBoundingClientRect();
-      let sy = sr.top - base.top + sr.height / 2;
-      if (list) sy = Math.max(list.top - base.top, Math.min(list.bottom - base.top, sy));
-      const sx = sr.right - base.left;
-      const color = lineColorFor(entry);
       const out: Line[] = [];
-      for (const key of activeTargets) {
-        const el = rows.current.get(key);
-        if (!el) continue;
-        const { x: tx, y: ty } = rel(el);
+      for (const p of pairs) {
+        const codeEl = rows.current.get(`code:${p.code}`);
+        const attrEl = rows.current.get(p.attrKey);
+        if (!codeEl || !attrEl) continue;        // code may be filtered out by search
+        const cr = codeEl.getBoundingClientRect();
+        const ar = attrEl.getBoundingClientRect();
+        const sx = cr.right - base.left;
+        let sy = cr.top - base.top + cr.height / 2;
+        // Clamp the code endpoint to the visible scroll band so off-screen
+        // codes don't trail lines into space.
+        if (list) sy = Math.max(list.top - base.top, Math.min(list.bottom - base.top, sy));
+        const tx = ar.left - base.left;
+        const ty = ar.top - base.top + ar.height / 2;
         const dx = Math.max(40, (tx - sx) * 0.45);
-        out.push({ d: `M ${sx},${sy} C ${sx + dx},${sy} ${tx - dx},${ty} ${tx},${ty}`, color });
+        out.push({ d: `M ${sx},${sy} C ${sx + dx},${sy} ${tx - dx},${ty} ${tx},${ty}`, color: lineColor });
       }
       setLines(out);
     }
@@ -104,7 +151,10 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
     list?.addEventListener('scroll', recompute);
     window.addEventListener('resize', recompute);
     return () => { list?.removeEventListener('scroll', recompute); window.removeEventListener('resize', recompute); };
-  }, [active, entry, activeTargets]);
+  }, [pairs, lineColor]);
+
+  const sameAttr = (col: string, v: string) =>
+    active?.kind === 'attr' && active.col === col && active.val === v;
 
   const col = (
     title: string,
@@ -116,14 +166,16 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
       <div className="whchart__col-head">{title}</div>
       {values.map((v) => {
         const key = `${keyPrefix}:${v}`;
-        const on = activeTargets.has(key);
+        const on = highlight.has(key);
         const c = opts?.colorize ? labelColor(v) : undefined;
         return (
           <div
             key={key}
             ref={setRow(key)}
-            className={`whchart__cell${on ? ' whchart__cell--on' : ''}`}
+            className={`whchart__cell whchart__cell--hit${on ? ' whchart__cell--on' : ''}`}
             style={on && c ? { color: c } : c && !on ? { color: c, opacity: 0.55 } : undefined}
+            onMouseEnter={() => hover({ kind: 'attr', col: keyPrefix, val: v })}
+            onClick={() => toggle({ kind: 'attr', col: keyPrefix, val: v }, sameAttr(keyPrefix, v))}
           >
             {v}
           </div>
@@ -142,7 +194,7 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
           </button>
         </div>
 
-        <div className="modal__body whchart__body" ref={bodyRef}>
+        <div className="modal__body whchart__body" ref={bodyRef} onMouseLeave={() => { if (!pinned) setActive(null); }}>
           <svg className="whchart__lines" aria-hidden="true">
             {lines.map((l, i) => (
               <path key={i} d={l.d} fill="none" stroke={l.color} strokeWidth={1.5} opacity={0.85} />
@@ -162,17 +214,20 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
               />
             </div>
             <div className="whchart__codes" ref={codeListRef}>
-              {codes.map((w) => (
-                <div
-                  key={w.wormhole}
-                  ref={setRow(`code:${w.wormhole}`)}
-                  className={`whchart__code${active === w.wormhole ? ' whchart__code--active' : ''}`}
-                  onMouseEnter={() => setActive(w.wormhole)}
-                  onClick={() => setActive((cur) => (cur === w.wormhole ? null : w.wormhole))}
-                >
-                  {w.wormhole}
-                </div>
-              ))}
+              {codes.map((w) => {
+                const on = highlight.has(`code:${w.wormhole}`);
+                return (
+                  <div
+                    key={w.wormhole}
+                    ref={setRow(`code:${w.wormhole}`)}
+                    className={`whchart__code${on ? ' whchart__code--active' : ''}`}
+                    onMouseEnter={() => hover({ kind: 'code', code: w.wormhole })}
+                    onClick={() => toggle({ kind: 'code', code: w.wormhole }, active?.kind === 'code' && active.code === w.wormhole)}
+                  >
+                    {w.wormhole}
+                  </div>
+                );
+              })}
             </div>
           </div>
 

--- a/web/src/data/whTypeChart.ts
+++ b/web/src/data/whTypeChart.ts
@@ -1,0 +1,152 @@
+// Wormhole reference data for the WH-type chart modal (a Nexum take on
+// whtype.info). Bundled static data — wormhole types change at most once an
+// expansion. "Level" (sig_level / scanning difficulty) is intentionally omitted.
+//
+// Each entry connects a wormhole code to the value(s) it occupies in each
+// column; the chart draws lines from a hovered code to those values.
+
+export type Respawn  = 'Static' | 'Wandering' | 'Reverse';
+export type ShipSize =
+  | 'up to Destroyer' | 'up to Battlecruiser' | 'up to Battleship'
+  | 'up to Freighter' | 'up to Capital';
+
+export interface WhChartEntry {
+  wormhole:  string;
+  respawn:   Respawn[];
+  spawn_in:  string[];
+  leads_to:  string[];
+  ship_size: ShipSize | null;
+  total_mass: string | null;
+  life_time:  string | null;
+}
+
+// Canonical, ordered value lists per column (drives the row order in the UI).
+export const RESPAWN_ORDER: Respawn[] = ['Static', 'Wandering', 'Reverse'];
+
+export const SPAWN_ORDER: string[] = [
+  'Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6',
+  'HighSec', 'LowSec', 'NullSec',
+  'Class 12 - Thera', 'Class 13 - Shattered', 'Pochven ▲ Trig space',
+  'Drone Regions', 'Drifter wormholes', 'Jove Observatories', 'never spawn', 'EXIT',
+];
+
+export const LEADS_ORDER: string[] = [
+  'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'HS', 'LS', 'NS', 'Thera', 'C13', 'Pochven',
+  'Sentinel MZ', 'Liberated Barbican', 'Sanctified Vidette', 'Conflux Eyrie', 'Azdaja Redoubt',
+  'drifter blackhole', 'jump to identify',
+];
+
+export const SHIP_ORDER: ShipSize[] = [
+  'up to Destroyer', 'up to Battlecruiser', 'up to Battleship', 'up to Freighter', 'up to Capital',
+];
+
+export const MASS_ORDER: string[] = [
+  '100 000 000 kg', '500 000 000 kg', '750 000 000 kg',
+  '1 000 000 000 kg', '2 000 000 000 kg', '3 000 000 000 kg', '3 300 000 000 kg', '5 000 000 000 kg',
+];
+
+export const LIFE_ORDER: string[] = ['4.5h', '12h', '16h', '24h', '48h'];
+
+export const WH_CHART: WhChartEntry[] = [
+  { wormhole: 'A009', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'NullSec', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C13'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'A239', respawn: ['Static'], spawn_in: ['Class 2'], leads_to: ['LS'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'A641', respawn: ['Wandering'], spawn_in: ['HighSec'], leads_to: ['HS'], ship_size: 'up to Freighter', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'A982', respawn: ['Wandering'], spawn_in: ['Class 3', 'Class 12 - Thera'], leads_to: ['C6'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'B041', respawn: ['Wandering'], spawn_in: ['HighSec'], leads_to: ['C6'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '48h' },
+  { wormhole: 'B274', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2'], leads_to: ['HS'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'B449', respawn: ['Wandering'], spawn_in: ['LowSec', 'NullSec'], leads_to: ['HS'], ship_size: 'up to Freighter', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'B520', respawn: ['Wandering'], spawn_in: ['Class 6'], leads_to: ['HS'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '48h' },
+  { wormhole: 'B735', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec', 'Jove Observatories'], leads_to: ['Liberated Barbican'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'C008', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C5'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'C125', respawn: ['Wandering'], spawn_in: ['Class 1'], leads_to: ['C2'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'C140', respawn: ['Wandering'], spawn_in: ['Class 5', 'Class 6'], leads_to: ['LS'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'C247', respawn: ['Static', 'Wandering'], spawn_in: ['Class 4'], leads_to: ['C3'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'C248', respawn: ['Wandering'], spawn_in: ['Class 6'], leads_to: ['NS'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'C391', respawn: ['Wandering'], spawn_in: ['Class 6'], leads_to: ['LS'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '48h' },
+  { wormhole: 'C414', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec', 'Jove Observatories'], leads_to: ['Conflux Eyrie'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'C729', respawn: ['Static'], spawn_in: ['Pochven ▲ Trig space'], leads_to: ['HS', 'LS', 'NS'], ship_size: 'up to Freighter', total_mass: '1 000 000 000 kg', life_time: '12h' },
+  { wormhole: 'D364', respawn: ['Static'], spawn_in: ['Class 5'], leads_to: ['C2'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'D382', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2', 'Drifter wormholes'], leads_to: ['C2'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'D792', respawn: ['Wandering'], spawn_in: ['Class 5', 'Class 6'], leads_to: ['HS'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'D845', respawn: ['Static'], spawn_in: ['Class 3'], leads_to: ['HS'], ship_size: 'up to Battleship', total_mass: '5 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'E004', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C1'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'E175', respawn: ['Static', 'Wandering'], spawn_in: ['Class 5'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'E545', respawn: ['Static'], spawn_in: ['Class 2'], leads_to: ['NS'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'E587', respawn: ['Static'], spawn_in: ['Class 12 - Thera'], leads_to: ['NS'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'F135', respawn: ['Wandering', 'Reverse'], spawn_in: ['Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6'], leads_to: ['Thera'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'F216', respawn: ['Wandering', 'Reverse'], spawn_in: ['Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6'], leads_to: ['Pochven'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '12h' },
+  { wormhole: 'F353', respawn: ['Wandering', 'Reverse'], spawn_in: ['Class 1'], leads_to: ['Thera'], ship_size: 'up to Battlecruiser', total_mass: '100 000 000 kg', life_time: '16h' },
+  { wormhole: 'G008', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C6'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'G024', respawn: ['Static'], spawn_in: ['Class 6'], leads_to: ['C2'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'H121', respawn: ['Wandering'], spawn_in: ['Class 1'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'H296', respawn: ['Static', 'Wandering'], spawn_in: ['Class 5'], leads_to: ['C5'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'H900', respawn: ['Static', 'Wandering'], spawn_in: ['Class 4'], leads_to: ['C5'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'I078', respawn: [], spawn_in: ['Pochven ▲ Trig space'], leads_to: ['Pochven'], ship_size: 'up to Battlecruiser', total_mass: '100 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'I182', respawn: ['Wandering'], spawn_in: ['Class 3', 'Class 12 - Thera'], leads_to: ['C2'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'J244', respawn: ['Static'], spawn_in: ['Class 1'], leads_to: ['LS'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'J377', respawn: ['Wandering', 'Reverse'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 12 - Thera'], leads_to: ['LS'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'J492', respawn: ['Wandering', 'Reverse'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4'], leads_to: ['LS'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'K329', respawn: ['Wandering'], spawn_in: ['Class 4'], leads_to: ['NS'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'K346', respawn: ['Static'], spawn_in: ['Class 3'], leads_to: ['NS'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'L005', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C2'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'L031', respawn: ['Wandering', 'Reverse'], spawn_in: ['NullSec'], leads_to: ['Thera'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'L477', respawn: ['Static'], spawn_in: ['Class 6'], leads_to: ['C3'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'L614', respawn: ['Wandering'], spawn_in: ['Class 1', 'NullSec'], leads_to: ['C5'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'L687', respawn: [], spawn_in: ['Pochven ▲ Trig space'], leads_to: ['Pochven'], ship_size: 'up to Battlecruiser', total_mass: '100 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'M001', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C4'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'M164', respawn: ['Wandering', 'Reverse'], spawn_in: ['LowSec'], leads_to: ['Thera'], ship_size: 'up to Freighter', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'M267', respawn: ['Static'], spawn_in: ['Class 5'], leads_to: ['C3'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'M555', respawn: ['Wandering'], spawn_in: ['HighSec'], leads_to: ['C5'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'M609', respawn: ['Wandering'], spawn_in: ['Class 1'], leads_to: ['C4'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'N062', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2', 'Drifter wormholes'], leads_to: ['C5'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'N110', respawn: ['Static'], spawn_in: ['Class 1'], leads_to: ['HS'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'N290', respawn: ['Wandering'], spawn_in: ['Class 4'], leads_to: ['LS'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'N432', respawn: ['Wandering'], spawn_in: ['LowSec', 'NullSec'], leads_to: ['C5'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'N766', respawn: ['Static'], spawn_in: ['Class 4'], leads_to: ['C2'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'N770', respawn: ['Wandering'], spawn_in: ['Class 3', 'Class 12 - Thera'], leads_to: ['C5'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'N944', respawn: ['Wandering'], spawn_in: ['LowSec', 'NullSec'], leads_to: ['LS'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'N968', respawn: ['Wandering'], spawn_in: ['Class 3', 'Class 12 - Thera'], leads_to: ['C3'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'O128', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec', 'never spawn'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'O477', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2', 'Drifter wormholes'], leads_to: ['C3'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'O546', respawn: [], spawn_in: ['Pochven ▲ Trig space'], leads_to: ['Pochven'], ship_size: 'up to Battlecruiser', total_mass: '100 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'O883', respawn: ['Wandering'], spawn_in: ['Class 1', 'NullSec'], leads_to: ['C3'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'P060', respawn: ['Static'], spawn_in: ['Class 4'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'Q003', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['NS'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'Q063', respawn: ['Static'], spawn_in: ['Class 12 - Thera'], leads_to: ['HS'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'Q317', respawn: ['Static'], spawn_in: ['Class 6'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'R051', respawn: ['Wandering'], spawn_in: ['HighSec'], leads_to: ['LS'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'R081', respawn: ['Wandering'], spawn_in: ['Pochven ▲ Trig space'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '12h' },
+  { wormhole: 'R259', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec', 'Jove Observatories'], leads_to: ['Azdaja Redoubt'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'R474', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2', 'Drifter wormholes'], leads_to: ['C6'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'R943', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec'], leads_to: ['C2'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'S047', respawn: ['Wandering'], spawn_in: ['Class 4'], leads_to: ['HS'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'S199', respawn: ['Wandering'], spawn_in: ['LowSec', 'NullSec'], leads_to: ['NS'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'S804', respawn: ['Wandering'], spawn_in: ['Class 1', 'NullSec'], leads_to: ['C6'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'S877', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec', 'Jove Observatories'], leads_to: ['Sentinel MZ'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'T405', respawn: ['Wandering'], spawn_in: ['Class 3', 'Class 12 - Thera'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'T458', respawn: ['Wandering', 'Reverse'], spawn_in: ['HighSec'], leads_to: ['Thera'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'U210', respawn: ['Static'], spawn_in: ['Class 3'], leads_to: ['LS'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'U319', respawn: ['Wandering'], spawn_in: ['LowSec', 'NullSec'], leads_to: ['C6'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '48h' },
+  { wormhole: 'U372', respawn: ['Wandering', 'Reverse'], spawn_in: ['Drone Regions'], leads_to: ['Pochven'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '12h' },
+  { wormhole: 'U574', respawn: ['Static', 'Wandering'], spawn_in: ['Class 4'], leads_to: ['C6'], ship_size: 'up to Battleship', total_mass: '3 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'V283', respawn: ['Wandering'], spawn_in: ['HighSec'], leads_to: ['NS'], ship_size: 'up to Freighter', total_mass: '3 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'V301', respawn: ['Wandering'], spawn_in: ['Class 3', 'Class 12 - Thera'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'V753', respawn: ['Static', 'Wandering'], spawn_in: ['Class 5'], leads_to: ['C6'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'V898', respawn: ['Static'], spawn_in: ['Class 12 - Thera'], leads_to: ['LS'], ship_size: 'up to Freighter', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'V911', respawn: ['Static', 'Wandering'], spawn_in: ['Class 6'], leads_to: ['C5'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'V928', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec', 'Jove Observatories'], leads_to: ['Sanctified Vidette'], ship_size: 'up to Battleship', total_mass: '750 000 000 kg', life_time: '16h' },
+  { wormhole: 'W237', respawn: ['Static', 'Wandering'], spawn_in: ['Class 6'], leads_to: ['C6'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '24h' },
+  { wormhole: 'X450', respawn: ['Wandering'], spawn_in: ['Pochven ▲ Trig space'], leads_to: ['NS'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '12h' },
+  { wormhole: 'X702', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec'], leads_to: ['C3'], ship_size: 'up to Battleship', total_mass: '1 000 000 000 kg', life_time: '24h' },
+  { wormhole: 'X877', respawn: ['Static', 'Wandering'], spawn_in: ['Class 4'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'Y683', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2', 'Drifter wormholes'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'Y790', respawn: ['Static'], spawn_in: ['Class 5'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'Z006', respawn: ['Wandering'], spawn_in: ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5', 'Class 6', 'Class 12 - Thera', 'Class 13 - Shattered'], leads_to: ['C3'], ship_size: 'up to Destroyer', total_mass: '3 000 000 000 kg', life_time: '4.5h' },
+  { wormhole: 'Z060', respawn: ['Static'], spawn_in: ['Class 1'], leads_to: ['NS'], ship_size: 'up to Battlecruiser', total_mass: '1 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'Z142', respawn: ['Wandering'], spawn_in: ['Class 5', 'Class 6'], leads_to: ['NS'], ship_size: 'up to Capital', total_mass: '3 300 000 000 kg', life_time: '16h' },
+  { wormhole: 'Z457', respawn: ['Static', 'Wandering'], spawn_in: ['Class 6'], leads_to: ['C4'], ship_size: 'up to Battleship', total_mass: '2 000 000 000 kg', life_time: '16h' },
+  { wormhole: 'Z647', respawn: ['Static', 'Wandering'], spawn_in: ['Class 2', 'Drifter wormholes'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '500 000 000 kg', life_time: '16h' },
+  { wormhole: 'Z971', respawn: ['Wandering'], spawn_in: ['HighSec', 'LowSec', 'NullSec'], leads_to: ['C1'], ship_size: 'up to Battlecruiser', total_mass: '100 000 000 kg', life_time: '16h' },
+  { wormhole: 'GEAR', respawn: [], spawn_in: [], leads_to: ['drifter blackhole'], ship_size: null, total_mass: null, life_time: null },
+  { wormhole: 'K162', respawn: [], spawn_in: ['EXIT'], leads_to: ['jump to identify'], ship_size: null, total_mass: null, life_time: null },
+];

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -518,6 +518,19 @@
     "friendly": "Friendly",
     "watch": "Watch"
   },
+  "whChart": {
+    "open": "⊟ Wormhole reference",
+    "tooltip": "Look up any wormhole type — spawn, destination, ship size, mass and lifetime",
+    "title": "Wormhole type reference",
+    "searchPlaceholder": "Filter…",
+    "colWormholes": "Wormholes",
+    "colRespawn": "Respawn",
+    "colSpawnIn": "Spawn in",
+    "colLeadsTo": "Leads to",
+    "colShipSize": "Ship jump size",
+    "colTotalMass": "Total mass",
+    "colLifetime": "Lifetime"
+  },
   "watchlist": {
     "hint": "Holes you're hunting for. Watch a system, a wormhole type, or a characteristic (shattered, an effect, frig holes); matches are highlighted on the map (and chime once, if enabled).",
     "chimeToggle": "Chime when a watched system appears",


### PR DESCRIPTION
A **Wormhole reference** button in the sidebar's Connections section opens a modal recreating [whtype.info](https://whtype.info): pick a wormhole code and curved lines light up its attributes across the columns.

## What it does
- Columns: **Wormholes** (searchable, scrollable) · **Respawn** · **Spawn in** · **Leads to** · **Ship jump size** · **Total mass** · **Lifetime**.
- **Hover** a code → SVG bezier lines connect it to each of its values and the matching rows highlight. **Click** to pin/unpin.
- Spawn/leads rows are colour-coded by system class.
- Lines recompute on code-list scroll + window resize; the source endpoint is clamped to the visible band so a scrolled-away code doesn't trail a line off-screen.

## Data
Bundled in `web/src/data/whTypeChart.ts` from the community-curated whtype.info dataset (all 101 codes incl. `K162` / drifter `GEAR`). The numbers (leads-to / mass / lifetime / ship-size) are SDE-derivable, but **spawn sources, Static/Wandering type, and the named drifter holes are not in CCP's SDE** — they're community knowledge (same reason our `wormholes.json` already curates `src`), so a snapshot is the practical source. **"Level" (scanning difficulty) omitted** — we don't track it.

Frontend-only; **no API or DB change**.

## Follow-up worth considering
The dump's `spawn_in` is richer than our `wormholes.json` `src` — a separate pass could backfill ours from it to improve the live WH picker (one source of truth). Happy to do that next if wanted.

## Verification
`tsc`, `eslint`, `yarn build` all clean. **Not browser-tested** — the SVG line layout/curvature wants a real eyeball; worth opening the modal and hovering a few codes (e.g. L477 → C6 spawn, C3 leads-to, Battleship, 2B, 16h) to confirm the lines land on the right rows.