### PR TITLE
Release v1.4.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -593,8 +593,13 @@
   display: flex;
   align-items: center;
   gap: 24px;
+  /* Sections are atomic (flex-shrink: 0), so when the row runs out of width
+     whole groups wrap to the next line rather than squishing or clipping —
+     this is what keeps the bar usable on vertical monitors / narrow laptops. */
+  flex-wrap: wrap;
+  row-gap: 4px;
   padding: 0 16px;
-  height: 48px;
+  min-height: 48px;
   background: #0d1117;
   border-bottom: 1px solid #1e2740;
   flex-shrink: 0;
@@ -606,34 +611,40 @@
   position: relative;
 }
 
-/* Responsive: the single 48px row needs ~1570px to fit every control. Below
-   that (vertical monitors, most laptops) wrap into two rows — map-editing
-   controls on row 1, stats/tools/user on row 2 — instead of clipping. The
-   --break spacer takes a full line so the secondary cluster drops cleanly,
-   and column-gap tightens (only while wrapped) so row 2 fits without a third
-   wrap; the desktop 24px gap is untouched. */
+/* A reorderable group of toolbar controls (drag-and-drop via dnd-kit). Always
+   draggable — grab cursor by default; interactive children keep their own. */
+.toolbar__section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  cursor: grab;
+  /* Lifted while dragging via inline z-index; smooth reflow comes from dnd-kit. */
+  touch-action: none;
+}
+.toolbar__section--dragging { cursor: grabbing; opacity: 0.85; }
+.toolbar__section button,
+.toolbar__section a,
+.toolbar__section .toolbar__char-system--clickable { cursor: pointer; }
+.toolbar__section input { cursor: text; }
+
+/* Fixed account actions pinned to the far right (not part of the drag set). */
+.toolbar__anchor-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* Narrow screens (vertical monitors, smaller laptops): tighten the inter-section
+   gap so more fits per row before wrapping, and give the wrapped rows a little
+   vertical breathing room. The desktop 24px gap is untouched above 1600px. */
 @media (max-width: 1600px) {
   .toolbar {
-    flex-wrap: wrap;
-    height: auto;
-    min-height: 48px;
-    row-gap: 4px;
     column-gap: 14px;
     padding-top: 6px;
     padding-bottom: 6px;
-  }
-
-  .toolbar__spacer--break {
-    flex-basis: 100%;
-    height: 0;
-  }
-
-  /* Keep each cluster intact so a tight row 2 wraps whole units, not glyphs. */
-  .toolbar__stats,
-  .toolbar__proximity,
-  .toolbar__server-status,
-  .toolbar__user {
-    flex-shrink: 0;
   }
 }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -619,14 +619,31 @@
   gap: 8px;
   flex-shrink: 0;
   cursor: grab;
+  padding: 2px 6px;
+  border-radius: 6px;
+  transition: background 0.12s;
   /* Lifted while dragging via inline z-index; smooth reflow comes from dnd-kit. */
   touch-action: none;
 }
-.toolbar__section--dragging { cursor: grabbing; opacity: 0.85; }
+/* Hover chip + brighter grip = "this block is draggable". */
+.toolbar__section:hover { background: rgba(120, 150, 210, 0.08); }
+.toolbar__section--dragging { cursor: grabbing; opacity: 0.85; background: rgba(120, 150, 210, 0.12); }
 .toolbar__section button,
 .toolbar__section a,
 .toolbar__section .toolbar__char-system--clickable { cursor: pointer; }
 .toolbar__section input { cursor: text; }
