### PR TITLE
Widen User Stats modal so period labels don't wrap

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6031,7 +6031,7 @@ select.sig-toolbar-btn option {
 
 /* ── User Stats Modal ────────────────────────────────────── */
 .stats-modal {
-  width: 480px;
+  width: 560px;
 }
 
 .stats-modal__periods {
@@ -6051,6 +6051,7 @@ select.sig-toolbar-btn option {
   font-family: inherit;
   font-size: calc(13px * var(--font-scale, 1));
   padding: 4px 0;
+  white-space: nowrap;
 }
 
 .stats-modal__period-btn:hover { background: #1a2240; color: #c8d0e0; }


### PR DESCRIPTION
The 'Last 365 days' period button wrapped to two lines at the modal's 480px width. Widened to 560px and added `white-space: nowrap` to the period buttons so all five labels sit on one line.