### PR TITLE
Release v1.3.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -606,6 +606,37 @@
   position: relative;
 }
 
+/* Responsive: the single 48px row needs ~1570px to fit every control. Below
+   that (vertical monitors, most laptops) wrap into two rows — map-editing
+   controls on row 1, stats/tools/user on row 2 — instead of clipping. The
+   --break spacer takes a full line so the secondary cluster drops cleanly,
+   and column-gap tightens (only while wrapped) so row 2 fits without a third
+   wrap; the desktop 24px gap is untouched. */
+@media (max-width: 1600px) {
+  .toolbar {
+    flex-wrap: wrap;
+    height: auto;
+    min-height: 48px;
+    row-gap: 4px;
+    column-gap: 14px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  .toolbar__spacer--break {
+    flex-basis: 100%;
+    height: 0;
+  }
+
+  /* Keep each cluster intact so a tight row 2 wraps whole units, not glyphs. */
+  .toolbar__stats,
+  .toolbar__proximity,
+  .toolbar__server-status,
+  .toolbar__user {
+    flex-shrink: 0;
+  }
+}
+
 .toolbar__brand {
   display: flex;
   align-items: center;

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -336,7 +336,9 @@ export function Toolbar() {
         />
       </div>
 
-      <div className="toolbar__spacer" />
+      {/* Wrap point on narrow screens: map-editing controls stay on row 1,
+          stats/tools/user drop to row 2 (see the toolbar media query). */}
+      <div className="toolbar__spacer toolbar__spacer--break" />
 
       <div className="toolbar__stats">
         <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>


### PR DESCRIPTION
## v1.3.1

### Responsive toolbar
- The toolbar now wraps into two rows below 1600px (vertical monitors, most laptops) instead of clipping the tools/user cluster. Single-row layout unchanged on wide desktops.

### Housekeeping
- Bump version to 1.3.1 (server + web).