### PR TITLE
Auto-classify gate connections from the SDE stargate graph

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -276,6 +276,41 @@ export async function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_map_routes_map ON map_routes (map_id);
 
+    -- Tracks one-shot data migrations that must NOT re-run on every boot
+    -- (unlike the idempotent DDL above) — e.g. a backfill we don't want to
+    -- keep re-applying over later manual edits.
+    CREATE TABLE IF NOT EXISTS applied_migrations (
+      name       TEXT        PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    -- One-time: classify existing connections that are really stargate links.
+    -- A connection whose two endpoints are stargate-adjacent in the SDE and
+    -- which carries no wormhole type is a gate, not a wormhole. Runs once
+    -- (guarded by applied_migrations) so it never re-flips a connection the
+    -- user later corrected by hand. New connections are classified the same
+    -- way at creation time in the POST handler.
+    DO $gateclassify$
+    BEGIN
+      IF to_regclass('public.map_stargates') IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM applied_migrations WHERE name = 'gate_classify_v1') THEN
+        UPDATE map_connections c
+           SET connection_type = 'jumpgate'
+          FROM map_systems s, map_systems t
+         WHERE c.source_id = s.id AND c.target_id = t.id
+           AND c.connection_type = 'standard'
+           AND COALESCE(c.wh_type, '') = ''
+           AND s.eve_system_id IS NOT NULL AND t.eve_system_id IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM map_stargates g
+              WHERE (g.system_id = s.eve_system_id AND g.destination_system_id = t.eve_system_id)
+                 OR (g.system_id = t.eve_system_id AND g.destination_system_id = s.eve_system_id)
+           );
+        INSERT INTO applied_migrations(name) VALUES ('gate_classify_v1');
+      END IF;
+    END
+    $gateclassify$;
+
     -- Resolved owner corp ID for structures. Populated by ESI lookup when
     -- the user supplies an eve_id (the structure's in-game ID) or when
     -- the structure name parser finds a known corp/alliance. Lets the

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1576,6 +1576,29 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
   const access = await requireMapWrite(res, mapId, req);
   if (!access) return;
 
+  // Auto-classify gate links: a connection between two stargate-adjacent SDE
+  // systems is a gate, not a wormhole. Only when the client didn't already say
+  // 'jumpgate' (a fresh connection never carries a wh type yet, so there's
+  // nothing to protect). Failures (e.g. map_stargates not seeded) leave it as-is.
+  let effectiveType: string = connectionType ?? 'standard';
+  if (effectiveType !== 'jumpgate') {
+    try {
+      const adj = await db.query(
+        `SELECT 1 FROM map_systems s, map_systems t
+          WHERE s.id = $1 AND t.id = $2
+            AND s.eve_system_id IS NOT NULL AND t.eve_system_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1 FROM map_stargates g
+               WHERE (g.system_id = s.eve_system_id AND g.destination_system_id = t.eve_system_id)
+                  OR (g.system_id = t.eve_system_id AND g.destination_system_id = s.eve_system_id)
+            )
+          LIMIT 1`,
+        [sourceId, targetId],
+      );
+      if ((adj.rowCount ?? 0) > 0) effectiveType = 'jumpgate';
+    } catch { /* stargate table absent / query failed — keep client's type */ }
+  }
+
   let inserted = 0;
   try {
     const ins = await db.query(
@@ -1585,7 +1608,7 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
        ON CONFLICT (id) DO NOTHING`,
       [id, mapId, sourceId, targetId, sourceHandle ?? null, targetHandle ?? null,
-       connectionType ?? 'standard', massStatus ?? null, timeStatus ?? null, size ?? 'large'],
+       effectiveType, massStatus ?? null, timeStatus ?? null, size ?? 'large'],
     );
     inserted = ins.rowCount ?? 0;
   } catch (err) {
@@ -1616,10 +1639,12 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
   }).catch(console.error);
   // Only notify on a genuinely new wormhole connection — not a duplicate-id
   // retry, and not an in-game stargate (jumpgate) link.
-  if (inserted > 0 && (connectionType ?? 'standard') !== 'jumpgate') {
+  if (inserted > 0 && effectiveType !== 'jumpgate') {
     dispatchNewConnection(access, mapId, sourceId, targetId, null, size ?? 'large', req.session.characterName ?? null);
   }
-  res.status(201).json({ ok: true });
+  // Return the resolved type so the originating client can reflect an
+  // auto-classified gate without waiting for a reload.
+  res.status(201).json({ ok: true, connectionType: effectiveType });
 });
 
 mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -949,9 +949,18 @@ export const useMapStore = create<MapStore>()((set, get) => {
         if (activeMapId) {
           const url  = `/api/maps/${activeMapId}/connections`;
           const body = JSON.stringify({ ...conn });
-          api(url, { method: 'POST', body }).catch(() =>
-            enqueue(`addConnection:${id}`, url, 'POST', body),
-          );
+          api<{ ok: boolean; connectionType?: string }>(url, { method: 'POST', body })
+            .then((r) => {
+              // Server may auto-classify a gate (stargate-adjacent systems).
+              // Reflect it locally so the chain/edge updates without a reload.
+              if (r?.connectionType && r.connectionType !== 'standard') {
+                set((s) => ({
+                  map: { ...s.map, connections: s.map.connections.map((c) =>
+                    c.id === id ? { ...c, connectionType: r.connectionType as MapConnection['connectionType'] } : c) },
+                }));
+              }
+            })
+            .catch(() => enqueue(`addConnection:${id}`, url, 'POST', body));
         }
       }
 


### PR DESCRIPTION
Fixes chains showing "Warp to the wormhole" for null-sec **gate** chains: connections defaulted to `'standard'` (wormhole) unless manually marked, with no auto-detection.

A connection between two systems that are **stargate-adjacent in the SDE** (`map_stargates`) is now recognised as a gate automatically.

## Changes
- **Connection POST** (`maps.ts`): when the client didn't send `'jumpgate'` and the two endpoints are stargate-adjacent, store `connection_type = 'jumpgate'`. Returns the resolved type so the originating client reflects it without a reload (`addConnection` applies it). Wrapped in try/catch — a missing/unseeded stargate table never blocks connection creation.
- **Backfill** (`migrate.ts`): a **one-time** reclassification of existing `standard`, no-wormhole-type connections whose endpoints are stargate-adjacent. Guarded by a new `applied_migrations` table so it runs **once** and never re-flips a connection the user later corrected by hand.
- **Heuristic safety**: only connections with **no** wormhole type are reclassified (an explicit WH code is left as a wormhole), and gate-adjacency is a strong signal since wormholes don't normally link gate-adjacent systems. Manual override (right-click → Jump Type) still wins.

## Live-server migration
The backfill is part of `migrate()`, which already runs on every server boot (`index.ts`). So deploying this to the live server **migrates existing maps automatically on first start** — no manual step. The `applied_migrations` guard means subsequent boots skip it.

## Test
- server + web `tsc` clean; `yarn build` clean.
- New gate-adjacent connection → stored as `jumpgate`; chain shows "Warp to gate" (with #303's wording). Wormhole links unaffected. Re-running migrate is a no-op.

## Note
Pairs with #303 (chain "Warp to gate" wording + searchable From/To). Order-independent; both land on `release`.