### PR TITLE
Fix sovereignty rows breaking per-character on a narrow panel

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -4120,7 +4120,9 @@ div.system-node__easy-handle {
 
 .sys-info__sov {
   display: flex;
-  flex-wrap: nowrap;
+  /* Wrap on a narrow panel so the P/C/A standings drop below the name instead
+     of squeezing the name column until it breaks character-by-character. */
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   background: #0d1421;
@@ -4141,6 +4143,9 @@ div.system-node__easy-handle {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  /* Claim ~120px so the standings wrap below once the row can't hold name +
+     badges; min-width: 0 still lets the name word-wrap when space is tight. */
+  flex: 1 1 120px;
   min-width: 0;
 }
 
@@ -7953,7 +7958,8 @@ select.sig-toolbar-btn option {
 .sys-info__sov-standings {
   display: flex;
   gap: 4px;
-  margin-left: auto;
+  /* No margin-left:auto — the grown text column pushes the badges right on a
+     shared line, and when they wrap to their own line they sit left-aligned. */
 }
 
 .sys-info__sov-standing {


### PR DESCRIPTION
### Bug
On a narrow System panel, the **Sovereignty** rows broke the alliance/corp name **character-by-character** ("Insidi/ous", "Infra/struc/ture/Man/age/ment").

### Cause
Each sov row is `[logo] [name column] [P/C/A standings]` as a **`flex-wrap: nowrap`** row. The standings block is fixed-width (3 pills × 52px min-width ≈ 164px) and pinned with `margin-left: auto`, so on a narrow panel the name column collapsed to a few px and wrapped per-character.

### Fix
- `.sys-info__sov`: `flex-wrap: nowrap` → **`wrap`**, so the standings drop below the name when the row can't hold both.
- `.sys-info__sov-text`: `flex: 1 1 120px` so it claims enough width to force that wrap (keeps `min-width: 0` so the name still word-wraps when tight).
- `.sys-info__sov-standings`: drop `margin-left: auto` — the grown text column already pushes the badges right on a shared (wide) line, and when wrapped they sit left-aligned.

CSS-only.