### PR TITLE
Fix toolbar sections overlapping after reset

### DIFF
--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -316,7 +316,11 @@ export function Toolbar() {
   const posOf = (id: string): { x: number; y: number } | null =>
     savedPositions[id] ?? defaultPositions[id] ?? null;
   const atDefaultLayout = Object.keys(savedPositions).length === 0;
-  const resetLayout = () => setSavedPositions({});
+  // Clear the measured defaults too, so EVERY section re-flows into a clean
+  // tidy row and re-seeds. Clearing only the saved positions would leave the
+  // sections you'd dragged with no default (back to flow) while the rest stayed
+  // absolute at their old defaults — and the two would overlap.
+  const resetLayout = () => { setSavedPositions({}); setDefaultPositions({}); };
 
   const dragSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
   const toolbarRef = useRef<HTMLElement>(null);


### PR DESCRIPTION
### Bug
Resetting the toolbar layout left sections piled on top of each other.

### Cause
`resetLayout` cleared only `savedPositions`, not the measured `defaultPositions`. After reset, the sections you had **dragged** lost their saved position and fell back to flow (they had no default), while the sections you **hadn't** dragged stayed absolutely positioned at their old defaults — both packing from the left, so they overlapped.

### Fix
Reset now clears `defaultPositions` too, so every section re-flows into a clean tidy row and re-seeds its default. One-line change.