### PR TITLE
Add west/north new-system placement directions

### DIFF
--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -18,6 +18,7 @@ import {
   type MinimapPosition,
 } from "../../hooks/useMinimapPosition";
 import { useUserSetting } from "../../hooks/useUserSetting";
+import { normalizePlacement } from "../../hooks/useLocationTracking";
 import { NOTIFY } from "../../utils/notificationPrefs";
 import { useResettableState } from "../../hooks/useResettableState";
 import { DEFAULT_BOOKMARK_FORMAT, BOOKMARK_TOKENS } from "../../utils/signatureBookmark";
@@ -612,7 +613,7 @@ export function MapSidebar() {
   const showMinimap = useMapStore((s) => s.showMinimap);
   const setShowMinimap = useMapStore((s) => s.setShowMinimap);
   const [minimapPosition, setMinimapPosition] = useMinimapPosition();
-  const [placement, setPlacement] = useUserSetting<string>("nexum.map.placement", "horizontal");
+  const [placement, setPlacement] = useUserSetting<string>("nexum.map.placement", "east");
   const [sigBookmarkFmt, setSigBookmarkFmt] = useUserSetting<string>("nexum.sig.bookmarkFormat", DEFAULT_BOOKMARK_FORMAT);
   const uniformSize = useMapStore((s) => s.uniformSize);
   const setUniformSize = useMapStore((s) => s.setUniformSize);
@@ -1151,9 +1152,11 @@ export function MapSidebar() {
                   </div>
                   <div className="map-sidebar__row">
                     <label className="map-sidebar__label" htmlFor="placement-dir">{t("mapSidebar.placement")}</label>
-                    <select id="placement-dir" className="map-sidebar__select" value={placement} onChange={(e) => setPlacement(e.target.value)}>
-                      <option value="horizontal">{t("mapSidebar.placementOptions.horizontal")}</option>
-                      <option value="vertical">{t("mapSidebar.placementOptions.vertical")}</option>
+                    <select id="placement-dir" className="map-sidebar__select" value={normalizePlacement(placement)} onChange={(e) => setPlacement(e.target.value)}>
+                      <option value="east">{t("mapSidebar.placementOptions.east")}</option>
+                      <option value="south">{t("mapSidebar.placementOptions.south")}</option>
+                      <option value="west">{t("mapSidebar.placementOptions.west")}</option>
+                      <option value="north">{t("mapSidebar.placementOptions.north")}</option>
                     </select>
                   </div>
                 </>

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -15,16 +15,32 @@ function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number,
 
 // Slots around the source, both clockwise (+y is down): cardinals first, then
 // diagonals, scaled by `ring` for distance. The user's default-placement pref
-// picks the starting direction — horizontal begins at the right, vertical at
-// the bottom — and rotation continues clockwise from there.
-const OFFSETS_HORIZONTAL: [number, number][] = [
-  [1, 0], [0, 1], [-1, 0], [0, -1],   // E, S, W, N
-  [1, 1], [-1, 1], [-1, -1], [1, -1], // SE, SW, NW, NE
-];
-const OFFSETS_VERTICAL: [number, number][] = [
-  [0, 1], [-1, 0], [0, -1], [1, 0],   // S, W, N, E
-  [-1, 1], [-1, -1], [1, -1], [1, 1], // SW, NW, NE, SE
-];
+// picks the starting cardinal direction; rotation continues clockwise from
+// there. Legacy 'horizontal'/'vertical' settings map to east/south.
+export type PlacementDirection = 'east' | 'south' | 'west' | 'north';
+
+export function normalizePlacement(v: string | null | undefined): PlacementDirection {
+  switch (v) {
+    case 'south':
+    case 'vertical': return 'south';
+    case 'west':     return 'west';
+    case 'north':    return 'north';
+    default:         return 'east'; // 'east' / 'horizontal' / unset
+  }
+}
+
+// Slot rings keyed by the preferred start: that cardinal first, then clockwise
+// through the rest, diagonals last.
+const OFFSETS_BY_DIR: Record<PlacementDirection, [number, number][]> = {
+  east:  [[1, 0], [0, 1], [-1, 0], [0, -1], [1, 1], [-1, 1], [-1, -1], [1, -1]],
+  south: [[0, 1], [-1, 0], [0, -1], [1, 0], [-1, 1], [-1, -1], [1, -1], [1, 1]],
+  west:  [[-1, 0], [0, -1], [1, 0], [0, 1], [-1, -1], [1, -1], [1, 1], [-1, 1]],
+  north: [[0, -1], [1, 0], [0, 1], [-1, 0], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+};
+// Dense-map fallback: a single step in the preferred direction.
+const FALLBACK_BY_DIR: Record<PlacementDirection, [number, number]> = {
+  east: [1, 0], south: [0, 1], west: [-1, 0], north: [0, -1],
+};
 
 // Pick a position for a newly auto-added system by rotating clockwise around
 // the system it was jumped from, starting in the preferred direction (right of
@@ -37,12 +53,12 @@ function findFreePosition(
   w: number,
   h: number,
   gap: number,
-  vertical: boolean,
+  direction: PlacementDirection,
 ): { x: number; y: number } {
   const collides = (x: number, y: number) =>
     systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
 
-  const offsets = vertical ? OFFSETS_VERTICAL : OFFSETS_HORIZONTAL;
+  const offsets = OFFSETS_BY_DIR[direction];
   const stepX = w + gap;
   const stepY = h + gap;
   for (let ring = 1; ring <= 6; ring++) {
@@ -52,8 +68,9 @@ function findFreePosition(
       if (!collides(x, y)) return { x, y };
     }
   }
-  // Dense map — fall back to the preferred direction.
-  return vertical ? { x: source.x, y: source.y + stepY } : { x: source.x + stepX, y: source.y };
+  // Dense map — fall back to a single step in the preferred direction.
+  const [fx, fy] = FALLBACK_BY_DIR[direction];
+  return { x: source.x + fx * stepX, y: source.y + fy * stepY };
 }
 
 /**
@@ -139,8 +156,8 @@ export function useLocationTracking(enabled: boolean) {
           y: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length : 0,
         };
       }
-      const vertical = readUserSetting<string>('nexum.map.placement', 'horizontal') === 'vertical';
-      const position = findFreePosition(source, map.systems, w, h, gap, vertical);
+      const direction = normalizePlacement(readUserSetting<string>('nexum.map.placement', 'east'));
+      const position = findFreePosition(source, map.systems, w, h, gap, direction);
 
       mapSystemId = addSystem(
         system.name,

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -394,7 +394,11 @@
     "crossMapSyncHelp": "When you add or edit signatures and anomalies on a system, copy them to the same system on your other maps (personal maps sync with your other personal maps; corp maps with the corp's other maps). Non-destructive: it only fills in missing or blank entries — it never overwrites data you've already entered or deletes anything.",
     "placementOptions": {
       "horizontal": "Horizontal (right)",
-      "vertical": "Vertical (below)"
+      "vertical": "Vertical (below)",
+      "east": "Right (east)",
+      "south": "Below (south)",
+      "west": "Left (west)",
+      "north": "Above (north)"
     },
     "resetZoom": "Reset to 100%",
     "compact": "Compact",


### PR DESCRIPTION
Adds two more new-system placement options so all four cardinals are available:

| Option | Direction |
|---|---|
| Right (east) | new system placed east of the current — *was "horizontal"* |
| Below (south) | south — *was "vertical"* |
| **Left (west)** | **new: west / left** |
| **Above (north)** | **new: north / above** |

### Changes
- `useLocationTracking`: the clockwise free-slot search (`OFFSETS_BY_DIR`) and the dense-map fallback (`FALLBACK_BY_DIR`) are now keyed by a `PlacementDirection` (`east|south|west|north`), each starting at its cardinal and rotating clockwise.
- `normalizePlacement()` maps legacy `horizontal`→`east` and `vertical`→`south`, so **existing users' placement is unchanged** and migrates to the canonical value on their next selection.
- MapSidebar select now lists the four directions; i18n keys added under `placementOptions`.