### PR TITLE
Skip system selection during dryRun simulateJumps

### DIFF
--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -160,7 +160,12 @@ const nexumDebug = {
       if (id) {
         prev = id;
         useMapStore.getState().setCurrentSystem(id);
-        useMapStore.getState().selectSystem(id);
+        // Selecting a system opens its detail panel, whose panes immediately
+        // GET /systems/:id/{signatures,structures,anomalies}. In a dry run the
+        // system was never persisted, so those reads 404 (and toast) for every
+        // ghost hop — flooding the console. Placement is what a dry run tests,
+        // so leave selection alone; the node + its connection still render.
+        if (!dryRun) useMapStore.getState().selectSystem(id);
         const pos = useMapStore.getState().map.systems.find((s) => s.id === id)?.position;
         console.log(`[nexum] jump ${i}/${names.length} → ${sys.name}  @ (${pos?.x}, ${pos?.y})`);
       }


### PR DESCRIPTION
## Symptom

Running `simulateJumps([...], 10000, { dryRun: true })` flooded the console with failed reads and error toasts (looked like a hang, though the page stayed responsive):

```
GET /api/maps/<map>/systems/<id>/signatures  404 (Not Found)   ← SignaturePane.tsx:331
GET /api/maps/<map>/systems/<id>/structures  404               ← StructuresPane.tsx:103
GET /api/maps/<map>/systems/<id>/anomalies   404               ← AnomalyPane
```

## Cause

For each hop, the simulator called `selectSystem(id)`, which opens `SystemPanel` and mounts the signature / structure / anomaly panes for the selected system. Those panes immediately GET their per-system sub-resources. In a dry run the system was **never persisted** (the write was suppressed by #290), so every one of those reads 404s — and `SignaturePane`'s `.catch` also fires `toast.error(...)`. Twenty selected ghost systems => ~60 failed fetches + error toasts.

The reads aren't (and shouldn't be) covered by the write-suppression flag, so they leaked through.

## Fix

A dry run exists to watch **placement** — nodes appearing and connecting on the canvas — not to inspect per-system server data that doesn't exist. So skip `selectSystem` when `dryRun` is on. The node and its connection still render, and the current-system marker still advances. Normal (non-dry) runs are unchanged: those systems are persisted, so the pane fetches succeed.

Follows #289 (effect null-coalesce) and #290 (dryRun write suppression). `tsc -b` clean.