### PR TITLE
Add a 'centre on me' map control

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  ReactFlow, Background, Controls, MiniMap,
+  ReactFlow, Background, Controls, ControlButton, MiniMap,
   useNodesState, BackgroundVariant, useReactFlow, ConnectionMode,
   applyNodeChanges,
 } from '@xyflow/react';
@@ -22,7 +22,7 @@ import { AddSystemModal } from '../ui/AddSystemModal';
 import { ContextMenu } from '../ui/ContextMenu';
 import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
-  XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon,
+  XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
 } from '@phosphor-icons/react';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -137,6 +137,7 @@ export function MapCanvas() {
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
   const centerRequestNodeId  = useMapStore((s) => s.centerRequestNodeId);
   const clearCenterRequest   = useMapStore((s) => s.clearCenterRequest);
+  const currentSystemId      = useMapStore((s) => s.currentSystemId);
   const routeOrigin          = useMapStore((s) => s.routeOrigin);
   const setRouteOrigin       = useMapStore((s) => s.setRouteOrigin);
   const requestCenterOnEveSystem = useMapStore((s) => s.requestCenterOnEveSystem);
@@ -263,6 +264,12 @@ export function MapCanvas() {
     );
     return true;
   }, [getNode, getZoom, setViewport]);
+
+  // "Centre on me" map-control: recentre on the pilot's current system node
+  // (the you-are-here node). Disabled when the pilot isn't in a mapped system.
+  const centerOnMe = useCallback(() => {
+    if (currentSystemId) centerOnSystem(currentSystemId);
+  }, [currentSystemId, centerOnSystem]);
 
   // On first load after login, centre the viewport on the pilot's last known
   // system (from /auth/me) if it's present on this map — so you land where you
@@ -1046,7 +1053,16 @@ export function MapCanvas() {
           size={snapToGrid ? 1 : 1}
           color={snapToGrid ? '#1a2240' : '#1a2040'}
         />
-        <Controls position={controlsPosition} />
+        <Controls position={controlsPosition}>
+          <ControlButton
+            onClick={centerOnMe}
+            disabled={!currentSystemId}
+            title={t('mapControls.centerOnMe')}
+            aria-label={t('mapControls.centerOnMe')}
+          >
+            <CrosshairSimpleIcon size={14} weight="bold" />
+          </ControlButton>
+        </Controls>
         {showMinimap && (
           <MiniMap
             pannable

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -647,7 +647,8 @@
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
     "fitView": "Fit view",
-    "interactive": "Toggle interactivity"
+    "interactive": "Toggle interactivity",
+    "centerOnMe": "Centre on my location"
   },
   "demo": {
     "hintClick": "Click a system to view its details here.",


### PR DESCRIPTION
Adds a **centre-on-me** button to the bottom map controls (alongside zoom / lock).

- A `ControlButton` (crosshair icon) that recentres the viewport on the pilot's **current system node** — the you-are-here node — via the existing `centerOnSystem` helper.
- **Disabled** when the pilot isn't in a mapped system (`currentSystemId == null`), e.g. offline or in an unmapped system with track-jumps off.
- New i18n key `mapControls.centerOnMe`.