### PR TITLE
Quarantine broken chains when a backing sig is deleted

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -171,6 +171,10 @@ export async function migrate() {
     ALTER TABLE map_connections ADD COLUMN IF NOT EXISTS wh_type   TEXT;
     ALTER TABLE map_connections ADD COLUMN IF NOT EXISTS mass_used BIGINT NOT NULL DEFAULT 0;
     ALTER TABLE map_connections ADD COLUMN IF NOT EXISTS eol_at    TIMESTAMPTZ;
+    -- "Broken" = the backing wormhole sig was deleted (hole collapsed): the
+    -- connection is kept on the map but quarantined (rendered severed, excluded
+    -- from routing) so the chain is still traceable. See broken_chain_feature.
+    ALTER TABLE map_connections ADD COLUMN IF NOT EXISTS broken    BOOLEAN NOT NULL DEFAULT FALSE;
     ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
     -- Manual intel tag a user can apply to a system via right-click. Distinct

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1600,7 +1600,7 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
     `SELECT id, source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
             target_handle AS "targetHandle", connection_type AS "connectionType", mass_status AS "massStatus",
             time_status AS "timeStatus", size, wh_type AS "type", COALESCE(mass_used, 0)::float8 AS "massUsed",
-            eol_at AS "eolAt", created_at AS "createdAt"
+            eol_at AS "eolAt", broken, created_at AS "createdAt"
        FROM map_connections WHERE id = $1 AND map_id = $2`,
     [id, mapId],
   ).then(({ rows }) => {
@@ -1625,7 +1625,7 @@ mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {
     timeStatus: 'time_status', size: 'size',
     sourceHandle: 'source_handle', targetHandle: 'target_handle',
     type: 'wh_type', massUsed: 'mass_used',
-    eolAt: 'eol_at',
+    eolAt: 'eol_at', broken: 'broken',
   };
 
   const updates = req.body as Record<string, unknown>;

--- a/server/src/routes/share.ts
+++ b/server/src/routes/share.ts
@@ -181,7 +181,7 @@ shareRouter.get('/:token', async (req, res) => {
                 connection_type AS "connectionType", mass_status AS "massStatus",
                 time_status AS "timeStatus", size, wh_type AS "type",
                 COALESCE(mass_used, 0)::float8 AS "massUsed",
-                eol_at AS "eolAt",
+                eol_at AS "eolAt", broken,
                 created_at AS "createdAt"
          FROM map_connections ${connectionWhere}`,
         [mapId],

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -88,7 +88,7 @@ export async function loadFullMap(mapId: string) {
               connection_type AS "connectionType", mass_status AS "massStatus",
               time_status AS "timeStatus", size, wh_type AS "type",
               COALESCE(mass_used, 0)::float8 AS "massUsed",
-              eol_at AS "eolAt",
+              eol_at AS "eolAt", broken,
               created_at AS "createdAt"
        FROM map_connections WHERE map_id = $1`,
       [mapId],

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3789,6 +3789,45 @@ div.system-node__easy-handle {
   }
 }
 
+/* Severed-connection marker: a ✂ badge dropped at the midpoint of a broken
+   (quarantined) connection. The dashed red edge plus this badge make a
+   collapsed chain obvious without removing it from the map. */
+.connection-break {
+  position: absolute;
+  pointer-events: all;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(20px * var(--font-scale, 1));
+  height: calc(20px * var(--font-scale, 1));
+  font-size: calc(13px * var(--font-scale, 1));
+  line-height: 1;
+  color: var(--cv-conn-expired);
+  background: color-mix(in srgb, var(--cv-conn-expired) 18%, #0b0e16);
+  border: 1px solid color-mix(in srgb, var(--cv-conn-expired) 55%, #0b0e16);
+  border-radius: 50%;
+}
+
+/* Broken-connection banner in the connection side panel. */
+.conn-broken-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  color: var(--cv-conn-expired);
+  background: color-mix(in srgb, var(--cv-conn-expired) 12%, #0b0e16);
+  border: 1px solid color-mix(in srgb, var(--cv-conn-expired) 40%, #0b0e16);
+}
+
+.conn-broken-banner__text {
+  flex: 1;
+  font-size: calc(12px * var(--font-scale, 1));
+  line-height: 1.35;
+}
+
 /* ── Side panel ──────────────────────────────────────────── */
 .system-panel {
   background: #0d1117;

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -76,6 +76,10 @@ export const ConnectionEdge = memo(({
   })();
 
   const isJumpgate = conn?.connectionType === 'jumpgate';
+  // Quarantined: the backing wormhole sig was deleted (hole collapsed). Kept on
+  // the map but rendered severed (dashed/red + a ✂ marker) so the chain is
+  // still traceable but clearly no longer an active link.
+  const broken = !!conn?.broken;
 
   // Live EOL state takes priority over the legacy categorical timeStatus.
   const eolState   = !isJumpgate ? computeEolState(conn?.eolAt, now) : null;
@@ -116,19 +120,29 @@ export const ConnectionEdge = memo(({
         id={id}
         path={edgePath}
         style={{
-          stroke: color,
+          stroke: broken ? 'var(--cv-conn-expired)' : color,
           strokeWidth: watchColor ? strokeWidth + 1 : strokeWidth,
-          strokeDasharray: isJumpgate ? '10 5' : undefined,
+          strokeDasharray: broken ? '5 7' : isJumpgate ? '10 5' : undefined,
           filter: [
-            selected ? `drop-shadow(0 0 6px ${color})` : null,
+            selected ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
             watchColor ? `drop-shadow(0 0 5px ${watchColor}) drop-shadow(0 0 2px ${watchColor})` : null,
           ].filter(Boolean).join(' ') || undefined,
-          opacity: selected || watchColor ? 1 : 0.85,
+          opacity: broken ? 0.7 : selected || watchColor ? 1 : 0.85,
         }}
         markerEnd={undefined}
       />
       <EdgeLabelRenderer>
-        {(() => {
+        {broken && (
+          <div
+            className="connection-break"
+            title={t('mapEdge.broken')}
+            style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)` }}
+            onClick={() => selectConnection(id)}
+          >
+            &#9986;
+          </div>
+        )}
+        {!broken && (() => {
           const typeNode = isJumpgate
             ? <span className="connection-label__jumpgate">JG</span>
             : conn?.type

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -20,10 +20,11 @@ import { SystemNode } from './SystemNode';
 import { ConnectionEdge } from './ConnectionEdge';
 import { AddSystemModal } from '../ui/AddSystemModal';
 import { ContextMenu } from '../ui/ContextMenu';
+import { ConfirmModal, shouldSkipConfirm } from '../ui/ConfirmModal';
 import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
   XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
-  LinkSimpleIcon, ArrowsOutIcon,
+  LinkSimpleIcon, LinkBreakIcon, ArrowsOutIcon,
 } from '@phosphor-icons/react';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -178,6 +179,8 @@ export function MapCanvas() {
 
   const [pendingPosition, setPendingPosition] = useState<{ x: number; y: number } | null>(null);
   const [contextMenu, setContextMenu]         = useState<CtxMenu | null>(null);
+  // Pending "remove orphan systems" sweep, held while the confirm modal is up.
+  const [orphanConfirm, setOrphanConfirm]     = useState<{ ids: string[] } | null>(null);
   const [customIntel] = useCustomIntel();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -1024,6 +1027,15 @@ export function MapCanvas() {
       ];
     }
 
+    // Orphans: systems with no *valid* connection — either no connection at all,
+    // or only broken (quarantined) ones. Home and locked systems are protected.
+    const orphanIds = systems
+      .filter((s) =>
+        !s.isHome && !s.locked &&
+        !connections.some((c) => !c.broken && (c.sourceId === s.id || c.targetId === s.id)),
+      )
+      .map((s) => s.id);
+
     return [
       {
         label: t('ctxMenu.addSystem'),
@@ -1047,6 +1059,17 @@ export function MapCanvas() {
         icon: <ArrowsOutIcon size={15} weight="regular" />,
         action: () => requestAutoLayout(),
         disabled: nodes.length === 0,
+      },
+      { separator: true as const },
+      {
+        label: t('ctxMenu.removeOrphans', { count: orphanIds.length }),
+        icon: <LinkBreakIcon size={15} weight="regular" color="#e25a5a" />,
+        action: () => {
+          if (orphanIds.length === 0) return;
+          if (shouldSkipConfirm()) orphanIds.forEach((id) => removeSystem(id));
+          else setOrphanConfirm({ ids: orphanIds });
+        },
+        disabled: orphanIds.length === 0,
       },
     ];
   })();
@@ -1152,6 +1175,17 @@ export function MapCanvas() {
 
       {pendingPosition && (
         <AddSystemModal position={pendingPosition} onClose={() => setPendingPosition(null)} />
+      )}
+
+      {orphanConfirm && (
+        <ConfirmModal
+          message={t('ctxMenu.removeOrphansConfirm', { count: orphanConfirm.ids.length })}
+          onConfirm={() => {
+            orphanConfirm.ids.forEach((id) => removeSystem(id));
+            setOrphanConfirm(null);
+          }}
+          onCancel={() => setOrphanConfirm(null)}
+        />
       )}
     </div>
     </HeatmapContext.Provider>

--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -212,6 +212,21 @@ export function ConnectionPanel() {
         <button className="icon-btn" onClick={() => selectConnection(null)} title={t('actions.close')}><XIcon size={14} weight="bold" /></button>
       </div>
 
+      {conn.broken && (
+        <div className="conn-broken-banner">
+          <span className="conn-broken-banner__text">{t('connPanel.brokenNotice')}</span>
+          <button
+            type="button"
+            className="sys-btn"
+            disabled={!canEdit}
+            onClick={() => update({ broken: false })}
+            title={t('connPanel.restoreTitle')}
+          >
+            {t('connPanel.restore')}
+          </button>
+        </div>
+      )}
+
       <label className="field">
         <span>{t('connPanel.whType')} <WHTypeInfo code={conn.type} /></span>
         <input

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -435,11 +435,11 @@ export function SignaturePane({ systemId }: { systemId: string }) {
     setSigs((prev) => prev.filter((s) => s.id !== id));
     setSelected((prev) => { const next = new Set(prev); next.delete(id); return next; });
 
-    // If the deleted sig was backing a connection, re-evaluate so we can clear
-    // the now-orphaned connection type.
+    // If the deleted sig was backing a connection, quarantine it — the hole
+    // collapsed, so the connection is severed (broken) but kept on the map.
     if (deleted && deleted.whType && deleted.whLeadsTo) {
       const nextSigs = sigsRef.current.filter((s) => s.id !== id);
-      reevaluateConnectionsForSystem(systemId, nextSigs, deleted);
+      reevaluateConnectionsForSystem(systemId, nextSigs, deleted, true);
     }
 
     api(`/api/maps/${activeMapId}/systems/${systemId}/signatures/${id}`, { method: 'DELETE' })

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -102,7 +102,7 @@ export function useLocationTracking(enabled: boolean) {
 
   useEffect(() => {
     if (!enabled) return;
-    const { map, addSystem, addConnection, selectSystem, setCurrentSystem, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
+    const { map, addSystem, addConnection, updateConnection, selectSystem, setCurrentSystem, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
 
     // No active map loaded yet (mid switchMap / first paint) — wait for the
     // next location update rather than racing addSystem against an empty store.
@@ -188,12 +188,16 @@ export function useLocationTracking(enabled: boolean) {
 
     if (trackJumps && canEdit && !map.locked && prevMapSystemId && prevMapSystemId !== mapSystemId) {
       const freshConnections = useMapStore.getState().map.connections;
-      const alreadyConnected = freshConnections.some(
+      const existing = freshConnections.find(
         (c) =>
           (c.sourceId === prevMapSystemId && c.targetId === mapSystemId) ||
           (c.sourceId === mapSystemId && c.targetId === prevMapSystemId),
       );
-      if (!alreadyConnected) {
+      if (existing) {
+        // Physically jumping the link is definitive proof it's live — if it was
+        // quarantined (backing sig deleted), un-break it so the map stays honest.
+        if (existing.broken) updateConnection(existing.id, { broken: false });
+      } else {
         // Pick the optimal source/target sides from the two systems' actual
         // positions so the auto-added connection attaches cleanly — bottom→top
         // for a vertical layout, right→left for a horizontal one — instead of a

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -708,6 +708,8 @@
     "unlockSystem": "Unlock System",
     "removeSystem": "Remove System",
     "removeSystems": "Remove {{count}} Systems",
+    "removeOrphans": "Remove Orphan Systems ({{count}})",
+    "removeOrphansConfirm": "Remove {{count}} orphan system(s)? These have no valid connection (none, or only broken ones). Home and locked systems are kept. This can be undone.",
     "addSystem": "Add System",
     "selectAll": "Select All",
     "noHomeSet": "No home system set. Right-click a system → \"Set as home\".",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -599,6 +599,9 @@
     "addNote": "Add note…"
   },
   "connPanel": {
+    "brokenNotice": "Connection broken — the backing wormhole sig was deleted. Kept on the map but quarantined from routing.",
+    "restore": "Restore",
+    "restoreTitle": "Clear the broken flag and treat this as a live connection again",
     "whType": "Wormhole type",
     "whTypePlaceholder": "K162, C247…",
     "massStatus": "Mass status",
@@ -1427,6 +1430,7 @@
   "mapEdge": {
     "lessThan24h": "< 24h",
     "lessThan4h": "< 4 hrs",
-    "lessThan1h": "< 1 hr"
+    "lessThan1h": "< 1 hr",
+    "broken": "Connection broken — the wormhole sig was deleted (hole collapsed)"
   }
 }

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -908,7 +908,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
               { id, sourceId, targetId, sourceHandle, targetHandle,
                 type: null, connectionType: 'standard',
                 massStatus: null, timeStatus: null, size: 'large',
-                massUsed: 0, eolAt: null,
+                massUsed: 0, eolAt: null, broken: false,
                 createdAt: new Date().toISOString() },
             ],
           },

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -148,6 +148,10 @@ export interface MapConnection {
   size: ConnectionSize;
   massUsed: number; // kg — total mass jumped through this connection
   eolAt: string | null; // ISO timestamp when EOL was marked (null = fresh)
+  /** True once the backing wormhole sig was deleted (hole collapsed). The
+   *  connection is kept on the map but quarantined — rendered severed and
+   *  excluded from routing — so the chain is still traceable. */
+  broken: boolean;
   createdAt: string;
 }
 

--- a/web/src/utils/whAutoDetect.ts
+++ b/web/src/utils/whAutoDetect.ts
@@ -23,6 +23,11 @@ export function reevaluateConnectionsForSystem(
   systemId: string,
   allSigs:  Signature[],
   oldSig:   Signature | undefined,
+  // When true, a connection that this (deleted) sig used to back is QUARANTINED
+  // — flagged `broken` rather than just having its type cleared — because a sig
+  // vanishing means the wormhole collapsed. Used by sig deletion / overwrite-
+  // paste; sig edits pass false and keep the old "clear the type" behaviour.
+  breakOnOrphan = false,
 ): void {
   const { map, updateConnection } = useMapStore.getState();
   const oldType  = oldSig?.whType?.toUpperCase();
@@ -62,7 +67,11 @@ export function reevaluateConnectionsForSystem(
     );
 
     if (best) {
-      if (conn.type === null || (conn.type.toUpperCase() === 'K162' && best !== 'K162')) {
+      if (conn.broken) {
+        // A sig backs this link again (e.g. it reappeared in a re-scan) —
+        // un-quarantine it and restore the type.
+        updateConnection(conn.id, { broken: false, type: best });
+      } else if (conn.type === null || (conn.type.toUpperCase() === 'K162' && best !== 'K162')) {
         // Empty, or a K162 placeholder being upgraded to a real code.
         updateConnection(conn.id, { type: best });
       } else if (oldBackedThis && conn.type.toUpperCase() !== best.toUpperCase()) {
@@ -74,10 +83,12 @@ export function reevaluateConnectionsForSystem(
       continue;
     }
 
-    // No sig backs the connection any more. If this sig used to back it,
-    // clear the now-orphaned auto-filled type.
-    if (oldBackedThis) {
-      updateConnection(conn.id, { type: null });
+    // No sig backs the connection any more. If this sig used to back it:
+    //  - on a delete (breakOnOrphan), quarantine it — the hole collapsed, so
+    //    sever the chain visually but keep it traceable;
+    //  - on an edit, just clear the orphaned auto-filled type as before.
+    if (oldBackedThis && !conn.broken) {
+      updateConnection(conn.id, breakOnOrphan ? { broken: true } : { type: null });
     }
   }
 }


### PR DESCRIPTION
## What & why

When a wormhole sig is deleted from a system's sig list (including overwrite-paste), the connection it backed is no longer live -- the hole collapsed. Previously the connection was left joined, so two now-separate chains still looked complete on the map to anyone not looking closely.

Per the request, we do **not** remove the connection (Tripwire-style, which loses the chain). Instead we **quarantine** it so it can still be followed, but is unmistakably severed.

## How

- **Data model:** new `map_connections.broken` flag (idempotent `ADD COLUMN ... DEFAULT FALSE` migration). Carried through the maps/share/mapRead reads and the PATCH `colMap`; added to the `MapConnection` type and the store's new-connection literal.
- **Sever on delete:** `reevaluateConnectionsForSystem` gains `breakOnOrphan`; `deleteSig` passes `true`, so an orphaned connection is flagged `broken` instead of just clearing its type.
- **Visual:** broken edges render red + dashed with a scissor (`✂`) marker at the midpoint and drop their now-stale mass/time labels. The connection panel shows a broken banner with a **Restore** button.
- **Auto-un-break:** a connection un-breaks when a sig backs the link again (re-scan) or the player physically jumps it (location tracking).

## Verification

- `server` `yarn build` clean
- `web` `yarn lint` 0 errors (pre-existing warnings only), `yarn build` clean