### PR TITLE
Add Optimize Connections + Spread Nodes to the map context menu

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  ReactFlow, Background, Controls, MiniMap,
+  ReactFlow, Background, Controls, ControlButton, MiniMap,
   useNodesState, BackgroundVariant, useReactFlow, ConnectionMode,
   applyNodeChanges,
 } from '@xyflow/react';
@@ -22,7 +22,7 @@ import { AddSystemModal } from '../ui/AddSystemModal';
 import { ContextMenu } from '../ui/ContextMenu';
 import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
-  XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon,
+  XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
 } from '@phosphor-icons/react';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -137,6 +137,7 @@ export function MapCanvas() {
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
   const centerRequestNodeId  = useMapStore((s) => s.centerRequestNodeId);
   const clearCenterRequest   = useMapStore((s) => s.clearCenterRequest);
+  const currentSystemId      = useMapStore((s) => s.currentSystemId);
   const routeOrigin          = useMapStore((s) => s.routeOrigin);
   const setRouteOrigin       = useMapStore((s) => s.setRouteOrigin);
   const requestCenterOnEveSystem = useMapStore((s) => s.requestCenterOnEveSystem);
@@ -263,6 +264,12 @@ export function MapCanvas() {
     );
     return true;
   }, [getNode, getZoom, setViewport]);
+
+  // "Centre on me" map-control: recentre on the pilot's current system node
+  // (the you-are-here node). Disabled when the pilot isn't in a mapped system.
+  const centerOnMe = useCallback(() => {
+    if (currentSystemId) centerOnSystem(currentSystemId);
+  }, [currentSystemId, centerOnSystem]);
 
   // On first load after login, centre the viewport on the pilot's last known
   // system (from /auth/me) if it's present on this map — so you land where you
@@ -1046,7 +1053,16 @@ export function MapCanvas() {
           size={snapToGrid ? 1 : 1}
           color={snapToGrid ? '#1a2240' : '#1a2040'}
         />
-        <Controls position={controlsPosition} />
+        <Controls position={controlsPosition}>
+          <ControlButton
+            onClick={centerOnMe}
+            disabled={!currentSystemId}
+            title={t('mapControls.centerOnMe')}
+            aria-label={t('mapControls.centerOnMe')}
+          >
+            <CrosshairSimpleIcon size={14} weight="bold" />
+          </ControlButton>
+        </Controls>
         {showMinimap && (
           <MiniMap
             pannable

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -23,6 +23,7 @@ import { ContextMenu } from '../ui/ContextMenu';
 import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
   XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
+  LinkSimpleIcon, ArrowsOutIcon,
 } from '@phosphor-icons/react';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -131,6 +132,7 @@ export function MapCanvas() {
   const autoLayoutPending    = useMapStore((s) => s.autoLayoutPending);
   const clearAutoLayoutPending = useMapStore((s) => s.clearAutoLayoutPending);
   const requestAutoLayout    = useMapStore((s) => s.requestAutoLayout);
+  const optimizeConnections  = useMapStore((s) => s.optimizeConnections);
   const compactMode          = useMapStore((s) => s.compactMode);
   const fitViewPending       = useMapStore((s) => s.fitViewPending);
   const clearFitView         = useMapStore((s) => s.clearFitView);
@@ -1006,6 +1008,18 @@ export function MapCanvas() {
         label: t('ctxMenu.selectAll'),
         icon: <SelectionAllIcon size={14} weight="regular" />,
         action: () => setNodes((ns) => ns.map((n) => ({ ...n, selected: true }))),
+        disabled: nodes.length === 0,
+      },
+      {
+        label: t('ctxMenu.optimizeConnections'),
+        icon: <LinkSimpleIcon size={15} weight="regular" />,
+        action: () => optimizeConnections(),
+        disabled: connections.length === 0,
+      },
+      {
+        label: t('ctxMenu.spreadNodes'),
+        icon: <ArrowsOutIcon size={15} weight="regular" />,
+        action: () => requestAutoLayout(),
         disabled: nodes.length === 0,
       },
     ];

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -647,7 +647,8 @@
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
     "fitView": "Fit view",
-    "interactive": "Toggle interactivity"
+    "interactive": "Toggle interactivity",
+    "centerOnMe": "Centre on my location"
   },
   "demo": {
     "hintClick": "Click a system to view its details here.",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -662,6 +662,8 @@
   },
   "ctxMenu": {
     "disconnect": "Disconnect",
+    "optimizeConnections": "Optimize Connections",
+    "spreadNodes": "Spread Nodes",
     "jumpType": "Jump Type",
     "standardJump": "Standard Jump",
     "jumpgate": "Jumpgate",


### PR DESCRIPTION
Adds the two layout actions to the **empty-canvas right-click menu** (previously sidebar-only):

- **Optimize Connections** — `optimizeConnections()` (re-pick optimal handle sides). Disabled when there are no connections.
- **Spread Nodes** — `requestAutoLayout()` (auto-layout to stop overlaps). Disabled when there are no nodes.

Both are in the `canEdit` branch of the context-menu builder, so they only appear for users who can edit the topology. New i18n keys `ctxMenu.optimizeConnections` / `ctxMenu.spreadNodes` (clean labels without the sidebar's glyph prefixes).

### ⚠️ Stacked on #263
Built on top of `feat/center-on-me-control` (#263) because both touch the same MapCanvas import line / locale file. **Merge #263 first** — then this PR's diff reduces to the context-menu changes only.