### PR TITLE
Size auto-placement cells to the largest node so the grid stays aligned

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useMapStore } from '../store/mapStore';
+import { useMapStore, getPlacementCell } from '../store/mapStore';
 import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
 import { readUserSetting } from './useUserSetting';
@@ -109,7 +109,7 @@ export interface JumpSystem {
  * console debug tool drives the exact same placement code as a real jump.
  */
 export function applyJump(system: JumpSystem, prevMapSystemId: string | null, canAdd: boolean): string | null {
-  const { map, addSystem, addConnection, updateConnection, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
+  const { map, addSystem, addConnection, updateConnection, snapToGrid } = useMapStore.getState();
 
   let mapSystemId: string;
   const existing = map.systems.find((s) => s.eveSystemId === system.eveSystemId);
@@ -117,8 +117,13 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
     mapSystemId = existing.id;
   } else {
     if (!canAdd) return null;
-    const w = uniformWidth || 220;
-    const h = uniformHeight || 120;
+    // Placement cell = the largest full node footprint (height included), so
+    // every cell fits any node and tiles with consistent 3-square gutters
+    // regardless of the uniform-size toggle. Falls back to a nominal node size
+    // before any node has been measured.
+    const cell = getPlacementCell();
+    const w = cell.w || 220;
+    const h = cell.h || 120;
     const gap = PLACEMENT_GAP;
     let source: { x: number; y: number };
     if (prevMapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -33,6 +33,21 @@ const nodeSizes = new Map<string, { w: number; h: number; countHeight: boolean }
 const GRID = 20;
 const snapUpToGrid = (n: number) => (n > 0 ? Math.ceil(n / GRID) * GRID : 0);
 
+// Largest *full* node footprint seen so far (width and height, ungated by
+// countHeight), snapped up to the grid. This is the auto-placement cell: unlike
+// the uniform-size max — which excludes tall static nodes from the height so it
+// doesn't force every node tall — placement needs a cell big enough for ANY
+// node, so cells tile with consistent 3-square gutters and nothing overflows
+// into its neighbour. Returns {0,0} until at least one node has reported a size.
+export function getPlacementCell(): { w: number; h: number } {
+  let w = 0, h = 0;
+  for (const s of nodeSizes.values()) {
+    if (s.w > w) w = s.w;
+    if (s.h > h) h = s.h;
+  }
+  return { w: snapUpToGrid(w), h: snapUpToGrid(h) };
+}
+
 function recomputeUniformMax(): { w: number; h: number } {
   let w = 0, h = 0, hAll = 0;
   let anyHeightEligible = false;


### PR DESCRIPTION
## Goal

Every auto-placed system should sit on a uniform grid, a consistent **3 grid squares** from its neighbour in any direction, with rows and columns aligned.

## Problem

Placement already lays nodes on a lattice (`source + ring*step`) with a `PLACEMENT_GAP` of 3 grid squares. But the vertical step used `uniformHeight`, which is intentionally gated to nodes **without** statics (`countHeight`) so tall WH/static nodes don't force every node tall in uniform-size mode. Reused as the placement cell, that cell is too short: tall static nodes overflow into the gutter, so the gap between rows comes out inconsistent (the gappy/uneven layout seen on mixed k-space + WH routes).

## Fix

Add `getPlacementCell()` to mapStore: the largest **full** node footprint (width and height, height ungated), snapped to the grid. `applyJump` uses that as the placement cell instead of `uniformWidth`/`uniformHeight`.

Now every cell is big enough for any node, so cells tile with consistent 3-square gutters and rows/columns line up; smaller nodes sit top-left in their cell (extra blank space inside, by design). Independent of the uniform-size toggle. Live tracking and `simulateJumps` share this path.

## Test

- `yarn tsc --noEmit` clean.
- Re-run the mixed route dry run with uniform size off:
  `nexumDebug.simulateJumps([...], 15000, { dryRun: true })` and confirm aligned columns/rows with even 3-square gutters.

## Caveat

The cell grows as larger nodes are measured. In practice the tallest nodes (home system + early WH hops) render before later placements, so it stabilises immediately. If a much taller node appears late in a run, rows placed before it can sit on a slightly tighter pitch — re-running layout resolves it. Can be made fully drift-proof later by snapshotting the cell, if needed.