### PR TITLE
Make the toolbar wrap to two rows on narrow screens

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -606,6 +606,37 @@
   position: relative;
 }
 
+/* Responsive: the single 48px row needs ~1570px to fit every control. Below
+   that (vertical monitors, most laptops) wrap into two rows — map-editing
+   controls on row 1, stats/tools/user on row 2 — instead of clipping. The
+   --break spacer takes a full line so the secondary cluster drops cleanly,
+   and column-gap tightens (only while wrapped) so row 2 fits without a third
+   wrap; the desktop 24px gap is untouched. */
+@media (max-width: 1600px) {
+  .toolbar {
+    flex-wrap: wrap;
+    height: auto;
+    min-height: 48px;
+    row-gap: 4px;
+    column-gap: 14px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  .toolbar__spacer--break {
+    flex-basis: 100%;
+    height: 0;
+  }
+
+  /* Keep each cluster intact so a tight row 2 wraps whole units, not glyphs. */
+  .toolbar__stats,
+  .toolbar__proximity,
+  .toolbar__server-status,
+  .toolbar__user {
+    flex-shrink: 0;
+  }
+}
+
 .toolbar__brand {
   display: flex;
   align-items: center;

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -336,7 +336,9 @@ export function Toolbar() {
         />
       </div>
 
-      <div className="toolbar__spacer" />
+      {/* Wrap point on narrow screens: map-editing controls stay on row 1,
+          stats/tools/user drop to row 2 (see the toolbar media query). */}
+      <div className="toolbar__spacer toolbar__spacer--break" />
 
       <div className="toolbar__stats">
         <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>


### PR DESCRIPTION
The single 48px toolbar row needs ~1570px to fit all controls, so vertical monitors and most laptops clipped the right-hand cluster. Below 1600px the bar now wraps: map-editing controls stay on row 1 and stats/tools/user drop to a second row (forced at the first spacer so the break is clean, not arbitrary). Column gap tightens to 14px only while wrapped so row 2 fits without a third wrap; the desktop gap and single-row layout are unchanged above 1600px.