### PR TITLE
Release v1.9.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.8.1",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/routes/systems.ts
+++ b/server/src/routes/systems.ts
@@ -263,7 +263,8 @@ systemsRouter.get('/:id(\\d+)', async (req, res) => {
 
   try {
     const { rows } = await db.query(
-      `SELECT s.id, s.name, s.security, s.class AS "systemClass", s.effect, s.statics,
+      `SELECT s.id, s.name, s.security, s.class AS "systemClass",
+              COALESCE(s.effect, 'none') AS effect, s.statics,
               r.name AS "regionName", r.npc_type AS "npcType"
        FROM solar_systems s
        LEFT JOIN map_regions r ON r.id = s.region_id

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.9.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6031,7 +6031,7 @@ select.sig-toolbar-btn option {
 
 /* ── User Stats Modal ────────────────────────────────────── */
 .stats-modal {
-  width: 480px;
+  width: 560px;
 }
 
 .stats-modal__periods {
@@ -6051,6 +6051,7 @@ select.sig-toolbar-btn option {
   font-family: inherit;
   font-size: calc(13px * var(--font-scale, 1));
   padding: 4px 0;
+  white-space: nowrap;
 }
 
 .stats-modal__period-btn:hover { background: #1a2240; color: #c8d0e0; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -26,7 +26,7 @@
   --cv-stand-bad: #f5a623; --cv-stand-hostile: #e74c3c;
 
   --cv-conn-4h: #f0c040; --cv-conn-1h: #ff9800; --cv-conn-expired: #f44336;
-  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #4db8c4;
+  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #4db8c4; --cv-conn-highlight: #67e8f9;
 
   --cv-status-unknown: #3a4a6a; --cv-status-visited: #3a8a5a; --cv-status-cleared: #2a6aaa;
   --cv-online-on: #3ddc84; --cv-online-off: #e05a5a;
@@ -58,7 +58,7 @@
   --cv-stand-bad: #e69f00; --cv-stand-hostile: #d55e00;
 
   --cv-conn-4h: #f0e442; --cv-conn-1h: #e69f00; --cv-conn-expired: #d55e00;
-  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #56b4e9;
+  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #56b4e9; --cv-conn-highlight: #56b4e9;
 
   --cv-status-unknown: #777788; --cv-status-visited: #e69f00; --cv-status-cleared: #0072b2;
   --cv-online-on: #009e73; --cv-online-off: #d55e00;
@@ -89,7 +89,7 @@
   --cv-stand-bad: #ee7733; --cv-stand-hostile: #cc3311;
 
   --cv-conn-4h: #88ccaa; --cv-conn-1h: #ee7733; --cv-conn-expired: #cc3311;
-  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #44aa99;
+  --cv-conn-standard: #8a9ab8; --cv-conn-jumpgate: #44aa99; --cv-conn-highlight: #ee99cc;
 
   --cv-status-unknown: #888888; --cv-status-visited: #117733; --cv-status-cleared: #aa4477;
   --cv-online-on: #117733; --cv-online-off: #cc3311;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,10 +12,27 @@ export function setShareToken(token: string | null): void {
   shareToken = token;
 }
 
+// When true, write requests (POST/PATCH/PUT/DELETE) are short-circuited to a
+// resolved no-op instead of hitting the network. Used by nexumDebug's
+// simulateJumps({ dryRun: true }) so the placement code can be exercised
+// (e.g. logged out) without firing — or queuing — doomed map writes. The
+// promise RESOLVES (not rejects), so callers' .catch(enqueue) never runs.
+let writesSuppressed = false;
+
+export function setWritesSuppressed(suppressed: boolean): void {
+  writesSuppressed = suppressed;
+}
+
 const WRITE_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
 
 export async function api<T = unknown>(path: string, options?: RequestInit): Promise<T> {
   const method = (options?.method ?? 'GET').toUpperCase();
+
+  // Dry-run: swallow writes before any network work so they neither send nor
+  // enqueue. Resolves undefined, matching a 204/empty response.
+  if (writesSuppressed && WRITE_METHODS.has(method)) {
+    return undefined as T;
+  }
 
   // In share mode: block writes outright (no edits without an account) and
   // append the token to every read so the server can authorise it.

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -17,6 +17,10 @@ import { watchMarker } from '../../data/watchMarkers';
 const STANDARD_COLOR = 'var(--cv-conn-standard)';
 const JUMPGATE_COLOR  = 'var(--cv-conn-jumpgate)';
 
+// Perpendicular spacing between multiple connections that share the same pair
+// of systems, so they fan apart instead of stacking on one line.
+const PARALLEL_SEP = 18;
+
 const EOL_LIFE_MS    = 4 * 60 * 60 * 1000;
 const EOL_LESS_1H_MS = 60 * 60 * 1000;
 
@@ -56,9 +60,19 @@ export const ConnectionEdge = memo(({
   sourcePosition, targetPosition, data, selected,
 }: EdgeProps) => {
   const { t } = useTranslation();
-  const conn = data as unknown as MapConnection & { edgeStyle?: string; connectionThickness?: 'thin' | 'standard' | 'thick' | 'extra' };
+  const conn = data as unknown as MapConnection & {
+    edgeStyle?: string;
+    connectionThickness?: 'thin' | 'standard' | 'thick' | 'extra';
+    highlighted?: boolean;
+    parallelIndex?: number;
+    parallelCount?: number;
+  };
   const selectConnection = useMapStore((s) => s.selectConnection);
   const now = useNow30s();
+
+  // Emphasised = clicked-selected OR lit because the hovered/selected system is
+  // one of its endpoints (so you can trace a system's links through a tangle).
+  const emphasized = selected || !!conn?.highlighted;
 
   // Watchlist: a connection whose wormhole type (or frig-hole size) is on the
   // user's watchlist gets a coloured glow in the marker colour.
@@ -66,7 +80,7 @@ export const ConnectionEdge = memo(({
   const watch = conn ? matchConnection(watchEntries, conn) : null;
   const watchColor = watch ? watchMarker(watch.marker).color : null;
 
-  const [edgePath, labelX, labelY] = (() => {
+  let [edgePath, labelX, labelY] = (() => {
     const args = { sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition };
     switch (conn?.edgeStyle) {
       case 'straight':     return getStraightPath({ sourceX, sourceY, targetX, targetY });
@@ -74,6 +88,29 @@ export const ConnectionEdge = memo(({
       default:             return getBezierPath(args);
     }
   })();
+
+  // Multiple connections between the same two systems would otherwise draw on
+  // top of each other. Bow each one perpendicular to the straight source->
+  // target line by an index-based offset, symmetric around the centre, so they
+  // fan apart. Style-agnostic: a single edge (the common case) is untouched.
+  const parallelCount = conn?.parallelCount ?? 1;
+  if (parallelCount > 1) {
+    const idx    = conn?.parallelIndex ?? 0;
+    const spread = (idx - (parallelCount - 1) / 2) * PARALLEL_SEP;
+    if (spread !== 0) {
+      const dx  = targetX - sourceX;
+      const dy  = targetY - sourceY;
+      const len = Math.hypot(dx, dy) || 1;
+      const nx  = -dy / len; // perpendicular unit vector
+      const ny  =  dx / len;
+      const cx  = (sourceX + targetX) / 2 + nx * spread;
+      const cy  = (sourceY + targetY) / 2 + ny * spread;
+      edgePath = `M ${sourceX},${sourceY} Q ${cx},${cy} ${targetX},${targetY}`;
+      // Quadratic-bezier midpoint (t=0.5) for the label.
+      labelX = 0.25 * sourceX + 0.5 * cx + 0.25 * targetX;
+      labelY = 0.25 * sourceY + 0.5 * cy + 0.25 * targetY;
+    }
+  }
 
   const isJumpgate = conn?.connectionType === 'jumpgate';
   // Quarantined: the backing wormhole sig was deleted (hole collapsed). Kept on
@@ -98,7 +135,7 @@ export const ConnectionEdge = memo(({
     conn?.connectionThickness === 'extra' ? 8 :
     4
   );
-  const strokeWidth = selected ? baseWidth + 2 : baseWidth;
+  const strokeWidth = emphasized ? baseWidth + 2 : baseWidth;
   const massLabel   = !isJumpgate && conn?.massStatus ? (MASS_LABELS[conn.massStatus] ?? null) : null;
 
   // Prefer the live countdown label; fall back to the static category label
@@ -124,10 +161,10 @@ export const ConnectionEdge = memo(({
           strokeWidth: watchColor ? strokeWidth + 1 : strokeWidth,
           strokeDasharray: broken ? '5 7' : isJumpgate ? '10 5' : undefined,
           filter: [
-            selected ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
+            emphasized ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
             watchColor ? `drop-shadow(0 0 5px ${watchColor}) drop-shadow(0 0 2px ${watchColor})` : null,
           ].filter(Boolean).join(' ') || undefined,
-          opacity: broken ? 0.7 : selected || watchColor ? 1 : 0.85,
+          opacity: broken ? 0.7 : emphasized || watchColor ? 1 : 0.85,
         }}
         markerEnd={undefined}
       />

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -16,6 +16,7 @@ import { watchMarker } from '../../data/watchMarkers';
 // colour-vision palettes (--cv-conn-* in App.css) re-map connection colours.
 const STANDARD_COLOR = 'var(--cv-conn-standard)';
 const JUMPGATE_COLOR  = 'var(--cv-conn-jumpgate)';
+const HIGHLIGHT_COLOR = 'var(--cv-conn-highlight)';
 
 // Perpendicular spacing between multiple connections that share the same pair
 // of systems, so they fan apart instead of stacking on one line.
@@ -70,9 +71,11 @@ export const ConnectionEdge = memo(({
   const selectConnection = useMapStore((s) => s.selectConnection);
   const now = useNow30s();
 
-  // Emphasised = clicked-selected OR lit because the hovered/selected system is
-  // one of its endpoints (so you can trace a system's links through a tangle).
-  const emphasized = selected || !!conn?.highlighted;
+  // Lit because the hovered/selected system is one of its endpoints — these get
+  // recoloured (not just glowed) so a system's links pop out of a tangle.
+  const highlighted = !!conn?.highlighted;
+  // Emphasised = clicked-selected OR highlighted: drives stroke width / glow.
+  const emphasized = selected || highlighted;
 
   // Watchlist: a connection whose wormhole type (or frig-hole size) is on the
   // user's watchlist gets a coloured glow in the marker colour.
@@ -125,6 +128,11 @@ export const ConnectionEdge = memo(({
   const color = isJumpgate
     ? JUMPGATE_COLOR
     : (eolState?.color ?? TIME_COLORS[timeStatus ?? ''] ?? STANDARD_COLOR);
+  // Final stroke: broken keeps severed-red; otherwise a highlighted link (its
+  // system is hovered/selected) takes the highlight hue, else its own state colour.
+  const strokeColor = broken
+    ? 'var(--cv-conn-expired)'
+    : highlighted ? HIGHLIGHT_COLOR : color;
   // Per-user thickness preference. Standard = the historical 4 / 6 pair;
   // other steps scale around that. Selected always renders 2px thicker
   // than unselected so the selection highlight stays visible at every
@@ -157,11 +165,14 @@ export const ConnectionEdge = memo(({
         id={id}
         path={edgePath}
         style={{
-          stroke: broken ? 'var(--cv-conn-expired)' : color,
+          // A hovered/selected system's links recolour to the highlight hue so
+          // they stand out; broken links keep the severed-red so their state
+          // stays readable even while highlighted.
+          stroke: strokeColor,
           strokeWidth: watchColor ? strokeWidth + 1 : strokeWidth,
           strokeDasharray: broken ? '5 7' : isJumpgate ? '10 5' : undefined,
           filter: [
-            emphasized ? `drop-shadow(0 0 6px ${broken ? 'var(--cv-conn-expired)' : color})` : null,
+            emphasized ? `drop-shadow(0 0 6px ${strokeColor})` : null,
             watchColor ? `drop-shadow(0 0 5px ${watchColor}) drop-shadow(0 0 2px ${watchColor})` : null,
           ].filter(Boolean).join(' ') || undefined,
           opacity: broken ? 0.7 : emphasized || watchColor ? 1 : 0.85,

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -566,12 +566,33 @@ export function MapCanvas() {
     Map<string, { sourceHandle: string; targetHandle: string }>
   >(new Map());
 
+  // Hovered system: while set, every connection touching it is highlighted so
+  // its links can be traced through overlapping edges. Cleared on mouse-out.
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const onNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node) => setHoveredNodeId(node.id), []);
+  const onNodeMouseLeave = useCallback(() => setHoveredNodeId(null), []);
+
   // Edges driven directly from store — no local duplicate state, except for
   // the live drag-handle overrides above.
   const edges = useMemo(
-    () =>
-      connections.map((c) => {
+    () => {
+      // Group connections by unordered system pair so multiples between the
+      // same two systems can be fanned apart (parallelIndex / parallelCount)
+      // instead of stacking on one line.
+      const pairGroups = new Map<string, string[]>();
+      for (const c of connections) {
+        const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
+        const g = pairGroups.get(key);
+        if (g) g.push(c.id);
+        else pairGroups.set(key, [c.id]);
+      }
+      return connections.map((c) => {
         const ov = dragHandles.get(c.id);
+        const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
+        const group = pairGroups.get(key)!;
+        const highlighted =
+          (hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId)) ||
+          (selectedSystemId != null && (c.sourceId === selectedSystemId || c.targetId === selectedSystemId));
         return {
           id: c.id,
           source: c.sourceId,
@@ -579,11 +600,17 @@ export function MapCanvas() {
           sourceHandle: ov?.sourceHandle ?? c.sourceHandle ?? undefined,
           targetHandle: ov?.targetHandle ?? c.targetHandle ?? undefined,
           type: 'connection',
-          data: { ...c, edgeStyle, connectionThickness } as unknown as Record<string, unknown>,
+          // Lift highlighted edges above the rest so the traced link sits on top.
+          zIndex: highlighted ? 10 : 0,
+          data: {
+            ...c, edgeStyle, connectionThickness, highlighted,
+            parallelIndex: group.indexOf(c.id), parallelCount: group.length,
+          } as unknown as Record<string, unknown>,
           selected: c.id === selectedConnectionId,
         };
-      }),
-    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles],
+      });
+    },
+    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId, selectedSystemId],
   );
 
   const onEdgesChange = useCallback(
@@ -1086,6 +1113,8 @@ export function MapCanvas() {
         onConnect={onConnect}
         onNodeDrag={onNodeDrag}
         onNodeDragStop={onNodeDragStop}
+        onNodeMouseEnter={onNodeMouseEnter}
+        onNodeMouseLeave={onNodeMouseLeave}
         onPaneContextMenu={onPaneContextMenu}
         onNodeContextMenu={onNodeContextMenu}
         onEdgeContextMenu={onEdgeContextMenu}

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -102,20 +102,25 @@ const nexumDebug = {
   // placement / connection behaviour matches a real jump. Use it to reproduce
   // positioning bugs (e.g. jumping in and out of the same system).
   //   nexumDebug.simulateJumps(['Jita', 'Perimeter', 'Jita', 'New Caldari'])
+  //   nexumDebug.simulateJumps(['Jita', 'Perimeter'], 1000, { dryRun: true })
   //   nexumDebug.stopJumps()
   // Names are EVE system names / J-codes; each is resolved via the systems API.
   // NOTE: this mutates the active map for real (adds systems + connections).
+  // Pass { dryRun: true } to exercise placement locally without firing (or
+  // queuing) any server writes — useful when logged out or without a saved map.
   _jumpTimer: null as ReturnType<typeof setInterval> | null,
 
-  async simulateJumps(names: string[], intervalMs = 2000) {
+  async simulateJumps(names: string[], intervalMs = 2000, opts: { dryRun?: boolean } = {}) {
     if (!Array.isArray(names) || names.some((n) => typeof n !== 'string')) {
-      console.error('[nexum] simulateJumps(names[], intervalMs?) — names must be an array of system names.');
+      console.error('[nexum] simulateJumps(names[], intervalMs?, { dryRun? }) — names must be an array of system names.');
       return;
     }
-    const [{ applyJump }, store, esi] = await Promise.all([
+    const { dryRun = false } = opts;
+    const [{ applyJump }, store, esi, client] = await Promise.all([
       import('./hooks/useLocationTracking'),
       import('./store/mapStore'),
       import('./hooks/useEsiSearch'),
+      import('./api/client'),
     ]);
     const { useMapStore } = store;
 
@@ -136,14 +141,22 @@ const nexumDebug = {
     if (this._jumpTimer) { clearInterval(this._jumpTimer); this._jumpTimer = null; }
     let prev = useMapStore.getState().currentSystemId;
     let i = 0;
-    console.log(`[nexum] Simulating ${names.length} jumps, one every ${intervalMs}ms. nexumDebug.stopJumps() to cancel.`);
+    console.log(`[nexum] Simulating ${names.length} jumps, one every ${intervalMs}ms${dryRun ? ' (dry run — no server writes)' : ''}. nexumDebug.stopJumps() to cancel.`);
 
     const step = async () => {
       if (i >= names.length) { this.stopJumps(); console.log('[nexum] Jump simulation complete.'); return; }
       const name = names[i++];
       const sys = await resolve(name);
       if (!sys) { console.warn(`[nexum] Could not resolve "${name}" — skipping.`); return; }
-      const id = applyJump(sys, prev, true);
+      // applyJump's writes are dispatched synchronously (the suppression check
+      // runs before fetch), so toggling around this call captures them all.
+      if (dryRun) client.setWritesSuppressed(true);
+      let id: string | null;
+      try {
+        id = applyJump(sys, prev, true);
+      } finally {
+        if (dryRun) client.setWritesSuppressed(false);
+      }
       if (id) {
         prev = id;
         useMapStore.getState().setCurrentSystem(id);
@@ -175,6 +188,7 @@ const nexumDebug = {
     console.log('nexumDebug.queue()     — show pending write queue');
     console.log('nexumDebug.flush()     — manually flush the write queue');
     console.log("nexumDebug.simulateJumps(['Jita','Perimeter','Jita'], 2000) — replay a route, one hop / interval");
+    console.log("nexumDebug.simulateJumps([...], 1000, { dryRun: true }) — replay without firing server writes (logged-out safe)");
     console.log('nexumDebug.stopJumps() — cancel a running jump simulation');
     console.log('nexumDebug.clear()     — clear the log buffer');
     console.groupEnd();

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -160,7 +160,12 @@ const nexumDebug = {
       if (id) {
         prev = id;
         useMapStore.getState().setCurrentSystem(id);
-        useMapStore.getState().selectSystem(id);
+        // Selecting a system opens its detail panel, whose panes immediately
+        // GET /systems/:id/{signatures,structures,anomalies}. In a dry run the
+        // system was never persisted, so those reads 404 (and toast) for every
+        // ghost hop — flooding the console. Placement is what a dry run tests,
+        // so leave selection alone; the node + its connection still render.
+        if (!dryRun) useMapStore.getState().selectSystem(id);
         const pos = useMapStore.getState().map.systems.find((s) => s.id === id)?.position;
         console.log(`[nexum] jump ${i}/${names.length} → ${sys.name}  @ (${pos?.x}, ${pos?.y})`);
       }

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -96,6 +96,71 @@ const nexumDebug = {
     });
   },
 
+  // ── Jump simulator ──────────────────────────────────────────────────────
+  // Replays a player route through the active map, one hop every `intervalMs`,
+  // driving the SAME applyJump() code path as live location tracking so node
+  // placement / connection behaviour matches a real jump. Use it to reproduce
+  // positioning bugs (e.g. jumping in and out of the same system).
+  //   nexumDebug.simulateJumps(['Jita', 'Perimeter', 'Jita', 'New Caldari'])
+  //   nexumDebug.stopJumps()
+  // Names are EVE system names / J-codes; each is resolved via the systems API.
+  // NOTE: this mutates the active map for real (adds systems + connections).
+  _jumpTimer: null as ReturnType<typeof setInterval> | null,
+
+  async simulateJumps(names: string[], intervalMs = 2000) {
+    if (!Array.isArray(names) || names.some((n) => typeof n !== 'string')) {
+      console.error('[nexum] simulateJumps(names[], intervalMs?) — names must be an array of system names.');
+      return;
+    }
+    const [{ applyJump }, store, esi] = await Promise.all([
+      import('./hooks/useLocationTracking'),
+      import('./store/mapStore'),
+      import('./hooks/useEsiSearch'),
+    ]);
+    const { useMapStore } = store;
+
+    const resolve = async (name: string) => {
+      const results = await (await fetch(
+        `${(await import('./api/client')).apiUrl(`/api/systems/search?q=${encodeURIComponent(name)}`)}`,
+        { credentials: 'include' },
+      )).json() as Array<{ id: number; name: string }>;
+      const hit = results.find((r) => r.name.toLowerCase() === name.toLowerCase()) ?? results[0];
+      if (!hit) return null;
+      const d = await esi.fetchSystemDetail(hit.id);
+      return {
+        eveSystemId: d.id, name: d.name, systemClass: d.systemClass, effect: d.effect,
+        statics: d.statics ?? [], regionName: d.regionName ?? null, npcType: d.npcType ?? null,
+      };
+    };
+
+    if (this._jumpTimer) { clearInterval(this._jumpTimer); this._jumpTimer = null; }
+    let prev = useMapStore.getState().currentSystemId;
+    let i = 0;
+    console.log(`[nexum] Simulating ${names.length} jumps, one every ${intervalMs}ms. nexumDebug.stopJumps() to cancel.`);
+
+    const step = async () => {
+      if (i >= names.length) { this.stopJumps(); console.log('[nexum] Jump simulation complete.'); return; }
+      const name = names[i++];
+      const sys = await resolve(name);
+      if (!sys) { console.warn(`[nexum] Could not resolve "${name}" — skipping.`); return; }
+      const id = applyJump(sys, prev, true);
+      if (id) {
+        prev = id;
+        useMapStore.getState().setCurrentSystem(id);
+        useMapStore.getState().selectSystem(id);
+        const pos = useMapStore.getState().map.systems.find((s) => s.id === id)?.position;
+        console.log(`[nexum] jump ${i}/${names.length} → ${sys.name}  @ (${pos?.x}, ${pos?.y})`);
+      }
+    };
+    await step();
+    this._jumpTimer = setInterval(() => { void step(); }, intervalMs);
+  },
+
+  stopJumps() {
+    if (this._jumpTimer) { clearInterval(this._jumpTimer); this._jumpTimer = null; console.log('[nexum] Jump simulation stopped.'); }
+    else console.log('[nexum] No jump simulation running.');
+  },
+
   clear() {
     log.length = 0;
     console.log('[nexum] Debug log cleared.');
@@ -109,6 +174,8 @@ const nexumDebug = {
     console.log('nexumDebug.mapState()  — current map store snapshot');
     console.log('nexumDebug.queue()     — show pending write queue');
     console.log('nexumDebug.flush()     — manually flush the write queue');
+    console.log("nexumDebug.simulateJumps(['Jita','Perimeter','Jita'], 2000) — replay a route, one hop / interval");
+    console.log('nexumDebug.stopJumps() — cancel a running jump simulation');
     console.log('nexumDebug.clear()     — clear the log buffer');
     console.groupEnd();
   },

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useMapStore } from '../store/mapStore';
+import { useMapStore, getPlacementCell } from '../store/mapStore';
 import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
 import { readUserSetting } from './useUserSetting';
@@ -109,7 +109,7 @@ export interface JumpSystem {
  * console debug tool drives the exact same placement code as a real jump.
  */
 export function applyJump(system: JumpSystem, prevMapSystemId: string | null, canAdd: boolean): string | null {
-  const { map, addSystem, addConnection, updateConnection, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
+  const { map, addSystem, addConnection, updateConnection, snapToGrid } = useMapStore.getState();
 
   let mapSystemId: string;
   const existing = map.systems.find((s) => s.eveSystemId === system.eveSystemId);
@@ -117,8 +117,13 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
     mapSystemId = existing.id;
   } else {
     if (!canAdd) return null;
-    const w = uniformWidth || 220;
-    const h = uniformHeight || 120;
+    // Placement cell = the largest full node footprint (height included), so
+    // every cell fits any node and tiles with consistent 3-square gutters
+    // regardless of the uniform-size toggle. Falls back to a nominal node size
+    // before any node has been measured.
+    const cell = getPlacementCell();
+    const w = cell.w || 220;
+    const h = cell.h || 120;
     const gap = PLACEMENT_GAP;
     let source: { x: number; y: number };
     if (prevMapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -87,6 +87,83 @@ function findFreePosition(
   return place(source.x + fx * stepX, source.y + fy * stepY);
 }
 
+export interface JumpSystem {
+  eveSystemId: number;
+  name:        string;
+  systemClass: string;
+  effect:      string;
+  statics:     string[];
+  regionName:  string | null;
+  npcType:     string | null;
+}
+
+/**
+ * Apply one "the player is now in `system`, arriving from `prevMapSystemId`"
+ * jump to the active map: reuse the system if it's already placed, otherwise
+ * auto-add it at the next free slot around the source (same clockwise
+ * findFreePosition logic live tracking uses), then add or un-break the
+ * connection. Returns the resulting map-system id, or null when the system
+ * isn't on the map and `canAdd` is false (locked / no edit / tracking off).
+ *
+ * Shared by the live tracker below and `nexumDebug.simulateJumps`, so the
+ * console debug tool drives the exact same placement code as a real jump.
+ */
+export function applyJump(system: JumpSystem, prevMapSystemId: string | null, canAdd: boolean): string | null {
+  const { map, addSystem, addConnection, updateConnection, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
+
+  let mapSystemId: string;
+  const existing = map.systems.find((s) => s.eveSystemId === system.eveSystemId);
+  if (existing) {
+    mapSystemId = existing.id;
+  } else {
+    if (!canAdd) return null;
+    const w = uniformWidth || 220;
+    const h = uniformHeight || 120;
+    const gap = PLACEMENT_GAP;
+    let source: { x: number; y: number };
+    if (prevMapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {
+      source = map.systems.find((s) => s.id === prevMapSystemId)!.position;
+    } else {
+      source = {
+        x: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.x, 0) / map.systems.length : 0,
+        y: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length : 0,
+      };
+    }
+    const direction = normalizePlacement(readUserSetting<string>('nexum.map.placement', 'east'));
+    const position = findFreePosition(source, map.systems, w, h, gap, direction, snapToGrid);
+    mapSystemId = addSystem(system.name, system.systemClass as SystemClass, position, {
+      eveSystemId: system.eveSystemId,
+      effect:      system.effect as WormholeEffect,
+      statics:     system.statics,
+      regionName:  system.regionName,
+      npcType:     system.npcType,
+    });
+  }
+
+  if (canAdd && prevMapSystemId && prevMapSystemId !== mapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {
+    const freshConnections = useMapStore.getState().map.connections;
+    const existingConn = freshConnections.find(
+      (c) =>
+        (c.sourceId === prevMapSystemId && c.targetId === mapSystemId) ||
+        (c.sourceId === mapSystemId && c.targetId === prevMapSystemId),
+    );
+    if (existingConn) {
+      // Physically jumping the link is proof it's live — un-quarantine if broken.
+      if (existingConn.broken) updateConnection(existingConn.id, { broken: false });
+    } else {
+      const placed = useMapStore.getState().map.systems;
+      const srcPos = placed.find((s) => s.id === prevMapSystemId)?.position;
+      const tgtPos = placed.find((s) => s.id === mapSystemId)?.position;
+      const { sourceHandle, targetHandle } = srcPos && tgtPos
+        ? pickHandles(srcPos, tgtPos)
+        : { sourceHandle: 'right' as const, targetHandle: 'left' as const };
+      addConnection(prevMapSystemId, mapSystemId, sourceHandle, targetHandle);
+    }
+  }
+
+  return mapSystemId;
+}
+
 /**
  * Map-side reaction to character location changes. The actual polling lives
  * in `useCharacterLocation` (10s, module-level, shared with the sidebar);
@@ -102,7 +179,7 @@ export function useLocationTracking(enabled: boolean) {
 
   useEffect(() => {
     if (!enabled) return;
-    const { map, addSystem, addConnection, updateConnection, selectSystem, setCurrentSystem, uniformWidth, uniformHeight, snapToGrid } = useMapStore.getState();
+    const { map, selectSystem, setCurrentSystem } = useMapStore.getState();
 
     // No active map loaded yet (mid switchMap / first paint) — wait for the
     // next location update rather than racing addSystem against an empty store.
@@ -135,81 +212,28 @@ export function useLocationTracking(enabled: boolean) {
     }
     lastEveSystemId.current = system.eveSystemId;
 
-    let mapSystemId: string;
-    const existing = map.systems.find((s) => s.eveSystemId === system.eveSystemId);
+    // A locked map never grows from passive tracking, nor does one a readonly /
+    // no-topology user is viewing; track-jumps off opts out of auto-add too.
     const trackJumps = useMapStore.getState().trackJumps;
-    if (existing) {
-      mapSystemId = existing.id;
-    } else {
-      // A locked map never grows from passive location tracking — that
-      // includes admins, who can still place systems manually via the
-      // canvas but shouldn't sprout them just by hopping through EVE.
-      // Readonly / no-topology-permission users are also blocked here.
-      // Track-jumps off explicitly opts the user out of the auto-add.
-      if (!trackJumps || map.locked || !canEdit) {
-        lastMapSystemId.current = null;
-        setCurrentSystem(null);
-        return;
-      }
-      // Offset by the widest node seen so an auto-added system never overlaps
-      // the one it's placed next to (positions are top-left corners). Falls back
-      // to a generous constant before any node has been measured.
-      const w = uniformWidth || 220;
-      const h = uniformHeight || 120;
-      const gap = PLACEMENT_GAP;
-      // Anchor placement on the system we jumped from (or the map centroid for
-      // the very first auto-add), then rotate clockwise around it into the
-      // first free slot — right, below, left, above, diagonals, wider rings.
-      let source: { x: number; y: number };
-      if (prevMapSystemId) {
-        source = map.systems.find((s) => s.id === prevMapSystemId)!.position;
-      } else {
-        source = {
-          x: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.x, 0) / map.systems.length : 0,
-          y: map.systems.length ? map.systems.reduce((sum, s) => sum + s.position.y, 0) / map.systems.length : 0,
-        };
-      }
-      const direction = normalizePlacement(readUserSetting<string>('nexum.map.placement', 'east'));
-      const position = findFreePosition(source, map.systems, w, h, gap, direction, snapToGrid);
-
-      mapSystemId = addSystem(
-        system.name,
-        system.systemClass as SystemClass,
-        position,
-        {
-          eveSystemId: system.eveSystemId,
-          effect:      system.effect as WormholeEffect,
-          statics:     system.statics,
-          regionName:  system.regionName,
-          npcType:     system.npcType,
-        },
-      );
-    }
-
-    if (trackJumps && canEdit && !map.locked && prevMapSystemId && prevMapSystemId !== mapSystemId) {
-      const freshConnections = useMapStore.getState().map.connections;
-      const existing = freshConnections.find(
-        (c) =>
-          (c.sourceId === prevMapSystemId && c.targetId === mapSystemId) ||
-          (c.sourceId === mapSystemId && c.targetId === prevMapSystemId),
-      );
-      if (existing) {
-        // Physically jumping the link is definitive proof it's live — if it was
-        // quarantined (backing sig deleted), un-break it so the map stays honest.
-        if (existing.broken) updateConnection(existing.id, { broken: false });
-      } else {
-        // Pick the optimal source/target sides from the two systems' actual
-        // positions so the auto-added connection attaches cleanly — bottom→top
-        // for a vertical layout, right→left for a horizontal one — instead of a
-        // fixed right→left that cuts diagonally across vertically-stacked nodes.
-        const placed = useMapStore.getState().map.systems;
-        const srcPos = placed.find((s) => s.id === prevMapSystemId)?.position;
-        const tgtPos = placed.find((s) => s.id === mapSystemId)?.position;
-        const { sourceHandle, targetHandle } = srcPos && tgtPos
-          ? pickHandles(srcPos, tgtPos)
-          : { sourceHandle: 'right' as const, targetHandle: 'left' as const };
-        addConnection(prevMapSystemId, mapSystemId, sourceHandle, targetHandle);
-      }
+    const canAdd = trackJumps && !map.locked && canEdit;
+    const mapSystemId = applyJump(
+      {
+        eveSystemId: system.eveSystemId,
+        name:        system.name,
+        systemClass: system.systemClass,
+        effect:      system.effect,
+        statics:     system.statics,
+        regionName:  system.regionName ?? null,
+        npcType:     system.npcType ?? null,
+      },
+      prevMapSystemId,
+      canAdd,
+    );
+    if (mapSystemId === null) {
+      // Not on the map and not allowed to add — record nothing, just clear.
+      lastMapSystemId.current = null;
+      setCurrentSystem(null);
+      return;
     }
 
     lastMapSystemId.current = mapSystemId;

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -33,6 +33,21 @@ const nodeSizes = new Map<string, { w: number; h: number; countHeight: boolean }
 const GRID = 20;
 const snapUpToGrid = (n: number) => (n > 0 ? Math.ceil(n / GRID) * GRID : 0);
 
+// Largest *full* node footprint seen so far (width and height, ungated by
+// countHeight), snapped up to the grid. This is the auto-placement cell: unlike
+// the uniform-size max — which excludes tall static nodes from the height so it
+// doesn't force every node tall — placement needs a cell big enough for ANY
+// node, so cells tile with consistent 3-square gutters and nothing overflows
+// into its neighbour. Returns {0,0} until at least one node has reported a size.
+export function getPlacementCell(): { w: number; h: number } {
+  let w = 0, h = 0;
+  for (const s of nodeSizes.values()) {
+    if (s.w > w) w = s.w;
+    if (s.h > h) h = s.h;
+  }
+  return { w: snapUpToGrid(w), h: snapUpToGrid(h) };
+}
+
 function recomputeUniformMax(): { w: number; h: number } {
   let w = 0, h = 0, hAll = 0;
   let anyHeightEligible = false;


### PR DESCRIPTION
Promotes `release` to `main`. Bumps version **1.8.1 -> 1.9.0** (web + server).

## Highlights

### Features
- **Connection highlighting (#294)** - hover (or select) a system and all of its connections light up: thicker, full opacity, glow, lifted above the rest, and recoloured to a distinct highlight hue (`--cv-conn-highlight`, palette-aware) so they're easy to trace through a tangle. Broken links keep their severed-red.
- **Parallel-edge offset (#294)** - multiple connections between the same pair of systems now fan apart instead of stacking on one line.

### Fixes & improvements
- **Aligned auto-placement (#293)** - auto-placed systems now tile on a uniform grid with consistent 3-square gutters and aligned rows/columns. The placement cell is sized to the largest node (height included) so tall WH/static nodes no longer overflow into the gutter. Shared by live tracking and the jump simulator.
- **System effect crash fix (#289)** - `/api/systems/:id` now coalesces a null effect to `'none'`, fixing a `TypeError` when viewing k-space systems on a mixed route.
- **User Stats modal width (#287)** - widened so period labels don't wrap.

### Dev tooling
- **`nexumDebug.simulateJumps` (#288, #290, #291)** - console tool that replays a route through the active map via the real placement path, for reproducing placement bugs. Added a `dryRun` mode that exercises placement without firing or queuing any server writes (logged-out safe) and skips selection to avoid 404 floods on ghost systems.

## PRs in this batch
#287, #288, #289, #290, #291, #293, #294

## Post-merge
Cut a `v1.9.0` GitHub release (tag `v1.9.0`) per the release workflow.