### PR TITLE
Fix null system effect crash in /api/systems/:id

### DIFF
--- a/server/src/routes/systems.ts
+++ b/server/src/routes/systems.ts
@@ -263,7 +263,8 @@ systemsRouter.get('/:id(\\d+)', async (req, res) => {
 
   try {
     const { rows } = await db.query(
-      `SELECT s.id, s.name, s.security, s.class AS "systemClass", s.effect, s.statics,
+      `SELECT s.id, s.name, s.security, s.class AS "systemClass",
+              COALESCE(s.effect, 'none') AS effect, s.statics,
               r.name AS "regionName", r.npc_type AS "npcType"
        FROM solar_systems s
        LEFT JOIN map_regions r ON r.id = s.region_id


### PR DESCRIPTION
## Problem

\`nexumDebug.simulateJumps([...k-space + wormhole route...])\` crashes with:

\`\`\`
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at SystemPanel (SystemPanel.tsx:475)
\`\`\`

## Root cause

K-space systems have no wormhole entry, so \`solar_systems.effect\` is stored as **NULL** (setup-db.ts populates it as \`wh?.effect ?? null\`).

Two endpoints serve system effect, and they were inconsistent:

- \`/api/character/...\` (live location tracking) already does \`COALESCE(s.effect, 'none')\` — so live jumps into k-space were always safe.
- \`/api/systems/:id\` (used by \`fetchSystemDetail\` -> \`simulateJumps\` and the search/add UI) returned the raw \`NULL\`.

So the debug tool fed \`effect: null\` into the panel: \`null !== 'none'\` is true, \`EFFECT_MODIFIERS[null]\` is \`undefined\`, and \`.length\` throws. The route crashed the moment it hit the first k-space hop (Hykkota).

## Fix

Coalesce \`s.effect\` to \`'none'\` in \`/api/systems/:id\`, matching the character endpoint. One line. Every consumer now gets a valid effect key.

No impact on live jumps — they use the character endpoint, which was already correct.