### PR TITLE
Release v1.5.2

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1446,25 +1446,36 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
   ).catch(console.error);
   await touchMap(mapId);
 
-  // Push the new system to other viewers of this map (live sync). Re-read the
-  // canonical row so the payload matches a fresh map load exactly (resolved
-  // eve id, security, etc.). actor = originating client → echo-suppressed.
-  db.query(
-    `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
-            region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
-            status, intel, is_home AS "isHome", locked, notes,
-            (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
-            last_activity_at AS "lastActivityAt"
-       FROM map_systems WHERE id = $1 AND map_id = $2`,
-    [id, mapId],
-  ).then(({ rows }) => {
+  // Re-read the canonical row so BOTH the live-sync payload and the response
+  // match a fresh map load exactly (resolved eve id, SDE security, etc.).
+  // Returning it lets the originating client backfill server-derived fields
+  // (e.g. security) onto its optimistic node — it's echo-suppressed from the
+  // broadcast below, so without this its node would lack sec status until a
+  // full reload.
+  let system: ({ position: { x: number; y: number } } & Record<string, unknown>) | null = null;
+  try {
+    const { rows } = await db.query(
+      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
+              region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
+              status, intel, is_home AS "isHome", locked, notes,
+              (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
+              last_activity_at AS "lastActivityAt"
+         FROM map_systems WHERE id = $1 AND map_id = $2`,
+      [id, mapId],
+    );
     const r = rows[0] as ({ x: number; y: number } & Record<string, unknown>) | undefined;
-    if (!r) return;
-    const { x, y, ...rest } = r;
-    publishToMap(mapId, { type: 'system.add', actor: req.get('x-client-id') ?? null, system: { ...rest, position: { x, y } } });
-  }).catch(console.error);
+    if (r) {
+      const { x, y, ...rest } = r;
+      system = { ...rest, position: { x, y } };
+      // Push to other viewers of this map (live sync). actor = originating
+      // client → echo-suppressed.
+      publishToMap(mapId, { type: 'system.add', actor: req.get('x-client-id') ?? null, system });
+    }
+  } catch (err) {
+    console.error(err);
+  }
 
-  res.status(201).json({ ok: true });
+  res.status(201).json({ ok: true, system });
 });
 
 mapsRouter.patch('/:mapId/systems/:systemId', async (req, res) => {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -4120,7 +4120,9 @@ div.system-node__easy-handle {
 
 .sys-info__sov {
   display: flex;
-  flex-wrap: nowrap;
+  /* Wrap on a narrow panel so the P/C/A standings drop below the name instead
+     of squeezing the name column until it breaks character-by-character. */
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   background: #0d1421;
@@ -4141,6 +4143,9 @@ div.system-node__easy-handle {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  /* Claim ~120px so the standings wrap below once the row can't hold name +
+     badges; min-width: 0 still lets the name word-wrap when space is tight. */
+  flex: 1 1 120px;
   min-width: 0;
 }
 
@@ -7953,7 +7958,8 @@ select.sig-toolbar-btn option {
 .sys-info__sov-standings {
   display: flex;
   gap: 4px;
-  margin-left: auto;
+  /* No margin-left:auto — the grown text column pushes the badges right on a
+     shared line, and when they wrap to their own line they sit left-aligned. */
 }
 
 .sys-info__sov-standing {

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  ReactFlow, Background, Controls, MiniMap,
+  ReactFlow, Background, Controls, ControlButton, MiniMap,
   useNodesState, BackgroundVariant, useReactFlow, ConnectionMode,
   applyNodeChanges,
 } from '@xyflow/react';
@@ -22,7 +22,7 @@ import { AddSystemModal } from '../ui/AddSystemModal';
 import { ContextMenu } from '../ui/ContextMenu';
 import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
-  XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon,
+  XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
 } from '@phosphor-icons/react';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -137,6 +137,7 @@ export function MapCanvas() {
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
   const centerRequestNodeId  = useMapStore((s) => s.centerRequestNodeId);
   const clearCenterRequest   = useMapStore((s) => s.clearCenterRequest);
+  const currentSystemId      = useMapStore((s) => s.currentSystemId);
   const routeOrigin          = useMapStore((s) => s.routeOrigin);
   const setRouteOrigin       = useMapStore((s) => s.setRouteOrigin);
   const requestCenterOnEveSystem = useMapStore((s) => s.requestCenterOnEveSystem);
@@ -263,6 +264,12 @@ export function MapCanvas() {
     );
     return true;
   }, [getNode, getZoom, setViewport]);
+
+  // "Centre on me" map-control: recentre on the pilot's current system node
+  // (the you-are-here node). Disabled when the pilot isn't in a mapped system.
+  const centerOnMe = useCallback(() => {
+    if (currentSystemId) centerOnSystem(currentSystemId);
+  }, [currentSystemId, centerOnSystem]);
 
   // On first load after login, centre the viewport on the pilot's last known
   // system (from /auth/me) if it's present on this map — so you land where you
@@ -1046,7 +1053,16 @@ export function MapCanvas() {
           size={snapToGrid ? 1 : 1}
           color={snapToGrid ? '#1a2240' : '#1a2040'}
         />
-        <Controls position={controlsPosition} />
+        <Controls position={controlsPosition}>
+          <ControlButton
+            onClick={centerOnMe}
+            disabled={!currentSystemId}
+            title={t('mapControls.centerOnMe')}
+            aria-label={t('mapControls.centerOnMe')}
+          >
+            <CrosshairSimpleIcon size={14} weight="bold" />
+          </ControlButton>
+        </Controls>
         {showMinimap && (
           <MiniMap
             pannable

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -23,6 +23,7 @@ import { ContextMenu } from '../ui/ContextMenu';
 import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
   XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
+  LinkSimpleIcon, ArrowsOutIcon,
 } from '@phosphor-icons/react';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -131,6 +132,7 @@ export function MapCanvas() {
   const autoLayoutPending    = useMapStore((s) => s.autoLayoutPending);
   const clearAutoLayoutPending = useMapStore((s) => s.clearAutoLayoutPending);
   const requestAutoLayout    = useMapStore((s) => s.requestAutoLayout);
+  const optimizeConnections  = useMapStore((s) => s.optimizeConnections);
   const compactMode          = useMapStore((s) => s.compactMode);
   const fitViewPending       = useMapStore((s) => s.fitViewPending);
   const clearFitView         = useMapStore((s) => s.clearFitView);
@@ -1006,6 +1008,18 @@ export function MapCanvas() {
         label: t('ctxMenu.selectAll'),
         icon: <SelectionAllIcon size={14} weight="regular" />,
         action: () => setNodes((ns) => ns.map((n) => ({ ...n, selected: true }))),
+        disabled: nodes.length === 0,
+      },
+      {
+        label: t('ctxMenu.optimizeConnections'),
+        icon: <LinkSimpleIcon size={15} weight="regular" />,
+        action: () => optimizeConnections(),
+        disabled: connections.length === 0,
+      },
+      {
+        label: t('ctxMenu.spreadNodes'),
+        icon: <ArrowsOutIcon size={15} weight="regular" />,
+        action: () => requestAutoLayout(),
         disabled: nodes.length === 0,
       },
     ];

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -647,7 +647,8 @@
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
     "fitView": "Fit view",
-    "interactive": "Toggle interactivity"
+    "interactive": "Toggle interactivity",
+    "centerOnMe": "Centre on my location"
   },
   "demo": {
     "hintClick": "Click a system to view its details here.",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -662,6 +662,8 @@
   },
   "ctxMenu": {
     "disconnect": "Disconnect",
+    "optimizeConnections": "Optimize Connections",
+    "spreadNodes": "Spread Nodes",
     "jumpType": "Jump Type",
     "standardJump": "Standard Jump",
     "jumpgate": "Jumpgate",

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -763,9 +763,29 @@ export const useMapStore = create<MapStore>()((set, get) => {
         if (activeMapId) {
           const url  = `/api/maps/${activeMapId}/systems`;
           const body = JSON.stringify({ ...added });
-          api(url, { method: 'POST', body }).catch(() =>
-            enqueue(`addSystem:${added.name}`, url, 'POST', body),
-          );
+          api<{ system?: { security?: number | null; eveSystemId?: number | null } }>(url, { method: 'POST', body })
+            .then((resp) => {
+              // Backfill server-derived fields (SDE security, resolved eve id)
+              // onto the optimistic node — addSystem can't know these, and the
+              // live-sync echo is suppressed for the originating client, so
+              // without this the node would lack sec status until a reload.
+              const srv = resp?.system;
+              if (!srv) return;
+              set((s) => ({
+                map: {
+                  ...s.map,
+                  systems: s.map.systems.map((sys) =>
+                    sys.id === id
+                      ? {
+                          ...sys,
+                          ...(srv.security != null ? { security: srv.security } : {}),
+                          ...(srv.eveSystemId != null ? { eveSystemId: srv.eveSystemId } : {}),
+                        }
+                      : sys),
+                },
+              }));
+            })
+            .catch(() => enqueue(`addSystem:${added.name}`, url, 'POST', body));
         }
       }
 


### PR DESCRIPTION
## v1.5.2

### Features
- **Centre-on-me map control** (#263): a crosshair button in the bottom map controls recenters the viewport on your current system node. Disabled when you're not in a mapped system.
- **Optimize Connections + Spread Nodes in the map context menu** (#264): both layout actions (previously sidebar-only) now available from the empty-canvas right-click menu.

### Fixes
- **Sovereignty rows wrap correctly on a narrow panel** (#261): name no longer breaks character-by-character; the P/C/A standings drop below it.
- **Consistent sec status on newly-added systems** (#262): a system added during the session now shows its security status immediately (backfilled from the SDE via the POST response) instead of only after a reload.

### Housekeeping
- Bump version to 1.5.2 (server + web).