### PR TITLE
Release v1.6.3

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -723,9 +723,9 @@
   cursor: grab;
   padding: 2px 6px;
   border-radius: 6px;
-  /* margin-left carries the saved "gap before"; animate it so a drop settles
-     smoothly. Not transitioning transform — that must track the cursor 1:1. */
-  transition: background 0.12s, margin-left 0.14s ease;
+  /* Placed sections get position:absolute + left/top inline; the transform
+     (set inline) tracks the cursor 1:1 while dragging, so don't transition it. */
+  transition: background 0.12s;
   touch-action: none;
 }
 /* Hover chip + brighter grip = "this block is draggable". */
@@ -748,13 +748,16 @@
 .toolbar__section:hover .toolbar__section-grip { opacity: 0.85; color: #8a9bc4; }
 .toolbar__section--dragging .toolbar__section-grip { opacity: 1; color: #a9b8dc; }
 
-/* Fixed account actions pinned to the far right (not part of the drag set). */
+/* Fixed account actions pinned to the far right (not part of the drag set).
+   align-self keeps them in the top row even when the bar grows for a 2nd row. */
 .toolbar__anchor-right {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
   margin-left: auto;
+  align-self: flex-start;
+  height: 48px;
 }
 
 /* Narrow screens (vertical monitors, smaller laptops): tighten the inter-section
@@ -772,6 +775,9 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  /* Stays in the top row even when the bar grows for a dragged 2nd-row section. */
+  align-self: flex-start;
+  height: 48px;
 }
 
 .toolbar__logo {

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -316,7 +316,11 @@ export function Toolbar() {
   const posOf = (id: string): { x: number; y: number } | null =>
     savedPositions[id] ?? defaultPositions[id] ?? null;
   const atDefaultLayout = Object.keys(savedPositions).length === 0;
-  const resetLayout = () => setSavedPositions({});
+  // Clear the measured defaults too, so EVERY section re-flows into a clean
+  // tidy row and re-seeds. Clearing only the saved positions would leave the
+  // sections you'd dragged with no default (back to flow) while the rest stayed
+  // absolute at their old defaults — and the two would overlap.
+  const resetLayout = () => { setSavedPositions({}); setDefaultPositions({}); };
 
   const dragSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
   const toolbarRef = useRef<HTMLElement>(null);

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -193,6 +193,26 @@ function ProximityChip() {
 // flow layout that seeds their default positions).
 const DEFAULT_TOOLBAR_ORDER = ['map', 'status', 'tools', 'server', 'account'];
 
+// Min gap (px) kept between sections so they never visually touch.
+const SECTION_GAP = 6;
+
+// Snap a dropped section's x to the nearest spot that doesn't overlap any
+// section sharing its row, so groups can't land on top of each other. `bars`
+// are the x-intervals {l,r} of those same-row sections. If the drop point is
+// already clear it's kept; otherwise the closest free slot (just before/after
+// an obstacle, or a bar edge) is chosen.
+function nearestFreeX(desiredX: number, w: number, bars: { l: number; r: number }[], barW: number): number {
+  const fits = (px: number) =>
+    px >= 0 && px + w <= barW && !bars.some((b) => px < b.r + SECTION_GAP && px + w + SECTION_GAP > b.l);
+  if (fits(desiredX)) return desiredX;
+  const cands = [0, Math.max(0, barW - w)];
+  for (const b of bars) { cands.push(b.r + SECTION_GAP, b.l - w - SECTION_GAP); }
+  const valid = cands.filter(fits);
+  if (!valid.length) return desiredX; // row full — nothing we can do, leave it
+  valid.sort((a, b) => Math.abs(a - desiredX) - Math.abs(b - desiredX));
+  return valid[0];
+}
+
 // One freely-placeable toolbar group. Always draggable, no separate handle: the
 // 6px pointer activation distance (see the DndContext sensor) means a tap still
 // clicks the controls inside — only a press-and-move starts a drag. The dragged
@@ -335,11 +355,21 @@ export function Toolbar() {
     const tb = toolbarRef.current?.getBoundingClientRect();
     const el = sectionEls.current.get(id);
     if (!cur || !tb || !el) return;
-    // Land exactly where dropped (start + drag delta); clamp to stay on the bar
-    // and within ~two rows. Absolute placement means no reflow — it stays put.
-    const maxX = Math.max(0, tb.width - el.offsetWidth);
-    const x = Math.min(Math.max(0, Math.round(cur.x + e.delta.x)), maxX);
+    // Land where dropped (start + drag delta); clamp to stay on the bar and
+    // within ~two rows. Absolute placement means no reflow — it stays put.
+    const w = el.offsetWidth, h = el.offsetHeight;
     const y = Math.min(Math.max(0, Math.round(cur.y + e.delta.y)), 56);
+    const dropX = Math.min(Math.max(0, Math.round(cur.x + e.delta.x)), Math.max(0, tb.width - w));
+    // Sections that share the dropped row (vertically overlapping) are obstacles;
+    // snap x to the nearest free slot so groups can't be dropped onto each other.
+    const bars: { l: number; r: number }[] = [];
+    sectionEls.current.forEach((oel, oid) => {
+      if (oid === id) return;
+      const p = posOf(oid);
+      if (!p || y + h <= p.y || y >= p.y + oel.offsetHeight) return;
+      bars.push({ l: p.x, r: p.x + oel.offsetWidth });
+    });
+    const x = nearestFreeX(dropX, w, bars, tb.width);
     setSavedPositions({ ...savedPositions, [id]: { x, y } });
   };
 

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type ReactNode } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, type ReactNode, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { timeAgo, jumps } from '../../i18n/format';
@@ -189,17 +189,9 @@ function ProximityChip() {
 // The reorderable toolbar groups, in their default left-to-right order. The
 // brand (far left) and the account actions — API keys + sign out (far right) —
 // are fixed and deliberately NOT in this list.
+// Default left-to-right order of the freely-placeable sections (used for the
+// flow layout that seeds their default positions).
 const DEFAULT_TOOLBAR_ORDER = ['map', 'status', 'tools', 'server', 'account'];
-
-// Reconcile a saved order with the sections we actually ship: drop unknown ids
-// and append any newly-added sections, so an order saved by an older build
-// never hides a control or leaves dnd-kit referencing a missing section.
-function reconcileToolbarOrder(saved: string[]): string[] {
-  const known = new Set(DEFAULT_TOOLBAR_ORDER);
-  const kept = saved.filter((id) => known.has(id));
-  const missing = DEFAULT_TOOLBAR_ORDER.filter((id) => !kept.includes(id));
-  return [...kept, ...missing];
-}
 
 // One freely-placeable toolbar group. Always draggable, no separate handle: the
 // 6px pointer activation distance (see the DndContext sensor) means a tap still
@@ -208,23 +200,24 @@ function reconcileToolbarOrder(saved: string[]): string[] {
 // margin-left so the group keeps the empty space you dropped it with, and the
 // left-to-right flow makes overlap impossible.
 function ToolbarSection({
-  id, gap, registerRef, children,
+  id, pos, registerRef, children,
 }: {
   id: string;
-  gap: number;
+  // Absolute position once known; null while it's still in flow (pre-measure).
+  pos: { x: number; y: number } | null;
   registerRef: (id: string, el: HTMLElement | null) => void;
   children: ReactNode;
 }) {
   const { setNodeRef, listeners, transform, isDragging } = useDraggable({ id });
+  const moved = transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined;
+  const style: CSSProperties = pos
+    ? { position: 'absolute', left: pos.x, top: pos.y, transform: moved, zIndex: isDragging ? 50 : undefined }
+    : { transform: moved, zIndex: isDragging ? 50 : undefined };
   return (
     <div
       ref={(el) => { setNodeRef(el); registerRef(id, el); }}
-      className={`toolbar__section${isDragging ? ' toolbar__section--dragging' : ''}`}
-      style={{
-        marginLeft: gap || undefined,
-        transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
-        zIndex: isDragging ? 50 : undefined,
-      }}
+      className={`toolbar__section${isDragging ? ' toolbar__section--dragging' : ''}${pos ? ' toolbar__section--placed' : ''}`}
+      style={style}
       {...listeners}
     >
       {/* Drag affordance: faint at rest, brightens on hover (the whole section
@@ -291,74 +284,63 @@ export function Toolbar() {
   const mapSwitcherRef = useRef<HTMLDivElement>(null);
   useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
 
-  // Per-user, cross-device layout. `order` is the left-to-right sequence; `gaps`
-  // is a margin-left (px) before each section so a dragged group keeps the empty
-  // space you dropped it with. Left-to-right flow makes overlap impossible.
-  const [savedSectionOrder, setSavedSectionOrder] =
-    useUserSetting<string[]>('nexum.toolbar.sections', DEFAULT_TOOLBAR_ORDER);
-  const [sectionGaps, setSectionGaps] =
-    useUserSetting<Record<string, number>>('nexum.toolbar.gaps', {});
-  const sectionOrder = reconcileToolbarOrder(savedSectionOrder);
-  const atDefaultLayout =
-    sectionOrder.length === DEFAULT_TOOLBAR_ORDER.length
-    && sectionOrder.every((id, i) => id === DEFAULT_TOOLBAR_ORDER[i])
-    && Object.values(sectionGaps).every((g) => !g);
-  const resetLayout = () => { setSavedSectionOrder(DEFAULT_TOOLBAR_ORDER); setSectionGaps({}); };
+  // Per-user, cross-device toolbar layout. Each reorderable section is freely
+  // placed: an absolute {x,y} relative to the bar. `savedPositions` holds only
+  // the sections the user has actually dragged; everything else falls back to a
+  // measured default — a tidy left-to-right row laid out in flow, then captured
+  // (and re-captured on resize so it stays responsive). Reset clears the saved
+  // positions and drops back to those defaults.
+  const [savedPositions, setSavedPositions] =
+    useUserSetting<Record<string, { x: number; y: number }>>('nexum.toolbar.positions', {});
+  const [defaultPositions, setDefaultPositions] = useState<Record<string, { x: number; y: number }>>({});
+  const posOf = (id: string): { x: number; y: number } | null =>
+    savedPositions[id] ?? defaultPositions[id] ?? null;
+  const atDefaultLayout = Object.keys(savedPositions).length === 0;
+  const resetLayout = () => setSavedPositions({});
 
   const dragSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
   const toolbarRef = useRef<HTMLElement>(null);
-  const brandRef = useRef<HTMLDivElement>(null);
   const sectionEls = useRef<Map<string, HTMLElement>>(new Map());
   const registerSectionRef = (id: string, el: HTMLElement | null) => {
     if (el) sectionEls.current.set(id, el); else sectionEls.current.delete(id);
   };
-  // Section rects snapshotted at drag start (before the dragged element gets a
-  // transform), so the drop maths isn't polluted by its live position.
-  const dragSnapshot = useRef<{ rects: Map<string, DOMRect>; brandRight: number; maxGap: number } | null>(null);
 
-  const onSectionDragStart = () => {
-    const rects = new Map<string, DOMRect>();
-    sectionEls.current.forEach((el, id) => rects.set(id, el.getBoundingClientRect()));
-    const brandRight = brandRef.current?.getBoundingClientRect().right ?? 0;
-    const maxGap = toolbarRef.current?.getBoundingClientRect().width ?? 600;
-    dragSnapshot.current = { rects, brandRight, maxGap };
-  };
+  // Seed the default position of any section that doesn't have one yet by
+  // measuring where it lands in flow (it renders in flow, vertically centred,
+  // until placed). Runs after layout; a no-op once every section has a position.
+  useLayoutEffect(() => {
+    const tb = toolbarRef.current?.getBoundingClientRect();
+    if (!tb) return;
+    let patch: Record<string, { x: number; y: number }> | null = null;
+    sectionEls.current.forEach((el, id) => {
+      if (savedPositions[id] || defaultPositions[id]) return;
+      const r = el.getBoundingClientRect();
+      (patch ??= {})[id] = { x: Math.round(r.left - tb.left), y: Math.round(r.top - tb.top) };
+    });
+    if (patch) setDefaultPositions((d) => ({ ...d, ...patch }));
+  }, [savedPositions, defaultPositions, user]);
+
+  // On resize, drop the measured defaults so un-customised sections re-flow and
+  // re-seed at the new width. User-dragged (saved) positions are left alone.
+  useEffect(() => {
+    let t: ReturnType<typeof setTimeout>;
+    const onResize = () => { clearTimeout(t); t = setTimeout(() => setDefaultPositions({}), 150); };
+    window.addEventListener('resize', onResize);
+    return () => { clearTimeout(t); window.removeEventListener('resize', onResize); };
+  }, []);
 
   const onSectionDragEnd = (e: DragEndEvent) => {
-    const snap = dragSnapshot.current;
-    dragSnapshot.current = null;
     const id = e.active.id as string;
-    const dragged = snap?.rects.get(id);
-    if (!snap || !dragged) return;
-
-    // Where the dragged group's left edge / centre ended up.
-    const dropLeft = dragged.left + e.delta.x;
-    const dropCx   = dragged.left + dragged.width / 2 + e.delta.x;
-    const dropCy   = dragged.top + dragged.height / 2 + e.delta.y;
-
-    // Insertion point among the other sections, in reading order: an earlier row
-    // (or the same row but to the left of a section's centre) comes first.
-    const others = sectionOrder.filter((s) => s !== id);
-    let insertAt = others.length;
-    for (let i = 0; i < others.length; i++) {
-      const r = snap.rects.get(others[i]);
-      if (!r) continue;
-      const earlierRow = dropCy < r.top;
-      const sameRow = dropCy >= r.top && dropCy <= r.bottom;
-      if (earlierRow || (sameRow && dropCx < r.left + r.width / 2)) { insertAt = i; break; }
-    }
-    const newOrder = [...others.slice(0, insertAt), id, ...others.slice(insertAt)];
-
-    // Gap before the dropped group = how far right of the previous element it
-    // landed (>= 0 so groups never overlap; capped to the bar width).
-    const prevId = insertAt > 0 ? others[insertAt - 1] : null;
-    const prevRight = prevId ? (snap.rects.get(prevId)?.right ?? snap.brandRight) : snap.brandRight;
-    const gap = Math.max(0, Math.min(Math.round(dropLeft - prevRight), snap.maxGap));
-
-    const orderChanged = newOrder.length !== sectionOrder.length
-      || newOrder.some((s, i) => s !== sectionOrder[i]);
-    if (orderChanged) setSavedSectionOrder(newOrder);
-    if ((sectionGaps[id] ?? 0) !== gap) setSectionGaps({ ...sectionGaps, [id]: gap });
+    const cur = posOf(id);
+    const tb = toolbarRef.current?.getBoundingClientRect();
+    const el = sectionEls.current.get(id);
+    if (!cur || !tb || !el) return;
+    // Land exactly where dropped (start + drag delta); clamp to stay on the bar
+    // and within ~two rows. Absolute placement means no reflow — it stays put.
+    const maxX = Math.max(0, tb.width - el.offsetWidth);
+    const x = Math.min(Math.max(0, Math.round(cur.x + e.delta.x)), maxX);
+    const y = Math.min(Math.max(0, Math.round(cur.y + e.delta.y)), 56);
+    setSavedPositions({ ...savedPositions, [id]: { x, y } });
   };
 
   async function handleDeleteMap() {
@@ -654,18 +636,23 @@ export function Toolbar() {
     ) : null,
   };
 
-  const renderOrder = sectionOrder.filter((id) => sections[id] != null);
+  const renderOrder = DEFAULT_TOOLBAR_ORDER.filter((id) => sections[id] != null);
+  // Grow the bar to fit the lowest-placed section (so a second row isn't clipped).
+  // ROW_H is a generous single-row height — erring tall just adds a little slack.
+  const ROW_H = 52;
+  const maxY = renderOrder.reduce((m, id) => Math.max(m, posOf(id)?.y ?? 0), 0);
+  const toolbarMinHeight = Math.max(ROW_H, maxY + ROW_H);
 
   return (
     <>
-    <header className="toolbar" ref={toolbarRef}>
-      <div className="toolbar__brand" ref={brandRef}>
+    <header className="toolbar toolbar--free" ref={toolbarRef} style={{ minHeight: toolbarMinHeight }}>
+      <div className="toolbar__brand">
         <span className="toolbar__logo">◈</span>
       </div>
 
-      <DndContext sensors={dragSensors} onDragStart={onSectionDragStart} onDragEnd={onSectionDragEnd}>
+      <DndContext sensors={dragSensors} onDragEnd={onSectionDragEnd}>
         {renderOrder.map((id) => (
-          <ToolbarSection key={id} id={id} gap={sectionGaps[id] || 0} registerRef={registerSectionRef}>
+          <ToolbarSection key={id} id={id} pos={posOf(id)} registerRef={registerSectionRef}>
             {sections[id]}
           </ToolbarSection>
         ))}


### PR DESCRIPTION
## v1.6.3

### Toolbar drag — true free placement
- The top-toolbar drag was rebuilt (#275): each section is now **absolutely placed** and lands exactly where you drop it (no reflow), including dragging onto a second row. Brand and account actions stay pinned. Defaults are measured (a tidy row) and re-measured on resize; only dragged sections persist.
- **No overlap** (#275): on drop a section snaps to the nearest free slot on its row instead of landing on top of another group.
- **Reset fix** (#276): resetting the layout now clears the measured defaults too, so sections re-flow into a clean tidy row instead of piling up.

### Housekeeping
- Bump version to 1.6.3 (server + web).