### PR TITLE
Fix uniform nodes overlapping after a system is added while the tab is unfocused

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -135,6 +135,7 @@ export function MapCanvas() {
   const requestAutoLayout    = useMapStore((s) => s.requestAutoLayout);
   const optimizeConnections  = useMapStore((s) => s.optimizeConnections);
   const compactMode          = useMapStore((s) => s.compactMode);
+  const uniformSize          = useMapStore((s) => s.uniformSize);
   const fitViewPending       = useMapStore((s) => s.fitViewPending);
   const clearFitView         = useMapStore((s) => s.clearFitView);
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
@@ -441,6 +442,27 @@ export function MapCanvas() {
       return () => clearTimeout(t);
     }
   }, [compactMode, canEdit, requestAutoLayout]);
+
+  // A system added while the tab is backgrounded never gets measured (the
+  // ResizeObserver is deferred for hidden tabs), so the uniform-size max can't
+  // see it. When the tab regains focus everything re-measures and that max can
+  // ratchet up — growing every node past the slots they were tiled into and
+  // leaving them overlapping. Re-run the (overlap-only, undoable) spread once
+  // the re-measure has settled, same as the compact-mode-off handler. No-op
+  // when nothing actually overlaps; only matters with uniform size on.
+  useEffect(() => {
+    if (!uniformSize || !canEdit) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return;
+      // Generous delay so re-measurement (and any SSE-reconnect map refetch)
+      // has finished before overlap detection runs.
+      clearTimeout(timer);
+      timer = setTimeout(() => requestAutoLayout(), 700);
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => { clearTimeout(timer); document.removeEventListener('visibilitychange', onVisible); };
+  }, [uniformSize, canEdit, requestAutoLayout]);
 
   useEffect(() => {
     if (!autoLayoutPending) return;


### PR DESCRIPTION
### Bug
Systems redraw overlapping after the map tab has been backgrounded/suspended — confirmed trigger: **a system is added (location tracking) while the tab doesn't have focus.**

### Root cause
In **uniform-size** mode the largest measured node size is applied as `min-width`/`min-height` to *every* node, and auto-placed nodes are tiled on a grid for that size. But `ResizeObserver` callbacks are deferred for a backgrounded tab, so a system added while unfocused is **never measured** → the uniform max doesn't grow to include it. On refocus everything re-measures (amplified by the SSE-reconnect → `switchMap` refetch, which calls `resetUniformSizes`), the uniform max **ratchets up**, every node grows to the new min-size, and nodes tiled for the old smaller size now **overlap**. (There's even an existing code comment noting uniform mode "ratchets up".)

### Fix
On `visibilitychange → visible`, after a delay long enough for the re-measure (and any reconnect refetch) to settle, re-run the existing **overlap-only spread** (`requestAutoLayout` → `resolveOverlaps`). This mirrors the handler that already runs after compact-mode-off grows nodes. It only moves nodes that genuinely overlap, is **undoable**, and **no-ops** when nothing overlaps. Gated on uniform-size + edit rights.

### Notes
- This is a self-healing fix: any ratchet-induced overlap is tidied automatically shortly after you return to the tab.
- A deeper alternative (cap node width so the uniform max can't ratchet) is bigger and would truncate long names — happy to do that instead if preferred.