### PR TITLE
Highlight a system's connections on hover + fan apart parallel edges

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -26,7 +26,7 @@
   --cv-stand-bad: #f5a623; --cv-stand-hostile: #e74c3c;
 
   --cv-conn-4h: #f0c040; --cv-conn-1h: #ff9800; --cv-conn-expired: #f44336;
-  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #4db8c4;
+  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #4db8c4; --cv-conn-highlight: #67e8f9;
 
   --cv-status-unknown: #3a4a6a; --cv-status-visited: #3a8a5a; --cv-status-cleared: #2a6aaa;
   --cv-online-on: #3ddc84; --cv-online-off: #e05a5a;
@@ -58,7 +58,7 @@
   --cv-stand-bad: #e69f00; --cv-stand-hostile: #d55e00;
 
   --cv-conn-4h: #f0e442; --cv-conn-1h: #e69f00; --cv-conn-expired: #d55e00;
-  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #56b4e9;
+  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #56b4e9; --cv-conn-highlight: #56b4e9;
 
   --cv-status-unknown: #777788; --cv-status-visited: #e69f00; --cv-status-cleared: #0072b2;
   --cv-online-on: #009e73; --cv-online-off: #d55e00;
@@ -89,7 +89,7 @@
   --cv-stand-bad: #ee7733; --cv-stand-hostile: #cc3311;
 
   --cv-conn-4h: #88ccaa; --cv-conn-1h: #ee7733; --cv-conn-expired: #cc3311;
-  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #44aa99;
+  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #44aa99; --cv-conn-highlight: #ee99cc;
 
   --cv-status-unknown: #888888; --cv-status-visited: #117733; --cv-status-cleared: #aa4477;
   --cv-online-on: #117733; --cv-online-off: #cc3311;

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -17,6 +17,10 @@ import { watchMarker } from '../../data/watchMarkers';
 const STANDARD_COLOR = 'var(--cv-conn-standard)';
 const JUMPGATE_COLOR  = 'var(--cv-conn-jumpgate)';
 
+// Perpendicular spacing between multiple connections that share the same pair
+// of systems, so they fan apart instead of stacking on one line.
+const PARALLEL_SEP = 18;
+
 const EOL_LIFE_MS    = 4 * 60 * 60 * 1000;
 const EOL_LESS_1H_MS = 60 * 60 * 1000;
 
