### PR TITLE
Keep the 3-square gap when a large node is placed above/left

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -152,6 +152,7 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
     if (prevMapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {
       const fixY = position.y < source.y; // placed above the source
       const fixX = position.x < source.x; // placed left of the source
+      console.log('[pf] register', { id: mapSystemId, src: prevMapSystemId, fixY, fixX, posY: position.y, srcY: source.y });
       if (fixY || fixX) registerPlacementFix(mapSystemId, prevMapSystemId, fixY, fixX);
     }
   }

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useMapStore, getPlacementCell } from '../store/mapStore';
+import { useMapStore, getPlacementCell, registerPlacementFix } from '../store/mapStore';
 import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
 import { readUserSetting } from './useUserSetting';
@@ -143,6 +143,17 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
       regionName:  system.regionName,
       npcType:     system.npcType,
     });
+
+    // If the node landed above/left of a real source, its true rendered size
+    // (unknown here) may be larger than the placement cell assumed — which
+    // would let it overlap the source. Schedule a one-shot gap fix that runs
+    // once the node has measured. Only relevant when placed relative to an
+    // actual source node (not the center-of-mass fallback).
+    if (prevMapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {
+      const fixY = position.y < source.y; // placed above the source
+      const fixX = position.x < source.x; // placed left of the source
+      if (fixY || fixX) registerPlacementFix(mapSystemId, prevMapSystemId, fixY, fixX);
+    }
   }
 
   if (canAdd && prevMapSystemId && prevMapSystemId !== mapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -152,7 +152,6 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
     if (prevMapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {
       const fixY = position.y < source.y; // placed above the source
       const fixX = position.x < source.x; // placed left of the source
-      console.log('[pf] register', { id: mapSystemId, src: prevMapSystemId, fixY, fixX, posY: position.y, srcY: source.y });
       if (fixY || fixX) registerPlacementFix(mapSystemId, prevMapSystemId, fixY, fixX);
     }
   }

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -730,11 +730,13 @@ export const useMapStore = create<MapStore>()((set, get) => {
       // it overlapped); a node already clear of the source is left where the
       // lattice put it, so aligned small nodes are untouched.
       const fix = placementFixes.get(id);
+      if (fix) console.log('[pf] measure', { id, width, height, fix });
       if (fix) {
         placementFixes.delete(id);
         const st  = get();
         const node = st.map.systems.find((s) => s.id === id);
         const src  = st.map.systems.find((s) => s.id === fix.sourceId);
+        console.log('[pf] lookup', { node: !!node, src: !!src, nodeY: node?.position.y, srcY: src?.position.y });
         if (node && src) {
           const snap = st.snapToGrid ? roundToGrid : (n: number) => n;
           let { x, y } = node.position;
@@ -747,11 +749,13 @@ export const useMapStore = create<MapStore>()((set, get) => {
             x = snap(src.position.x - PLACEMENT_GAP - width);
             moved = true;
           }
+          console.log('[pf] correct', { moved, newY: y, newX: x });
           if (moved) st.moveSystem(id, { x, y }, { skipUndo: true });
         }
       }
     },
     forgetNodeSize: (id) => {
+      if (placementFixes.has(id)) console.log('[pf] forget deletes fix', id);
       placementFixes.delete(id);
       if (!nodeSizes.delete(id)) return;
       const { w, h } = recomputeUniformMax();

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -32,6 +32,18 @@ const nodeSizes = new Map<string, { w: number; h: number; countHeight: boolean }
 // of N renders an N-px outer box.
 const GRID = 20;
 const snapUpToGrid = (n: number) => (n > 0 ? Math.ceil(n / GRID) * GRID : 0);
+const roundToGrid  = (n: number) => Math.round(n / GRID) * GRID;
+const PLACEMENT_GAP = 3 * GRID; // keep in sync with useLocationTracking
+
+// One-shot post-measure placement fixes. A node auto-placed *above* or *left*
+// of its source can overlap it once it renders taller/wider than the placement
+// cell knew at the time (a brand-new max not yet measured — e.g. the first
+// statics-heavy WH node). Keyed by node id and consumed on first measure in
+// reportNodeSize, which nudges it back to the 3-square gap using its real size.
+const placementFixes = new Map<string, { sourceId: string; fixY: boolean; fixX: boolean }>();
+export function registerPlacementFix(nodeId: string, sourceId: string, fixY: boolean, fixX: boolean): void {
+  placementFixes.set(nodeId, { sourceId, fixY, fixX });
+}
 
 // Largest *full* node footprint seen so far (width and height, ungated by
 // countHeight), snapped up to the grid. This is the auto-placement cell: unlike
@@ -712,8 +724,35 @@ export const useMapStore = create<MapStore>()((set, get) => {
       if (cur.uniformWidth !== w || cur.uniformHeight !== h) {
         set({ uniformWidth: w, uniformHeight: h });
       }
+
+      // Consume a pending placement fix now we know this node's real size.
+      // Only ever moves the node FARTHER from the source (restores the gap when
+      // it overlapped); a node already clear of the source is left where the
+      // lattice put it, so aligned small nodes are untouched.
+      const fix = placementFixes.get(id);
+      if (fix) {
+        placementFixes.delete(id);
+        const st  = get();
+        const node = st.map.systems.find((s) => s.id === id);
+        const src  = st.map.systems.find((s) => s.id === fix.sourceId);
+        if (node && src) {
+          const snap = st.snapToGrid ? roundToGrid : (n: number) => n;
+          let { x, y } = node.position;
+          let moved = false;
+          if (fix.fixY && y + height > src.position.y - PLACEMENT_GAP) {
+            y = snap(src.position.y - PLACEMENT_GAP - height);
+            moved = true;
+          }
+          if (fix.fixX && x + width > src.position.x - PLACEMENT_GAP) {
+            x = snap(src.position.x - PLACEMENT_GAP - width);
+            moved = true;
+          }
+          if (moved) st.moveSystem(id, { x, y }, { skipUndo: true });
+        }
+      }
     },
     forgetNodeSize: (id) => {
+      placementFixes.delete(id);
       if (!nodeSizes.delete(id)) return;
       const { w, h } = recomputeUniformMax();
       const cur = get();

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -730,13 +730,11 @@ export const useMapStore = create<MapStore>()((set, get) => {
       // it overlapped); a node already clear of the source is left where the
       // lattice put it, so aligned small nodes are untouched.
       const fix = placementFixes.get(id);
-      if (fix) console.log('[pf] measure', { id, width, height, fix });
       if (fix) {
         placementFixes.delete(id);
         const st  = get();
         const node = st.map.systems.find((s) => s.id === id);
         const src  = st.map.systems.find((s) => s.id === fix.sourceId);
-        console.log('[pf] lookup', { node: !!node, src: !!src, nodeY: node?.position.y, srcY: src?.position.y });
         if (node && src) {
           const snap = st.snapToGrid ? roundToGrid : (n: number) => n;
           let { x, y } = node.position;
@@ -749,14 +747,16 @@ export const useMapStore = create<MapStore>()((set, get) => {
             x = snap(src.position.x - PLACEMENT_GAP - width);
             moved = true;
           }
-          console.log('[pf] correct', { moved, newY: y, newX: x });
           if (moved) st.moveSystem(id, { x, y }, { skipUndo: true });
         }
       }
     },
     forgetNodeSize: (id) => {
-      if (placementFixes.has(id)) console.log('[pf] forget deletes fix', id);
-      placementFixes.delete(id);
+      // NB: do NOT drop a pending placementFix here. forgetNodeSize fires on
+      // every ResizeObserver-effect cleanup — including React StrictMode's
+      // setup/cleanup/setup double-invoke in dev — which would wipe the fix
+      // before the real measure consumes it. The fix is cleared in
+      // reportNodeSize (on apply) or removeSystem (on real removal).
       if (!nodeSizes.delete(id)) return;
       const { w, h } = recomputeUniformMax();
       const cur = get();
@@ -918,6 +918,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
     },
 
     removeSystem: (id) => {
+      placementFixes.delete(id);
       const { activeMapId, map } = get();
       const sys = map.systems.find((s) => s.id === id);
       const affectedConns = map.connections.filter((c) => c.sourceId === id || c.targetId === id);


### PR DESCRIPTION
Bug (from `simulateJumps(['SN9S-N','JD-TYH','SN9S-N','Z-MO29','SN9S-N','Ohmahailen','SN9S-N','J001769'], 10000, {dryRun:true})`): the statics-heavy `J001769` placed **above** its source overlapped it instead of leaving the 3-square gap.

## Cause
Auto-placement sizes its lattice cell from **already-measured** nodes. A brand-new node that renders taller/wider than anything measured so far (the first statics-heavy WH system) isn't accounted for. When it lands **above** (north) or **left** (west) of its source, its bottom/right edge intrudes into the source - there's no measured size to size the step from. (South/east are fine: the node extends away from the source, so the gap depends on the source's known size.)

## Fix
A one-shot **post-measure** correction:
- `applyJump` registers a fix (`registerPlacementFix`) when a node lands above/left of a *real* source node (not the center-of-mass fallback).
- On the node's **first measure**, `reportNodeSize` nudges it to exactly the 3-square gap using its real rendered size.
- It only ever moves the node **farther** from the source (restores the gap when it overlapped); a node already clear of the source is left where the lattice put it - so aligned small nodes are untouched. Respects `snapToGrid`. `skipUndo`.

## Test
- `tsc` + `yarn build` clean; lint unchanged.
- Re-run the route: `J001769` now sits a clean 3 squares above its source; small/short nodes placed above keep their lattice position; south/east unchanged.

## Note
In a `dryRun` the correction's position write fires after the suppression window, so a logged-out dry run may log a caught network error per corrected node (cosmetic). Live placement persists the corrected position correctly.