+
+/* Six-dot drag grip: discoverable but quiet at rest, emphasised on hover/drag. */
+.toolbar__section-grip {
+  display: flex;
+  align-items: center;
+  margin-right: -2px;
+  color: #5a6886;
+  opacity: 0.3;
+  transition: opacity 0.12s, color 0.12s;
+}
+.toolbar__section:hover .toolbar__section-grip { opacity: 0.85; color: #8a9bc4; }
+.toolbar__section--dragging .toolbar__section-grip { opacity: 1; color: #a9b8dc; }
 
 /* Fixed account actions pinned to the far right (not part of the drag set). */
 .toolbar__anchor-right {

--- a/web/src/components/ui/CharacterSwitcher.tsx
+++ b/web/src/components/ui/CharacterSwitcher.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { charPortrait } from '../../utils/eveImages';
 import { useTranslation } from 'react-i18next';
 import { CaretDownIcon, PlusIcon, CheckIcon, MapPinIcon, TrashIcon } from '@phosphor-icons/react';
@@ -32,14 +33,7 @@ export function CharacterSwitcher() {
   const [pendingRemove, setPendingRemove] = useState<{ id: number; characterName: string } | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
+  useClickOutside(open, wrapRef, () => setOpen(false));
 
   if (!user) return null;
   const characters = user.characters ?? [];

--- a/web/src/components/ui/HeatmapMenu.tsx
+++ b/web/src/components/ui/HeatmapMenu.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FireIcon } from '@phosphor-icons/react';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { HEAT_METRICS, type HeatMetric } from '../../utils/heatmap';
 
 /**
@@ -17,14 +18,7 @@ export function HeatmapMenu() {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
+  useClickOutside(open, wrapRef, () => setOpen(false));
 
   const active = metric !== 'none';
 

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CaretDownIcon, CheckIcon } from '@phosphor-icons/react';
 import { SUPPORTED_LANGUAGES, LANGUAGE_NAMES, type SupportedLanguage } from '../../i18n';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { LangFlag } from './LangFlag';
 
 // Custom dropdown (not a native <select>) because native <option>s can't render
@@ -12,14 +13,7 @@ export function LanguageSwitcher() {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
+  useClickOutside(open, wrapRef, () => setOpen(false));
 
   const choose = (lng: SupportedLanguage) => {
     void i18n.changeLanguage(lng);

--- a/web/src/components/ui/NpcStationsPane.tsx
+++ b/web/src/components/ui/NpcStationsPane.tsx
@@ -93,8 +93,10 @@ export function NpcStationsPane({ eveSystemId }: { eveSystemId: number | null })
 
   useEffect(() => {
     const close = () => setCtx(null);
-    window.addEventListener('mousedown', close);
-    return () => window.removeEventListener('mousedown', close);
+    // Capture phase so a click on the map (whose canvas swallows bubbling
+    // pointer events) also dismisses the station context menu.
+    document.addEventListener('pointerdown', close, true);
+    return () => document.removeEventListener('pointerdown', close, true);
   }, []);
 
   const onContextMenu = (e: React.MouseEvent, station: NpcStation) => {

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -32,7 +32,7 @@ import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
-  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon,
+  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon, DotsSixVerticalIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { charPortrait, typeIcon } from '../../utils/eveImages';
@@ -221,6 +221,11 @@ function ToolbarSection({ id, children }: { id: string; children: ReactNode }) {
       }}
       {...listeners}
     >
+      {/* Drag affordance: faint at rest, brightens on hover (the whole section
+          is the drag target, this just signals it). */}
+      <span className="toolbar__section-grip" aria-hidden="true">
+        <DotsSixVerticalIcon size={13} weight="bold" />
+      </span>
       {children}
     </div>
   );

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { timeAgo, jumps } from '../../i18n/format';
@@ -19,11 +19,20 @@ import { HeatmapMenu } from './HeatmapMenu';
 import { WhTypeChartModal } from './WhTypeChartModal';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
 import { useClickOutside } from '../../hooks/useClickOutside';
+import { useUserSetting } from '../../hooks/useUserSetting';
+import {
+  DndContext, PointerSensor, useSensor, useSensors, closestCenter,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext, useSortable, arrayMove, rectSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
-  KeyIcon, GraphIcon,
+  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { charPortrait, typeIcon } from '../../utils/eveImages';
@@ -181,6 +190,42 @@ function ProximityChip() {
   );
 }
 
+// The reorderable toolbar groups, in their default left-to-right order. The
+// brand (far left) and the account actions — API keys + sign out (far right) —
+// are fixed and deliberately NOT in this list.
+const DEFAULT_TOOLBAR_ORDER = ['map', 'status', 'tools', 'server', 'account'];
+
+// Reconcile a saved order with the sections we actually ship: drop unknown ids
+// and append any newly-added sections, so an order saved by an older build
+// never hides a control or leaves dnd-kit referencing a missing section.
+function reconcileToolbarOrder(saved: string[]): string[] {
+  const known = new Set(DEFAULT_TOOLBAR_ORDER);
+  const kept = saved.filter((id) => known.has(id));
+  const missing = DEFAULT_TOOLBAR_ORDER.filter((id) => !kept.includes(id));
+  return [...kept, ...missing];
+}
+
+// One reorderable toolbar group. Always draggable, no separate handle: the 6px
+// pointer activation distance (see the DndContext sensor) means a tap still
+// clicks the controls inside — only a press-and-move starts a drag.
+function ToolbarSection({ id, children }: { id: string; children: ReactNode }) {
+  const { setNodeRef, listeners, transform, transition, isDragging } = useSortable({ id });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`toolbar__section${isDragging ? ' toolbar__section--dragging' : ''}`}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition,
+        zIndex: isDragging ? 50 : undefined,
+      }}
+      {...listeners}
+    >
+      {children}
+    </div>
+  );
+}
+
 export function Toolbar() {
   const { t } = useTranslation();
   const mapName         = useMapStore((s) => s.map.name);
@@ -235,180 +280,213 @@ export function Toolbar() {
   const mapSwitcherRef = useRef<HTMLDivElement>(null);
   useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
 
+  // Per-user, cross-device section order. Drag a section to reorder; the reset
+  // button restores the default. Reconciled each render so a stale/partial
+  // saved order can't hide a control.
+  const [savedSectionOrder, setSavedSectionOrder] =
+    useUserSetting<string[]>('nexum.toolbar.sections', DEFAULT_TOOLBAR_ORDER);
+  const sectionOrder = reconcileToolbarOrder(savedSectionOrder);
+  const atDefaultOrder = sectionOrder.length === DEFAULT_TOOLBAR_ORDER.length
+    && sectionOrder.every((id, i) => id === DEFAULT_TOOLBAR_ORDER[i]);
+  const dragSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const onSectionDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const from = sectionOrder.indexOf(active.id as string);
+    const to   = sectionOrder.indexOf(over.id as string);
+    if (from !== -1 && to !== -1) setSavedSectionOrder(arrayMove(sectionOrder, from, to));
+  };
+
   async function handleDeleteMap() {
     if (!activeMapId) return;
     await deleteMap(activeMapId);
   }
 
-  return (
-    <>
-    <header className="toolbar">
-      <div className="toolbar__brand">
-        <span className="toolbar__logo">◈</span>
-      </div>
-
-      {/* Map switcher */}
-      <div className="toolbar__map-switcher" ref={mapSwitcherRef}>
-        <button
-          className="toolbar__map-name-btn"
-          onClick={() => setShowMaps((v) => !v)}
-          title={t('toolbar.switchMap')}
-        >
-          {(() => {
-            const active = maps.find((m) => m.id === activeMapId);
-            if (!active) return null;
-            if (active.sharedWithMe) {
-              return <span className="toolbar__map-type toolbar__map-type--shared">{t('toolbar.mapType.shared')}</span>;
-            }
-            if (!user?.corpMode) return null;
-            return active.isCorpMap
-              ? <span className="toolbar__map-type toolbar__map-type--corp">{t('toolbar.mapType.corp')}</span>
-              : <span className="toolbar__map-type toolbar__map-type--solo">{t('toolbar.mapType.solo')}</span>;
-          })()}
-          {mapName || t('toolbar.noMap')}
-          <span className="toolbar__caret">▾</span>
-        </button>
-
-        {mapLocked && (
-          <span
-            className="toolbar__locked-chip"
-            data-tooltip={t('toolbar.lockedTooltip')}
+  // Each reorderable section's content, keyed by id. Brand and the account
+  // actions (API keys / sign out) live outside this map — they're pinned.
+  const sections: Record<string, ReactNode> = {
+    map: (
+      <>
+        <div className="toolbar__map-switcher" ref={mapSwitcherRef}>
+          <button
+            className="toolbar__map-name-btn"
+            onClick={() => setShowMaps((v) => !v)}
+            title={t('toolbar.switchMap')}
           >
-            <span className="toolbar__locked-icon">🔒</span>
-            {t('toolbar.locked')}
-          </span>
-        )}
+            {(() => {
+              const active = maps.find((m) => m.id === activeMapId);
+              if (!active) return null;
+              if (active.sharedWithMe) {
+                return <span className="toolbar__map-type toolbar__map-type--shared">{t('toolbar.mapType.shared')}</span>;
+              }
+              if (!user?.corpMode) return null;
+              return active.isCorpMap
+                ? <span className="toolbar__map-type toolbar__map-type--corp">{t('toolbar.mapType.corp')}</span>
+                : <span className="toolbar__map-type toolbar__map-type--solo">{t('toolbar.mapType.solo')}</span>;
+            })()}
+            {mapName || t('toolbar.noMap')}
+            <span className="toolbar__caret">▾</span>
+          </button>
 
-        {showMaps && (
-          <div className="map-dropdown" onMouseLeave={() => setShowMaps(false)}>
-            {[...maps].sort((a, b) => {
-              // Three-tier ordering: own personal → corp → shared-with-me.
-              // Inside a tier, alphabetical by name.
-              const aTier = a.sharedWithMe ? 2 : a.isCorpMap ? 1 : 0;
-              const bTier = b.sharedWithMe ? 2 : b.isCorpMap ? 1 : 0;
-              if (aTier !== bTier) return aTier - bTier;
-              return a.name.localeCompare(b.name);
-            }).map((m) => (
-              <button
-                key={m.id}
-                className={`map-dropdown__item${m.id === activeMapId ? ' map-dropdown__item--active' : ''}`}
-                onClick={async () => { setShowMaps(false); await switchMap(m.id); requestFitView(); }}
-              >
-                {m.sharedWithMe
-                  ? <span className="map-dropdown__badge map-dropdown__badge--shared">{t('toolbar.mapType.shared')}</span>
-                  : user?.corpMode && !m.isCorpMap
-                    ? <span className="map-dropdown__badge map-dropdown__badge--solo">{t('toolbar.mapType.solo')}</span>
-                    : null}
-                {!m.sharedWithMe && m.isCorpMap && <span className="map-dropdown__badge map-dropdown__badge--corp">{t('toolbar.mapType.corp')}</span>}
-                {m.locked    && <span className="map-dropdown__badge map-dropdown__badge--lock">🔒</span>}
-                {m.name}
-              </button>
-            ))}
-            <div className="map-dropdown__divider" />
+          {mapLocked && (
             <span
-              className={`map-dropdown__new-wrap${noCreateOption ? ' map-dropdown__new-wrap--disabled' : ''}`}
-              data-disabled-reason={noCreateOption ? t('toolbar.mapLimitReached') : undefined}
+              className="toolbar__locked-chip"
+              data-tooltip={t('toolbar.lockedTooltip')}
             >
-              <button
-                className="map-dropdown__item map-dropdown__item--action"
-                onClick={() => { setShowMaps(false); setShowCreate(true); }}
-                disabled={noCreateOption}
-              >
-                {t('toolbar.newMap')}
-              </button>
+              <span className="toolbar__locked-icon">🔒</span>
+              {t('toolbar.locked')}
             </span>
-            {canManageMaps && maps.length > 1 && !maps.find((m) => m.id === activeMapId)?.sharedWithMe && (
-              <button className="map-dropdown__item map-dropdown__item--danger" onClick={() => { setShowMaps(false); setDeleteConfirm(true); }}>
-                {t('toolbar.deleteThisMap')}
-              </button>
-            )}
-          </div>
+          )}
+
+          {showMaps && (
+            <div className="map-dropdown" onMouseLeave={() => setShowMaps(false)}>
+              {[...maps].sort((a, b) => {
+                // Three-tier ordering: own personal → corp → shared-with-me.
+                // Inside a tier, alphabetical by name.
+                const aTier = a.sharedWithMe ? 2 : a.isCorpMap ? 1 : 0;
+                const bTier = b.sharedWithMe ? 2 : b.isCorpMap ? 1 : 0;
+                if (aTier !== bTier) return aTier - bTier;
+                return a.name.localeCompare(b.name);
+              }).map((m) => (
+                <button
+                  key={m.id}
+                  className={`map-dropdown__item${m.id === activeMapId ? ' map-dropdown__item--active' : ''}`}
+                  onClick={async () => { setShowMaps(false); await switchMap(m.id); requestFitView(); }}
+                >
+                  {m.sharedWithMe
+                    ? <span className="map-dropdown__badge map-dropdown__badge--shared">{t('toolbar.mapType.shared')}</span>
+                    : user?.corpMode && !m.isCorpMap
+                      ? <span className="map-dropdown__badge map-dropdown__badge--solo">{t('toolbar.mapType.solo')}</span>
+                      : null}
+                  {!m.sharedWithMe && m.isCorpMap && <span className="map-dropdown__badge map-dropdown__badge--corp">{t('toolbar.mapType.corp')}</span>}
+                  {m.locked    && <span className="map-dropdown__badge map-dropdown__badge--lock">🔒</span>}
+                  {m.name}
+                </button>
+              ))}
+              <div className="map-dropdown__divider" />
+              <span
+                className={`map-dropdown__new-wrap${noCreateOption ? ' map-dropdown__new-wrap--disabled' : ''}`}
+                data-disabled-reason={noCreateOption ? t('toolbar.mapLimitReached') : undefined}
+              >
+                <button
+                  className="map-dropdown__item map-dropdown__item--action"
+                  onClick={() => { setShowMaps(false); setShowCreate(true); }}
+                  disabled={noCreateOption}
+                >
+                  {t('toolbar.newMap')}
+                </button>
+              </span>
+              {canManageMaps && maps.length > 1 && !maps.find((m) => m.id === activeMapId)?.sharedWithMe && (
+                <button className="map-dropdown__item map-dropdown__item--danger" onClick={() => { setShowMaps(false); setDeleteConfirm(true); }}>
+                  {t('toolbar.deleteThisMap')}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="toolbar__option">
+          <label className="toolbar__option-label" htmlFor="map-name">{t('toolbar.name')}</label>
+          <input
+            id="map-name"
+            className="toolbar__map-name"
+            value={mapName}
+            onChange={(e) => setMapName(e.target.value)}
+            // Let the field own its pointer (caret / text selection) without the
+            // surrounding section reading the drag as a reorder.
+            onPointerDown={(e) => e.stopPropagation()}
+            spellCheck={false}
+            readOnly={!canEdit || !isMapOwner}
+          />
+        </div>
+      </>
+    ),
+
+    status: (
+      <>
+        <div className="toolbar__stats">
+          <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>
+            <PlanetIcon size={16} weight="regular" />
+            <span className="toolbar__stat-count">{systemCount}</span>
+          </span>
+          <span className="toolbar__stat" data-tooltip={t('toolbar.totalConnections')}>
+            <LinkSimpleIcon size={16} weight="regular" />
+            <span className="toolbar__stat-count">{connectionCount}</span>
+          </span>
+        </div>
+        <ProximityChip />
+      </>
+    ),
+
+    tools: (
+      <>
+        {user && (user.canViewReports || (user.role === 'admin' && user.corpMode)) && (
+          <button
+            className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+            onClick={() => { window.location.hash = '#/admin/users'; }}
+            data-tooltip={t('toolbar.admin')}
+            aria-label={t('toolbar.admin')}
+          >
+            <ShieldStarIcon size={18} weight="regular" />
+          </button>
         )}
-      </div>
-
-      {/* Map name edit */}
-      <div className="toolbar__option">
-        <label className="toolbar__option-label" htmlFor="map-name">{t('toolbar.name')}</label>
-        <input
-          id="map-name"
-          className="toolbar__map-name"
-          value={mapName}
-          onChange={(e) => setMapName(e.target.value)}
-          spellCheck={false}
-          readOnly={!canEdit || !isMapOwner}
-        />
-      </div>
-
-      {/* Wrap point on narrow screens: map-editing controls stay on row 1,
-          stats/tools/user drop to row 2 (see the toolbar media query). */}
-      <div className="toolbar__spacer toolbar__spacer--break" />
-
-      <div className="toolbar__stats">
-        <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>
-          <PlanetIcon size={16} weight="regular" />
-          <span className="toolbar__stat-count">{systemCount}</span>
-        </span>
-        <span className="toolbar__stat" data-tooltip={t('toolbar.totalConnections')}>
-          <LinkSimpleIcon size={16} weight="regular" />
-          <span className="toolbar__stat-count">{connectionCount}</span>
-        </span>
-      </div>
-
-      <ProximityChip />
-
-      <div className="toolbar__spacer" />
-
-      {user && (user.canViewReports || (user.role === 'admin' && user.corpMode)) && (
         <button
           className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-          onClick={() => { window.location.hash = '#/admin/users'; }}
-          data-tooltip={t('toolbar.admin')}
-          aria-label={t('toolbar.admin')}
+          onClick={() => setShowStats(true)}
+          data-tooltip={t('toolbar.userStats')}
+          aria-label={t('toolbar.userStats')}
         >
-          <ShieldStarIcon size={18} weight="regular" />
+          <ChartBarIcon size={18} weight="regular" />
         </button>
-      )}
-      <button
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        onClick={() => setShowStats(true)}
-        data-tooltip={t('toolbar.userStats')}
-        aria-label={t('toolbar.userStats')}
-      >
-        <ChartBarIcon size={18} weight="regular" />
-      </button>
 
-      <a
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        href="/help/"
-        target="_blank"
-        rel="noopener noreferrer"
-        data-tooltip={t('toolbar.help')}
-        aria-label={t('toolbar.help')}
-      >
-        <QuestionIcon size={18} weight="regular" />
-      </a>
+        <a
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          href="/help/"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-tooltip={t('toolbar.help')}
+          aria-label={t('toolbar.help')}
+        >
+          <QuestionIcon size={18} weight="regular" />
+        </a>
 
-      <button
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        onClick={() => setShowWhChart(true)}
-        data-tooltip={t('whChart.tooltip')}
-        aria-label={t('whChart.title')}
-      >
-        <GraphIcon size={18} weight="regular" />
-      </button>
+        <button
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          onClick={() => setShowWhChart(true)}
+          data-tooltip={t('whChart.tooltip')}
+          aria-label={t('whChart.title')}
+        >
+          <GraphIcon size={18} weight="regular" />
+        </button>
 
-      <HeatmapMenu />
+        <HeatmapMenu />
 
-      <button
-        className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
-        onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
-        aria-pressed={mapOptionsOpen}
-        data-tooltip={t('toolbar.mapOptions')}
-        aria-label={t('toolbar.mapOptions')}
-      >
-        <SlidersHorizontalIcon size={18} weight="regular" />
-      </button>
+        <button
+          className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
+          onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
+          aria-pressed={mapOptionsOpen}
+          data-tooltip={t('toolbar.mapOptions')}
+          aria-label={t('toolbar.mapOptions')}
+        >
+          <SlidersHorizontalIcon size={18} weight="regular" />
+        </button>
 
+        <button
+          className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
+          onClick={() => setTrackJumps(!trackJumps)}
+          aria-pressed={trackJumps}
+          aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
+          data-tooltip={trackJumps
+            ? t('toolbar.trackJumpsTooltipOn')
+            : t('toolbar.trackJumpsTooltipOff')}
+        >
+          <FootprintsIcon size={18} weight="regular" />
+          <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
+        </button>
+      </>
+    ),
+
+    server: (
       <div className="toolbar__server-status">
         <div className="toolbar__server-row">
           <span
@@ -442,85 +520,106 @@ export function Toolbar() {
           <span className="toolbar__server-label">ESI</span>
         </div>
       </div>
+    ),
 
-      <button
-        className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
-        onClick={() => setTrackJumps(!trackJumps)}
-        aria-pressed={trackJumps}
-        aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
-        data-tooltip={trackJumps
-          ? t('toolbar.trackJumpsTooltipOn')
-          : t('toolbar.trackJumpsTooltipOff')}
-      >
-        <FootprintsIcon size={18} weight="regular" />
-        <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
-      </button>
+    account: user ? (
+      <div className="toolbar__user">
+        <span
+          className={`toolbar__online-dot${online === true ? ' toolbar__online-dot--on' : online === false ? ' toolbar__online-dot--off' : ''}`}
+          title={onlineTooltip(t, online, lastLogin)}
+        />
+        <img
+          className="toolbar__avatar"
+          src={charPortrait(user.characterId, 64)}
+          alt={user.characterName}
+        />
+        {ship && (
+          <span
+            className="toolbar__ship-wrap"
+            data-tooltip={ship.shipName && ship.shipName !== ship.typeName
+              ? `${ship.typeName} — ${ship.shipName}`
+              : ship.typeName}
+          >
+            <img
+              className="toolbar__ship"
+              src={typeIcon(ship.typeId, 64)}
+              alt={ship.typeName}
+            />
+          </span>
+        )}
+        <div className="toolbar__char-info">
+          <span className="toolbar__char-name">
+            {user.characterName}
+            {/* Role only matters in corp mode — in solo deployments every
+                user is implicitly admin of their own maps, so the badge
+                just adds noise. */}
+            {user.corpMode && (
+              <span
+                className={`role-badge role-badge--${user.role}`}
+                title={t('toolbar.role', { role: user.role })}
+              >
+                {user.role}
+              </span>
+            )}
+          </span>
+          <div className="toolbar__char-sub">
+            {shownSystem && (shownSystemOnMap ? (
+              <button
+                type="button"
+                className="toolbar__char-system toolbar__char-system--clickable"
+                data-tooltip={t('toolbar.centerOnSystem', { system: shownSystem })}
+                onClick={() => { if (shownSystemEveId != null) requestCenterOnEveSystem(shownSystemEveId); }}
+              >
+                <MapPinIcon size={11} weight="fill" />
+                {shownSystem}
+              </button>
+            ) : (
+              <span
+                className="toolbar__char-system"
+                data-tooltip={shownSystemIsLast ? t('toolbar.lastKnownSystem') : t('toolbar.currentSystem')}
+              >
+                <MapPinIcon size={11} weight="fill" />
+                {shownSystem}
+              </span>
+            ))}
+            {checkedAt && <CheckedAtIcon checkedAt={checkedAt} />}
+          </div>
+        </div>
+        <CharacterSwitcher />
+        <LanguageSwitcher />
+      </div>
+    ) : null,
+  };
+
+  const renderOrder = sectionOrder.filter((id) => sections[id] != null);
+
+  return (
+    <>
+    <header className="toolbar">
+      <div className="toolbar__brand">
+        <span className="toolbar__logo">◈</span>
+      </div>
+
+      <DndContext sensors={dragSensors} collisionDetection={closestCenter} onDragEnd={onSectionDragEnd}>
+        <SortableContext items={renderOrder} strategy={rectSortingStrategy}>
+          {renderOrder.map((id) => (
+            <ToolbarSection key={id} id={id}>{sections[id]}</ToolbarSection>
+          ))}
+        </SortableContext>
+      </DndContext>
 
       {user && (
-        <div className="toolbar__user">
-          <span
-            className={`toolbar__online-dot${online === true ? ' toolbar__online-dot--on' : online === false ? ' toolbar__online-dot--off' : ''}`}
-            title={onlineTooltip(t, online, lastLogin)}
-          />
-          <img
-            className="toolbar__avatar"
-            src={charPortrait(user.characterId, 64)}
-            alt={user.characterName}
-          />
-          {ship && (
-            <span
-              className="toolbar__ship-wrap"
-              data-tooltip={ship.shipName && ship.shipName !== ship.typeName
-                ? `${ship.typeName} — ${ship.shipName}`
-                : ship.typeName}
+        <div className="toolbar__anchor-right">
+          {!atDefaultOrder && (
+            <button
+              className="toolbar__toggle toolbar__toggle--icon"
+              onClick={() => setSavedSectionOrder(DEFAULT_TOOLBAR_ORDER)}
+              data-tooltip={t('toolbar.resetLayout')}
+              aria-label={t('toolbar.resetLayout')}
             >
-              <img
-                className="toolbar__ship"
-                src={typeIcon(ship.typeId, 64)}
-                alt={ship.typeName}
-              />
-            </span>
+              <ArrowCounterClockwiseIcon size={16} weight="regular" />
+            </button>
           )}
-          <div className="toolbar__char-info">
-            <span className="toolbar__char-name">
-              {user.characterName}
-              {/* Role only matters in corp mode — in solo deployments every
-                  user is implicitly admin of their own maps, so the badge
-                  just adds noise. */}
-              {user.corpMode && (
-                <span
-                  className={`role-badge role-badge--${user.role}`}
-                  title={t('toolbar.role', { role: user.role })}
-                >
-                  {user.role}
-                </span>
-              )}
-            </span>
-            <div className="toolbar__char-sub">
-              {shownSystem && (shownSystemOnMap ? (
-                <button
-                  type="button"
-                  className="toolbar__char-system toolbar__char-system--clickable"
-                  data-tooltip={t('toolbar.centerOnSystem', { system: shownSystem })}
-                  onClick={() => { if (shownSystemEveId != null) requestCenterOnEveSystem(shownSystemEveId); }}
-                >
-                  <MapPinIcon size={11} weight="fill" />
-                  {shownSystem}
-                </button>
-              ) : (
-                <span
-                  className="toolbar__char-system"
-                  data-tooltip={shownSystemIsLast ? t('toolbar.lastKnownSystem') : t('toolbar.currentSystem')}
-                >
-                  <MapPinIcon size={11} weight="fill" />
-                  {shownSystem}
-                </span>
-              ))}
-              {checkedAt && <CheckedAtIcon checkedAt={checkedAt} />}
-            </div>
-          </div>
-          <CharacterSwitcher />
-          <LanguageSwitcher />
           <button
             className="toolbar__toggle toolbar__toggle--icon"
             onClick={() => setShowKeys(true)}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -591,7 +591,6 @@ export function Toolbar() {
           </div>
         </div>
         <CharacterSwitcher />
-        <LanguageSwitcher />
       </div>
     ) : null,
   };
@@ -625,6 +624,7 @@ export function Toolbar() {
               <ArrowCounterClockwiseIcon size={16} weight="regular" />
             </button>
           )}
+          <LanguageSwitcher />
           <button
             className="toolbar__toggle toolbar__toggle--icon"
             onClick={() => setShowKeys(true)}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { timeAgo, jumps } from '../../i18n/format';
@@ -18,6 +18,7 @@ import { CharacterSwitcher } from './CharacterSwitcher';
 import { HeatmapMenu } from './HeatmapMenu';
 import { WhTypeChartModal } from './WhTypeChartModal';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
@@ -231,6 +232,8 @@ export function Toolbar() {
   const [showKeys, setShowKeys] = useState(false);
   const [showWhChart, setShowWhChart] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const mapSwitcherRef = useRef<HTMLDivElement>(null);
+  useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
 
   async function handleDeleteMap() {
     if (!activeMapId) return;
@@ -245,7 +248,7 @@ export function Toolbar() {
       </div>
 
       {/* Map switcher */}
-      <div className="toolbar__map-switcher">
+      <div className="toolbar__map-switcher" ref={mapSwitcherRef}>
         <button
           className="toolbar__map-name-btn"
           onClick={() => setShowMaps((v) => !v)}

--- a/web/src/components/ui/WHTypeInfo.tsx
+++ b/web/src/components/ui/WHTypeInfo.tsx
@@ -39,10 +39,12 @@ export function WHTypeInfo({ code, children }: Props) {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
-    window.addEventListener('mousedown', onClick);
+    // Capture phase: the react-flow map canvas swallows bubbling pointer events,
+    // so a bubbling listener wouldn't fire for clicks out on the map.
+    document.addEventListener('pointerdown', onClick, true);
     window.addEventListener('keydown', onKey);
     return () => {
-      window.removeEventListener('mousedown', onClick);
+      document.removeEventListener('pointerdown', onClick, true);
       window.removeEventListener('keydown', onKey);
     };
   }, [open, hoverMode]);

--- a/web/src/hooks/useClickOutside.ts
+++ b/web/src/hooks/useClickOutside.ts
@@ -14,8 +14,10 @@ export function useClickOutside<T extends HTMLElement>(
   ref: RefObject<T | null>,
   onOutside: () => void,
 ) {
+  // Keep the latest callback without re-subscribing the listener every render.
+  // Written in an effect, not during render — refs are write-after-commit.
   const cb = useRef(onOutside);
-  cb.current = onOutside;
+  useEffect(() => { cb.current = onOutside; });
 
   useEffect(() => {
     if (!enabled) return;

--- a/web/src/hooks/useClickOutside.ts
+++ b/web/src/hooks/useClickOutside.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+// Call `onOutside` when a pointer-down lands outside `ref` (e.g. to close a
+// menu/dropdown). No-op while `enabled` is false.
+//
+// Uses the CAPTURE phase + `pointerdown` deliberately: the react-flow map canvas
+// stops pointer-event propagation in the bubble phase, so a plain bubbling
+// listener never fires for clicks on the map — menus would stay open until you
+// clicked their own trigger. Capturing at the document means "click anywhere
+// outside" reliably closes, including on the map. Keep the menu's trigger button
+// inside `ref` so its own click toggles rather than triggering an outside-close.
+export function useClickOutside<T extends HTMLElement>(
+  enabled: boolean,
+  ref: RefObject<T | null>,
+  onOutside: () => void,
+) {
+  const cb = useRef(onOutside);
+  cb.current = onOutside;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) cb.current();
+    };
+    document.addEventListener('pointerdown', onDown, true);
+    return () => document.removeEventListener('pointerdown', onDown, true);
+  }, [enabled, ref]);
+}

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1011,6 +1011,7 @@
     "trackJumpsTooltipOn": "Tracking jumps — new systems are added as you move",
     "trackJumpsTooltipOff": "Not tracking jumps — only existing systems get the you-are-here indicator",
     "signOut": "Sign out",
+    "resetLayout": "Reset toolbar layout",
     "role": "Role: {{role}}",
     "checkedAgo": "checked {{time}}",
     "lastKnownSystem": "Last known system",


### PR DESCRIPTION
## v1.4.0

### Customisable toolbar (#254)
- The toolbar is now grouped into **drag-and-drop reorderable sections** (Map, Status, Tools, Server, Account), with the order persisted per-user (cross-device). Brand stays pinned far-left; language + API keys + sign out pinned far-right. A six-dot grip + hover chip signals draggability; a reset button restores the default.
- Sections are atomic units, so the responsive two-row wrap now drops whole groups cleanly (replaces the earlier forced-break hack).

### Menus close on outside click (#253)
- Dropdowns/menus (character switcher, language, heatmap, map switcher, WH-type popover, NPC-station context menu) now close on a click **anywhere** outside — including on the map canvas. Fixed via a shared capture-phase `useClickOutside` hook.

### Housekeeping
- Bump version to 1.4.0 (server + web).