@@ -56,9 +60,19 @@ export const ConnectionEdge = memo(({
   sourcePosition, targetPosition, data, selected,
 }: EdgeProps) => {
   const { t } = useTranslation();
-  const conn = data as unknown as MapConnection & { edgeStyle?: string; connectionThickness?: 'thin' | 'standard' | 'thick' | 'extra' };
+  const conn = data as unknown as MapConnection & {
+    edgeStyle?: string;
+    connectionThickness?: 'thin' | 'standard' | 'thick' | 'extra';
+    highlighted?: boolean;
+    parallelIndex?: number;
+    parallelCount?: number;
+  };
   const selectConnection = useMapStore((s) => s.selectConnection);
   const now = useNow30s();
+
+  // Emphasised = clicked-selected OR lit because the hovered/selected system is
+  // one of its endpoints (so you can trace a system's links through a tangle).
+  const emphasized = selected || !!conn?.highlighted;
 
   // Watchlist: a connection whose wormhole type (or frig-hole size) is on the
   // user's watchlist gets a coloured glow in the marker colour.
@@ -66,7 +80,7 @@ export const ConnectionEdge = memo(({
   const watch = conn ? matchConnection(watchEntries, conn) : null;
   const watchColor = watch ? watchMarker(watch.marker).color : null;
 
-  const [edgePath, labelX, labelY] = (() => {
+  let [edgePath, labelX, labelY] = (() => {
     const args = { sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition };
     switch (conn?.edgeStyle) {
       case 'straight':     return getStraightPath({ sourceX, sourceY, targetX, targetY });
@@ -74,6 +88,29 @@ export const ConnectionEdge = memo(({
       default:             return getBezierPath(args);
     }
   })();
+
+  // Multiple connections between the same two systems would otherwise draw on
+  // top of each other. Bow each one perpendicular to the straight source->
+  // target line by an index-based offset, symmetric around the centre, so they
+  // fan apart. Style-agnostic: a single edge (the common case) is untouched.
+  const parallelCount = conn?.parallelCount ?? 1;
+  if (parallelCount > 1) {
+    const idx    = conn?.parallelIndex ?? 0;
+    const spread = (idx - (parallelCount - 1) / 2) * PARALLEL_SEP;
+    if (spread !== 0) {
+      const dx  = targetX - sourceX;
+      const dy  = targetY - sourceY;
+      const len = Math.hypot(dx, dy) || 1;
+      const nx  = -dy / len; // perpendicular unit vector
+      const ny  =  dx / len;
+      const cx  = (sourceX + targetX) / 2 + nx * spread;
+      const cy  = (sourceY + targetY) / 2 + ny * spread;
+      edgePath = `M ${sourceX},${sourceY} Q ${cx},${cy} ${targetX},${targetY}`;
+      // Quadratic-bezier midpoint (t=0.5) for the label.
+      labelX = 0.25 * sourceX + 0.5 * cx + 0.25 * targetX;
+      labelY = 0.25 * sourceY + 0.5 * cy + 0.25 * targetY;
+    }
+  }
 
   const isJumpgate = conn?.connectionType === 'jumpgate';
   // Quarantined: the backing wormhole sig was deleted (hole collapsed). Kept on
@@ -98,7 +135,7 @@ export const ConnectionEdge = memo(({
     conn?.connectionThickness === 'extra' ? 8 :
     4
   );
-  const strokeWidth = selected ? baseWidth + 2 : baseWidth;
+  const strokeWidth = emphasized ? baseWidth + 2 : baseWidth;
   const massLabel   = !isJumpgate && conn?.massStatus ? (MASS_LABELS[conn.massStatus] ?? null) : null;
 
   // Prefer the live countdown label; fall back to the static category label
@@ -124,10 +161,10 @@ export const ConnectionEdge = memo(({
           strokeWidth: watchColor ? strokeWidth + 1 : strokeWidth,
           strokeDasharray: broken ? '5 7' : isJumpgate ? '10 5' : undefined,
           filter: [
-            selected ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
+            emphasized ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
             watchColor ? `drop-shadow(0 0 5px ${watchColor}) drop-shadow(0 0 2px ${watchColor})` : null,
           ].filter(Boolean).join(' ') || undefined,
-          opacity: broken ? 0.7 : selected || watchColor ? 1 : 0.85,
+          opacity: broken ? 0.7 : emphasized || watchColor ? 1 : 0.85,
         }}
         markerEnd={undefined}
       />

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -16,6 +16,7 @@ import { watchMarker } from '../../data/watchMarkers';
 // colour-vision palettes (--cv-conn-* in App.css) re-map connection colours.
 const STANDARD_COLOR = 'var(--cv-conn-standard)';
 const JUMPGATE_COLOR  = 'var(--cv-conn-jumpgate)';
+const HIGHLIGHT_COLOR = 'var(--cv-conn-highlight)';
 
 // Perpendicular spacing between multiple connections that share the same pair
 // of systems, so they fan apart instead of stacking on one line.
@@ -70,9 +71,11 @@ export const ConnectionEdge = memo(({
   const selectConnection = useMapStore((s) => s.selectConnection);
   const now = useNow30s();
 
-  // Emphasised = clicked-selected OR lit because the hovered/selected system is
-  // one of its endpoints (so you can trace a system's links through a tangle).
-  const emphasized = selected || !!conn?.highlighted;
+  // Lit because the hovered/selected system is one of its endpoints — these get
+  // recoloured (not just glowed) so a system's links pop out of a tangle.
+  const highlighted = !!conn?.highlighted;
+  // Emphasised = clicked-selected OR highlighted: drives stroke width / glow.
+  const emphasized = selected || highlighted;
 
   // Watchlist: a connection whose wormhole type (or frig-hole size) is on the
   // user's watchlist gets a coloured glow in the marker colour.
@@ -125,6 +128,11 @@ export const ConnectionEdge = memo(({
   const color = isJumpgate
     ? JUMPGATE_COLOR
     : (eolState?.color ?? TIME_COLORS[timeStatus ?? ''] ?? STANDARD_COLOR);
+  // Final stroke: broken keeps severed-red; otherwise a highlighted link (its
+  // system is hovered/selected) takes the highlight hue, else its own state colour.
+  const strokeColor = broken
+    ? 'var(--cv-conn-expired)'
+    : highlighted ? HIGHLIGHT_COLOR : color;
   // Per-user thickness preference. Standard = the historical 4 / 6 pair;
   // other steps scale around that. Selected always renders 2px thicker
   // than unselected so the selection highlight stays visible at every
@@ -157,11 +165,14 @@ export const ConnectionEdge = memo(({
         id={id}
         path={edgePath}
         style={{
-          stroke: broken ? 'var(--cv-conn-expired)' : color,
+          // A hovered/selected system's links recolour to the highlight hue so
+          // they stand out; broken links keep the severed-red so their state
+          // stays readable even while highlighted.
+          stroke: strokeColor,
           strokeWidth: watchColor ? strokeWidth + 1 : strokeWidth,
           strokeDasharray: broken ? '5 7' : isJumpgate ? '10 5' : undefined,
           filter: [
-            emphasized ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
+            emphasized ? `drop-shadow(0 0 6px ${strokeColor})` : null,
             watchColor ? `drop-shadow(0 0 5px ${watchColor}) drop-shadow(0 0 2px ${watchColor})` : null,
           ].filter(Boolean).join(' ') || undefined,
           opacity: broken ? 0.7 : emphasized || watchColor ? 1 : 0.85,

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -566,12 +566,33 @@ export function MapCanvas() {
     Map<string, { sourceHandle: string; targetHandle: string }>
   >(new Map());
 
+  // Hovered system: while set, every connection touching it is highlighted so
+  // its links can be traced through overlapping edges. Cleared on mouse-out.
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const onNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node) => setHoveredNodeId(node.id), []);
+  const onNodeMouseLeave = useCallback(() => setHoveredNodeId(null), []);
+
   // Edges driven directly from store — no local duplicate state, except for
   // the live drag-handle overrides above.
   const edges = useMemo(
-    () =>
-      connections.map((c) => {
+    () => {
+      // Group connections by unordered system pair so multiples between the
+      // same two systems can be fanned apart (parallelIndex / parallelCount)
+      // instead of stacking on one line.
+      const pairGroups = new Map<string, string[]>();
+      for (const c of connections) {
+        const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
+        const g = pairGroups.get(key);
+        if (g) g.push(c.id);
+        else pairGroups.set(key, [c.id]);
+      }
+      return connections.map((c) => {
         const ov = dragHandles.get(c.id);
+        const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
+        const group = pairGroups.get(key)!;
+        const highlighted =
+          (hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId)) ||
+          (selectedSystemId != null && (c.sourceId === selectedSystemId || c.targetId === selectedSystemId));
         return {
           id: c.id,
           source: c.sourceId,
@@ -579,11 +600,17 @@ export function MapCanvas() {
           sourceHandle: ov?.sourceHandle ?? c.sourceHandle ?? undefined,
           targetHandle: ov?.targetHandle ?? c.targetHandle ?? undefined,
           type: 'connection',
-          data: { ...c, edgeStyle, connectionThickness } as unknown as Record<string, unknown>,
+          // Lift highlighted edges above the rest so the traced link sits on top.
+          zIndex: highlighted ? 10 : 0,
+          data: {
+            ...c, edgeStyle, connectionThickness, highlighted,
+            parallelIndex: group.indexOf(c.id), parallelCount: group.length,
+          } as unknown as Record<string, unknown>,
           selected: c.id === selectedConnectionId,
         };
-      }),
-    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles],
+      });
+    },
+    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId, selectedSystemId],
   );
 
   const onEdgesChange = useCallback(
@@ -1086,6 +1113,8 @@ export function MapCanvas() {
         onConnect={onConnect}
         onNodeDrag={onNodeDrag}
         onNodeDragStop={onNodeDragStop}
+        onNodeMouseEnter={onNodeMouseEnter}
+        onNodeMouseLeave={onNodeMouseLeave}
         onPaneContextMenu={onPaneContextMenu}
         onNodeContextMenu={onNodeContextMenu}
         onEdgeContextMenu={onEdgeContextMenu}


### PR DESCRIPTION
## Goal

Make overlapping connections traceable (re: the tangled-edges question). Two changes, both opt-in-by-interaction and non-destructive:

### 1. Highlight a system's links
Hovering a system - or having it selected - now lights up **every connection touching it**: thicker stroke, full opacity, a glow, and lifted above the other edges (`zIndex`). So when several lines cross, you hover the system and immediately see which links belong to it.

- `MapCanvas`: new `hoveredNodeId` state via `onNodeMouseEnter`/`onNodeMouseLeave`; the `edges` memo marks each edge `highlighted` when `hoveredNodeId` **or** `selectedSystemId` is one of its endpoints.
- `ConnectionEdge`: `emphasized = selected || highlighted` drives the existing selection styling (width / glow / opacity).

### 2. Fan apart parallel edges
Multiple connections between the **same pair of systems** previously drew on top of each other. The `edges` memo now groups by unordered system-pair and tags each edge with `parallelIndex` / `parallelCount`; `ConnectionEdge` bows them perpendicular to the source->target line by a symmetric offset (`PARALLEL_SEP`). A single edge per pair (the common case) is untouched, and it works for all three edge styles.

## Notes / scope

- This does **not** attempt obstacle-avoiding routing (long edges can still cross unrelated nodes) - that's a much larger effort with shaky payoff. The highlight is the practical answer to 'which line goes where'; the offset stops genuine duplicates stacking.
- No new user-facing strings, so no i18n changes.

## Test

- `yarn tsc --noEmit` clean; `yarn lint` clean for both files.
- Hover a system with several connections - its links glow and lift. Move off - they return to normal. Click a system (panel open) - its links stay lit.
- Add two connections between the same pair of systems - they fan apart instead of overlapping.