### PR TITLE
Release v1.5.3

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -18,6 +18,7 @@ import {
   type MinimapPosition,
 } from "../../hooks/useMinimapPosition";
 import { useUserSetting } from "../../hooks/useUserSetting";
+import { normalizePlacement } from "../../hooks/useLocationTracking";
 import { NOTIFY } from "../../utils/notificationPrefs";
 import { useResettableState } from "../../hooks/useResettableState";
 import { DEFAULT_BOOKMARK_FORMAT, BOOKMARK_TOKENS } from "../../utils/signatureBookmark";
@@ -612,7 +613,7 @@ export function MapSidebar() {
   const showMinimap = useMapStore((s) => s.showMinimap);
   const setShowMinimap = useMapStore((s) => s.setShowMinimap);
   const [minimapPosition, setMinimapPosition] = useMinimapPosition();
-  const [placement, setPlacement] = useUserSetting<string>("nexum.map.placement", "horizontal");
+  const [placement, setPlacement] = useUserSetting<string>("nexum.map.placement", "east");
   const [sigBookmarkFmt, setSigBookmarkFmt] = useUserSetting<string>("nexum.sig.bookmarkFormat", DEFAULT_BOOKMARK_FORMAT);
   const uniformSize = useMapStore((s) => s.uniformSize);
   const setUniformSize = useMapStore((s) => s.setUniformSize);
@@ -1151,9 +1152,11 @@ export function MapSidebar() {
                   </div>
                   <div className="map-sidebar__row">
                     <label className="map-sidebar__label" htmlFor="placement-dir">{t("mapSidebar.placement")}</label>
-                    <select id="placement-dir" className="map-sidebar__select" value={placement} onChange={(e) => setPlacement(e.target.value)}>
-                      <option value="horizontal">{t("mapSidebar.placementOptions.horizontal")}</option>
-                      <option value="vertical">{t("mapSidebar.placementOptions.vertical")}</option>
+                    <select id="placement-dir" className="map-sidebar__select" value={normalizePlacement(placement)} onChange={(e) => setPlacement(e.target.value)}>
+                      <option value="east">{t("mapSidebar.placementOptions.east")}</option>
+                      <option value="south">{t("mapSidebar.placementOptions.south")}</option>
+                      <option value="west">{t("mapSidebar.placementOptions.west")}</option>
+                      <option value="north">{t("mapSidebar.placementOptions.north")}</option>
                     </select>
                   </div>
                 </>

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -15,16 +15,32 @@ function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number,
 
 // Slots around the source, both clockwise (+y is down): cardinals first, then
 // diagonals, scaled by `ring` for distance. The user's default-placement pref
-// picks the starting direction — horizontal begins at the right, vertical at
-// the bottom — and rotation continues clockwise from there.
-const OFFSETS_HORIZONTAL: [number, number][] = [
-  [1, 0], [0, 1], [-1, 0], [0, -1],   // E, S, W, N
-  [1, 1], [-1, 1], [-1, -1], [1, -1], // SE, SW, NW, NE
-];
-const OFFSETS_VERTICAL: [number, number][] = [
-  [0, 1], [-1, 0], [0, -1], [1, 0],   // S, W, N, E
-  [-1, 1], [-1, -1], [1, -1], [1, 1], // SW, NW, NE, SE
-];
+// picks the starting cardinal direction; rotation continues clockwise from
+// there. Legacy 'horizontal'/'vertical' settings map to east/south.
+export type PlacementDirection = 'east' | 'south' | 'west' | 'north';
+
+export function normalizePlacement(v: string | null | undefined): PlacementDirection {
+  switch (v) {
+    case 'south':
+    case 'vertical': return 'south';
+    case 'west':     return 'west';
+    case 'north':    return 'north';
+    default:         return 'east'; // 'east' / 'horizontal' / unset
+  }
+}
+
+// Slot rings keyed by the preferred start: that cardinal first, then clockwise
+// through the rest, diagonals last.
+const OFFSETS_BY_DIR: Record<PlacementDirection, [number, number][]> = {
+  east:  [[1, 0], [0, 1], [-1, 0], [0, -1], [1, 1], [-1, 1], [-1, -1], [1, -1]],
+  south: [[0, 1], [-1, 0], [0, -1], [1, 0], [-1, 1], [-1, -1], [1, -1], [1, 1]],
+  west:  [[-1, 0], [0, -1], [1, 0], [0, 1], [-1, -1], [1, -1], [1, 1], [-1, 1]],
+  north: [[0, -1], [1, 0], [0, 1], [-1, 0], [1, -1], [1, 1], [-1, 1], [-1, -1]],
+};
+// Dense-map fallback: a single step in the preferred direction.
+const FALLBACK_BY_DIR: Record<PlacementDirection, [number, number]> = {
+  east: [1, 0], south: [0, 1], west: [-1, 0], north: [0, -1],
+};
 
 // Pick a position for a newly auto-added system by rotating clockwise around
 // the system it was jumped from, starting in the preferred direction (right of
@@ -37,12 +53,12 @@ function findFreePosition(
   w: number,
   h: number,
   gap: number,
-  vertical: boolean,
+  direction: PlacementDirection,
 ): { x: number; y: number } {
   const collides = (x: number, y: number) =>
     systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
 
-  const offsets = vertical ? OFFSETS_VERTICAL : OFFSETS_HORIZONTAL;
+  const offsets = OFFSETS_BY_DIR[direction];
   const stepX = w + gap;
   const stepY = h + gap;
   for (let ring = 1; ring <= 6; ring++) {
@@ -52,8 +68,9 @@ function findFreePosition(
       if (!collides(x, y)) return { x, y };
     }
   }
-  // Dense map — fall back to the preferred direction.
-  return vertical ? { x: source.x, y: source.y + stepY } : { x: source.x + stepX, y: source.y };
+  // Dense map — fall back to a single step in the preferred direction.
+  const [fx, fy] = FALLBACK_BY_DIR[direction];
+  return { x: source.x + fx * stepX, y: source.y + fy * stepY };
 }
 
 /**
@@ -139,8 +156,8 @@ export function useLocationTracking(enabled: boolean) {
           y: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length : 0,
         };
       }
-      const vertical = readUserSetting<string>('nexum.map.placement', 'horizontal') === 'vertical';
-      const position = findFreePosition(source, map.systems, w, h, gap, vertical);
+      const direction = normalizePlacement(readUserSetting<string>('nexum.map.placement', 'east'));
+      const position = findFreePosition(source, map.systems, w, h, gap, direction);
 
       mapSystemId = addSystem(
         system.name,

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -13,6 +13,15 @@ function boxesOverlap(ax: number, ay: number, bx: number, by: number, w: number,
   return ax < bx + w + gap && ax + w + gap > bx && ay < by + h + gap && ay + h + gap > by;
 }
 
+// Snap-grid size — must match MapCanvas's snapGrid ([20,20]) and mapStore's GRID.
+const GRID = 20;
+// Auto-placed systems always sit a consistent 3 grid squares clear of the
+// system they're placed next to — rather than a node-width-dependent gap that
+// drifted as the uniform-size max grew.
+const PLACEMENT_GAP = 3 * GRID;
+const ceilToGrid  = (n: number) => Math.ceil(n / GRID) * GRID;
+const roundToGrid = (n: number) => Math.round(n / GRID) * GRID;
+
 // Slots around the source, both clockwise (+y is down): cardinals first, then
 // diagonals, scaled by `ring` for distance. The user's default-placement pref
 // picks the starting cardinal direction; rotation continues clockwise from
@@ -54,23 +63,28 @@ function findFreePosition(
   h: number,
   gap: number,
   direction: PlacementDirection,
+  snap: boolean,
 ): { x: number; y: number } {
   const collides = (x: number, y: number) =>
     systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
 
+  // Grid-aligned step: a whole node footprint rounded up to the grid plus the
+  // fixed gap, so spacing is consistent instead of drifting with node width.
+  // When snap-to-grid is on, the final position is rounded onto the grid too.
+  const place = (x: number, y: number) =>
+    snap ? { x: roundToGrid(x), y: roundToGrid(y) } : { x, y };
   const offsets = OFFSETS_BY_DIR[direction];
-  const stepX = w + gap;
-  const stepY = h + gap;
+  const stepX = ceilToGrid(w) + gap;
+  const stepY = ceilToGrid(h) + gap;
   for (let ring = 1; ring <= 6; ring++) {
     for (const [dx, dy] of offsets) {
-      const x = source.x + dx * ring * stepX;
-      const y = source.y + dy * ring * stepY;
-      if (!collides(x, y)) return { x, y };
+      const c = place(source.x + dx * ring * stepX, source.y + dy * ring * stepY);
+      if (!collides(c.x, c.y)) return c;
     }
   }
   // Dense map — fall back to a single step in the preferred direction.
   const [fx, fy] = FALLBACK_BY_DIR[direction];
-  return { x: source.x + fx * stepX, y: source.y + fy * stepY };
+  return place(source.x + fx * stepX, source.y + fy * stepY);
 }
 
 /**
@@ -88,7 +102,7 @@ export function useLocationTracking(enabled: boolean) {
 
   useEffect(() => {
     if (!enabled) return;
-    const { map, addSystem, addConnection, selectSystem, setCurrentSystem, uniformWidth, uniformHeight } = useMapStore.getState();
+    const { map, addSystem, addConnection, selectSystem, setCurrentSystem, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
 
     // No active map loaded yet (mid switchMap / first paint) — wait for the
     // next location update rather than racing addSystem against an empty store.
@@ -137,13 +151,12 @@ export function useLocationTracking(enabled: boolean) {
         setCurrentSystem(null);
         return;
       }
-      // Offset by the widest node seen + a gap so an auto-added system never
-      // overlaps the one it's placed next to (positions are top-left corners;
-      // a flat +200 touched because nodes are ~200 wide). Falls back to a
-      // generous constant before any node has been measured.
+      // Offset by the widest node seen so an auto-added system never overlaps
+      // the one it's placed next to (positions are top-left corners). Falls back
+      // to a generous constant before any node has been measured.
       const w = uniformWidth || 220;
       const h = uniformHeight || 120;
-      const gap = 30;
+      const gap = PLACEMENT_GAP;
       // Anchor placement on the system we jumped from (or the map centroid for
       // the very first auto-add), then rotate clockwise around it into the
       // first free slot — right, below, left, above, diagonals, wider rings.
@@ -157,7 +170,7 @@ export function useLocationTracking(enabled: boolean) {
         };
       }
       const direction = normalizePlacement(readUserSetting<string>('nexum.map.placement', 'east'));
-      const position = findFreePosition(source, map.systems, w, h, gap, direction);
+      const position = findFreePosition(source, map.systems, w, h, gap, direction, snapToGrid);
 
       mapSystemId = addSystem(
         system.name,

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -394,7 +394,11 @@
     "crossMapSyncHelp": "When you add or edit signatures and anomalies on a system, copy them to the same system on your other maps (personal maps sync with your other personal maps; corp maps with the corp's other maps). Non-destructive: it only fills in missing or blank entries — it never overwrites data you've already entered or deletes anything.",
     "placementOptions": {
       "horizontal": "Horizontal (right)",
-      "vertical": "Vertical (below)"
+      "vertical": "Vertical (below)",
+      "east": "Right (east)",
+      "south": "Below (south)",
+      "west": "Left (west)",
+      "north": "Above (north)"
     },
     "resetZoom": "Reset to 100%",
     "compact": "Compact",


### PR DESCRIPTION
## v1.5.3

### New-system placement
- **Four placement directions** (#266): new systems can now be placed right (east), below (south), **left (west)**, or **above (north)** of the current system — previously only horizontal/vertical. Legacy settings map to east/south, so existing users are unaffected.
- **Consistent, grid-aligned placement** (#267): auto-placed systems now sit a consistent 3-grid-square gap away (no longer drifting with node width), and snap onto the grid when snap-to-grid is enabled.

### Housekeeping
- Bump version to 1.5.3 (server + web).