### PR TITLE
Show sec status consistently on newly-added systems

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1446,25 +1446,36 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
   ).catch(console.error);
   await touchMap(mapId);
 
-  // Push the new system to other viewers of this map (live sync). Re-read the
-  // canonical row so the payload matches a fresh map load exactly (resolved
-  // eve id, security, etc.). actor = originating client → echo-suppressed.
-  db.query(
-    `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
-            region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
-            status, intel, is_home AS "isHome", locked, notes,
-            (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
-            last_activity_at AS "lastActivityAt"
-       FROM map_systems WHERE id = $1 AND map_id = $2`,
-    [id, mapId],
-  ).then(({ rows }) => {
+  // Re-read the canonical row so BOTH the live-sync payload and the response
+  // match a fresh map load exactly (resolved eve id, SDE security, etc.).
+  // Returning it lets the originating client backfill server-derived fields
+  // (e.g. security) onto its optimistic node — it's echo-suppressed from the
+  // broadcast below, so without this its node would lack sec status until a
+  // full reload.
+  let system: ({ position: { x: number; y: number } } & Record<string, unknown>) | null = null;
+  try {
+    const { rows } = await db.query(
+      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
+              region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
+              status, intel, is_home AS "isHome", locked, notes,
+              (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
+              last_activity_at AS "lastActivityAt"
+         FROM map_systems WHERE id = $1 AND map_id = $2`,
+      [id, mapId],
+    );
     const r = rows[0] as ({ x: number; y: number } & Record<string, unknown>) | undefined;
-    if (!r) return;
-    const { x, y, ...rest } = r;
-    publishToMap(mapId, { type: 'system.add', actor: req.get('x-client-id') ?? null, system: { ...rest, position: { x, y } } });
-  }).catch(console.error);
+    if (r) {
+      const { x, y, ...rest } = r;
+      system = { ...rest, position: { x, y } };
+      // Push to other viewers of this map (live sync). actor = originating
+      // client → echo-suppressed.
+      publishToMap(mapId, { type: 'system.add', actor: req.get('x-client-id') ?? null, system });
+    }
+  } catch (err) {
+    console.error(err);
+  }
 
-  res.status(201).json({ ok: true });
+  res.status(201).json({ ok: true, system });
 });
 
 mapsRouter.patch('/:mapId/systems/:systemId', async (req, res) => {

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -763,9 +763,29 @@ export const useMapStore = create<MapStore>()((set, get) => {
         if (activeMapId) {
           const url  = `/api/maps/${activeMapId}/systems`;
           const body = JSON.stringify({ ...added });
-          api(url, { method: 'POST', body }).catch(() =>
-            enqueue(`addSystem:${added.name}`, url, 'POST', body),
-          );
+          api<{ system?: { security?: number | null; eveSystemId?: number | null } }>(url, { method: 'POST', body })
+            .then((resp) => {
+              // Backfill server-derived fields (SDE security, resolved eve id)
+              // onto the optimistic node — addSystem can't know these, and the
+              // live-sync echo is suppressed for the originating client, so
+              // without this the node would lack sec status until a reload.
+              const srv = resp?.system;
+              if (!srv) return;
+              set((s) => ({
+                map: {
+                  ...s.map,
+                  systems: s.map.systems.map((sys) =>
+                    sys.id === id
+                      ? {
+                          ...sys,
+                          ...(srv.security != null ? { security: srv.security } : {}),
+                          ...(srv.eveSystemId != null ? { eveSystemId: srv.eveSystemId } : {}),
+                        }
+                      : sys),
+                },
+              }));
+            })
+            .catch(() => enqueue(`addSystem:${added.name}`, url, 'POST', body));
         }
       }
 


### PR DESCRIPTION
### Bug
Known-space system nodes **sometimes** show their security status and sometimes don't (e.g. the just-jumped-to system shows no sec number while its neighbours do).

### Cause
`security` is derived server-side from the SDE (`solar_systems` join) **only on map read**. When a system is added during the session:
- The client's optimistic node has no `security` (addSystem can't know it).
- The server broadcasts `system.add` *with* security to other viewers — but **echo-suppresses the originating client**.
- So the adder's node has no sec status until a full reload; other viewers' nodes do.

### Fix
- **Server** `POST /:mapId/systems`: it already re-reads the canonical row (with the SDE security) for the live-sync broadcast — now also returns that row in the response (`{ ok: true, system }`).
- **Client** `addSystem`: on the POST response, backfill `security` (and the resolved `eveSystemId`) onto the optimistic node via a local-only state update.

Path-agnostic (covers tracked / gate / WH / manual adds), no extra round-trip. Server `tsc`, web `tsc`/build, and lint all clean.