### PR TITLE
Close menus on outside click (including map clicks)

### DIFF
--- a/web/src/components/ui/CharacterSwitcher.tsx
+++ b/web/src/components/ui/CharacterSwitcher.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { charPortrait } from '../../utils/eveImages';
 import { useTranslation } from 'react-i18next';
 import { CaretDownIcon, PlusIcon, CheckIcon, MapPinIcon, TrashIcon } from '@phosphor-icons/react';
@@ -32,14 +33,7 @@ export function CharacterSwitcher() {
   const [pendingRemove, setPendingRemove] = useState<{ id: number; characterName: string } | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
+  useClickOutside(open, wrapRef, () => setOpen(false));
 
   if (!user) return null;
   const characters = user.characters ?? [];

--- a/web/src/components/ui/HeatmapMenu.tsx
+++ b/web/src/components/ui/HeatmapMenu.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FireIcon } from '@phosphor-icons/react';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { HEAT_METRICS, type HeatMetric } from '../../utils/heatmap';
 
 /**
@@ -17,14 +18,7 @@ export function HeatmapMenu() {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
+  useClickOutside(open, wrapRef, () => setOpen(false));
 
   const active = metric !== 'none';
 

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CaretDownIcon, CheckIcon } from '@phosphor-icons/react';
 import { SUPPORTED_LANGUAGES, LANGUAGE_NAMES, type SupportedLanguage } from '../../i18n';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { LangFlag } from './LangFlag';
 
 // Custom dropdown (not a native <select>) because native <option>s can't render
@@ -12,14 +13,7 @@ export function LanguageSwitcher() {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
+  useClickOutside(open, wrapRef, () => setOpen(false));
 
   const choose = (lng: SupportedLanguage) => {
     void i18n.changeLanguage(lng);

--- a/web/src/components/ui/NpcStationsPane.tsx
+++ b/web/src/components/ui/NpcStationsPane.tsx
@@ -93,8 +93,10 @@ export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null })
 
   useEffect(() => {
     const close = () => setCtx(null);
-    window.addEventListener('mousedown', close);
-    return () => window.removeEventListener('mousedown', close);
+    // Capture phase so a click on the map (whose canvas swallows bubbling
+    // pointer events) also dismisses the station context menu.
+    document.addEventListener('pointerdown', close, true);
+    return () => document.removeEventListener('pointerdown', close, true);
   }, []);
 
   const onContextMenu = (e: React.MouseEvent, station: NpcStation) => {

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { timeAgo, jumps } from '../../i18n/format';
@@ -18,6 +18,7 @@ import { CharacterSwitcher } from './CharacterSwitcher';
 import { HeatmapMenu } from './HeatmapMenu';
 import { WhTypeChartModal } from './WhTypeChartModal';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
@@ -231,6 +232,8 @@ export function Toolbar() {
   const [showKeys, setShowKeys] = useState(false);
   const [showWhChart, setShowWhChart] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const mapSwitcherRef = useRef<HTMLDivElement>(null);
+  useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
 
   async function handleDeleteMap() {
     if (!activeMapId) return;
@@ -245,7 +248,7 @@ export function Toolbar() {
       </div>
 
       {/* Map switcher */}
-      <div className="toolbar__map-switcher">
+      <div className="toolbar__map-switcher" ref={mapSwitcherRef}>
         <button
           className="toolbar__map-name-btn"
           onClick={() => setShowMaps((v) => !v)}

--- a/web/src/components/ui/WHTypeInfo.tsx
+++ b/web/src/components/ui/WHTypeInfo.tsx
@@ -39,10 +39,12 @@ export function WHTypeInfo({ code, children }: Props) {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
-    window.addEventListener('mousedown', onClick);
+    // Capture phase: the react-flow map canvas swallows bubbling pointer events,
+    // so a bubbling listener wouldn't fire for clicks out on the map.
+    document.addEventListener('pointerdown', onClick, true);
     window.addEventListener('keydown', onKey);
     return () => {
-      window.removeEventListener('mousedown', onClick);
+      document.removeEventListener('pointerdown', onClick, true);
       window.removeEventListener('keydown', onKey);
     };
   }, [open, hoverMode]);

--- a/web/src/hooks/useClickOutside.ts
+++ b/web/src/hooks/useClickOutside.ts
@@ -14,8 +14,10 @@ export function useClickOutside<T extends HTMLElement>(
   ref: RefObject<T | null>,
   onOutside: () => void,
 ) {
+  // Keep the latest callback without re-subscribing the listener every render.
+  // Written in an effect, not during render — refs are write-after-commit.
   const cb = useRef(onOutside);
-  cb.current = onOutside;
+  useEffect(() => { cb.current = onOutside; });
 
   useEffect(() => {
     if (!enabled) return;

--- a/web/src/hooks/useClickOutside.ts
+++ b/web/src/hooks/useClickOutside.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+// Call `onOutside` when a pointer-down lands outside `ref` (e.g. to close a
+// menu/dropdown). No-op while `enabled` is false.
+//
+// Uses the CAPTURE phase + `pointerdown` deliberately: the react-flow map canvas
+// stops pointer-event propagation in the bubble phase, so a plain bubbling
+// listener never fires for clicks on the map — menus would stay open until you
+// clicked their own trigger. Capturing at the document means "click anywhere
+// outside" reliably closes, including on the map. Keep the menu's trigger button
+// inside `ref` so its own click toggles rather than triggering an outside-close.
+export function useClickOutside<T extends HTMLElement>(
+  enabled: boolean,
+  ref: RefObject<T | null>,
+  onOutside: () => void,
+) {
+  const cb = useRef(onOutside);
+  cb.current = onOutside;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) cb.current();
+    };
+    document.addEventListener('pointerdown', onDown, true);
+    return () => document.removeEventListener('pointerdown', onDown, true);
+  }, [enabled, ref]);
+}


### PR DESCRIPTION
## Problem
Open dropdowns/menus (character switcher, language switcher, heatmap menu, the toolbar map switcher, the WH-type signature popover, NPC-station context menu) didn't close when you clicked the map or other UI — you had to click their own trigger to dismiss them.

**Root cause:** these listened for outside clicks in the **bubble phase** (`mousedown`), but the react-flow map canvas stops pointer-event propagation in the bubble phase, so the listener never fired for clicks out on the map. (`ContextMenu` and `usePopover` already worked because they use capture-phase `pointerdown`.) The toolbar map switcher had no outside-click handler at all — only `onMouseLeave`.

## Change
- New shared **`useClickOutside`** hook: capture-phase `pointerdown`, so "click anywhere outside" reliably closes — including on the map.
- Routed CharacterSwitcher, LanguageSwitcher, HeatmapMenu, and the Toolbar map switcher through it.
- Switched the two remaining ad-hoc listeners (WHTypeInfo, NpcStationsPane) to capture-phase `pointerdown` in place (they keep their keydown / context-menu coupling).

Result: a click anywhere outside an open menu closes it.