### PR TITLE
Release v1.6.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -135,6 +135,7 @@ export function MapCanvas() {
   const requestAutoLayout    = useMapStore((s) => s.requestAutoLayout);
   const optimizeConnections  = useMapStore((s) => s.optimizeConnections);
   const compactMode          = useMapStore((s) => s.compactMode);
+  const uniformSize          = useMapStore((s) => s.uniformSize);
   const fitViewPending       = useMapStore((s) => s.fitViewPending);
   const clearFitView         = useMapStore((s) => s.clearFitView);
   const centerRequestEveId   = useMapStore((s) => s.centerRequestEveId);
@@ -441,6 +442,27 @@ export function MapCanvas() {
       return () => clearTimeout(t);
     }
   }, [compactMode, canEdit, requestAutoLayout]);
+
+  // A system added while the tab is backgrounded never gets measured (the
+  // ResizeObserver is deferred for hidden tabs), so the uniform-size max can't
+  // see it. When the tab regains focus everything re-measures and that max can
+  // ratchet up — growing every node past the slots they were tiled into and
+  // leaving them overlapping. Re-run the (overlap-only, undoable) spread once
+  // the re-measure has settled, same as the compact-mode-off handler. No-op
+  // when nothing actually overlaps; only matters with uniform size on.
+  useEffect(() => {
+    if (!uniformSize || !canEdit) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return;
+      // Generous delay so re-measurement (and any SSE-reconnect map refetch)
+      // has finished before overlap detection runs.
+      clearTimeout(timer);
+      timer = setTimeout(() => requestAutoLayout(), 700);
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => { clearTimeout(timer); document.removeEventListener('visibilitychange', onVisible); };
+  }, [uniformSize, canEdit, requestAutoLayout]);
 
   useEffect(() => {
     if (!autoLayoutPending) return;


### PR DESCRIPTION
## v1.6.1

### Fix
- **Uniform-size nodes overlapping after a system is added while the tab is unfocused** (#271): a system added (via location tracking) while the map tab is backgrounded never gets measured, so the uniform-size max ratchets up on refocus and tiled nodes overlap. Now the overlap-only spread re-runs once the tab regains focus and re-measures, tidying it automatically (undoable, no-op when nothing overlaps).

### Housekeeping
- Bump version to 1.6.1 (server + web).