### PR TITLE
Highlight connections on hover only

### DIFF
--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -189,7 +189,9 @@ export const ConnectionEdge = memo(({
           <div
             className="connection-break"
             title={t('mapEdge.broken')}
-            style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)` }}
+            // Lift above a highlighted edge (zIndex 10) so the marker isn't
+            // drawn under the hover-elevated line.
+            style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`, zIndex: highlighted ? 1001 : undefined }}
             onClick={() => selectConnection(id)}
           >
             &#9986;
@@ -218,7 +220,10 @@ export const ConnectionEdge = memo(({
           return (
             <div
               className="connection-label"
-              style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)` }}
+              // Lift above a highlighted edge (zIndex 10) — the edge-label
+              // layer has no stacking context, so the label's own z-index wins
+              // against the hover-elevated line and the badge stays readable.
+              style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`, zIndex: highlighted ? 1001 : undefined }}
               onClick={() => selectConnection(id)}
             >
               {count === 3 ? (

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -202,7 +202,11 @@ export const ConnectionEdge = memo(({
               ? <span className="connection-label__gate">G</span>
               : conn?.type
                 ? <span className="connection-label__type">{conn.type}</span>
-                : null;
+                // Typeless wormhole normally shows no badge; surface a "WH" one
+                // while hovered so every traced link reveals its jump type.
+                : highlighted
+                  ? <span className="connection-label__type">WH</span>
+                  : null;
           const massNode = !noLifetime && massLabel
             ? <span className={massLabel.cls}>{massLabel.text}</span>
             : null;

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -590,9 +590,11 @@ export function MapCanvas() {
         const ov = dragHandles.get(c.id);
         const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
         const group = pairGroups.get(key)!;
+        // Hover-only: a *selected* system would keep its links lit permanently
+        // (e.g. your located system on a 2-node map), which reads as a stuck
+        // hover effect — so highlight only follows the mouse.
         const highlighted =
-          (hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId)) ||
-          (selectedSystemId != null && (c.sourceId === selectedSystemId || c.targetId === selectedSystemId));
+          hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId);
         return {
           id: c.id,
           source: c.sourceId,
@@ -610,7 +612,7 @@ export function MapCanvas() {
         };
       });
     },
-    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId, selectedSystemId],
+    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId],
   );
 
   const onEdgesChange = useCallback(


### PR DESCRIPTION
Bug: with 2 systems on a map, the connection showed the highlight (thick/glow/recolour) constantly.

Cause: the connection-highlight (#294) fired when **either** `hoveredNodeId` **or** `selectedSystemId` was an endpoint. A selected/located system keeps its links lit permanently — and with 2 systems the single connection always touches your located system, so it never turned off (the "stuck hover" in the screenshot).

Fix: highlight follows the **mouse only** — dropped the `selectedSystemId` clause (and its memo dep). Hovering a system still lights its links; selecting/locating one no longer does.

## Test
- `tsc` + `yarn build` clean; lint unchanged.
- 2-system map: connection renders normally; hovering a node lights its connection; mousing off clears it.