### PR TITLE
Chains: auto-resolve wormhole sig from system scans

### DIFF
--- a/server/src/routes/wormholes.ts
+++ b/server/src/routes/wormholes.ts
@@ -16,7 +16,13 @@ const log = createLogger('wormholes');
 // appear"), which is community knowledge; that stays curated in
 // data/wormholes.json and is merged in here by code. (static / sibling_groups
 // live in that file too but aren't served by this endpoint.)
-const ATTR = { destClass: 1381, totalMass: 1382, maxJumpable: 1383, massRegen: 1384, maxTime: 1503 };
+// Dogma attribute ids (verified against the `dogma_attributes` name table):
+//   1381 wormholeTargetSystemClass
+//   1382 wormholeMaxStableTime  (MINUTES)
+//   1383 wormholeMaxStableMass  (total, kg)
+//   1384 wormholeMassRegeneration (kg)
+//   1385 wormholeMaxJumpMass    (per-jump cap, kg — the "size" determinant)
+const ATTR = { destClass: 1381, maxTime: 1382, totalMass: 1383, massRegen: 1384, maxJumpable: 1385 };
 
 // CCP's wormholeTargetSystemClass values → our destination codes.
 const CLASS_MAP: Record<number, string> = {
@@ -115,7 +121,7 @@ async function loadSpecs(): Promise<Record<string, WormholeSpec>> {
         maxJumpMass:   Math.round(parseFloat(row.max_jumpable ?? '0')),
         massRegen:     Math.round(parseFloat(row.mass_regen   ?? '0')),
         lifetimeHours: row.max_time != null
-                         ? Math.round(parseFloat(row.max_time) / 3600)
+                         ? Math.round(parseFloat(row.max_time) / 60) // attr is minutes
                          : cur?.lifetime ?? 0,
         dest,
         src:           cur?.src ?? [],

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3808,6 +3808,12 @@ div.system-node__easy-handle {
   font-family: monospace; font-size: calc(10px * var(--font-scale, 1));
 }
 .chain-step__broken { display: inline-flex; align-items: center; gap: 4px; color: var(--cv-conn-expired); }
+/* Type / Size line under a wormhole hop's "warp to" line. */
+.chain-step__meta {
+  display: flex; flex-wrap: wrap; gap: 4px 12px;
+  padding-left: 16px;
+  font-size: calc(10px * var(--font-scale, 1)); color: #8a9ab8;
+}
 
 /* Per-end "backing signature" link controls in the connection panel. */
 .conn-siglink {

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMapStore } from '../../store/mapStore';
 import { useCanEdit } from '../../hooks/useCanEdit';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { api } from '../../api/client';
 import { toast } from './Toaster';
 import { buildChainPath, buildChainSteps } from '../../utils/chains';
@@ -23,6 +24,7 @@ export function ChainsPane() {
   const removeRoute       = useMapStore((s) => s.removeRoute);
   const requestCenterOnNode = useMapStore((s) => s.requestCenterOnNode);
   const canEdit           = useCanEdit();
+  const whTypes           = useWormholeTypes();
 
   const [fromId, setFromId] = useState('');
   const [toId, setToId]     = useState('');
@@ -62,15 +64,18 @@ export function ChainsPane() {
     return () => { cancelled = true; };
   }, [expandedId, map.id, map.routes]);
 
-  // Wormhole size class -> label (reuses the connection-panel size strings).
-  const sizeLabel = (size: string) => {
-    switch (size) {
-      case 'xl':     return t('connPanel.sizeXl');
-      case 'large':  return t('connPanel.sizeLarge');
-      case 'medium': return t('connPanel.sizeMedium');
-      case 'small':  return t('connPanel.sizeSmall');
-      default:       return size;
-    }
+  // Derive a wormhole's size class from its SDE max-jumpable-mass (attr 1383,
+  // served via /api/wormholes/types), mapped to the connection-panel size
+  // labels. Returns null for unknown codes (e.g. K162, which has no dogma).
+  const sizeLabel = (whType: string | null): string | null => {
+    if (!whType) return null;
+    const spec = whTypes[whType.toUpperCase()];
+    const m = spec?.maxJumpMass ?? 0;
+    if (!m) return null;
+    if (m >= 1_000_000_000) return t('connPanel.sizeXl');
+    if (m >= 300_000_000)   return t('connPanel.sizeLarge');
+    if (m >= 62_000_000)    return t('connPanel.sizeMedium');
+    return t('connPanel.sizeSmall');
   };
 
   const create = () => {
@@ -191,12 +196,15 @@ export function ChainsPane() {
                             </span>
                           )}
                         </div>
-                        {step.kind === 'wormhole' && !step.broken && (step.whType || step.size) && (
-                          <div className="chain-step__meta">
-                            {step.whType && <span>{t('chains.whTypeLabel')}: {step.whType}</span>}
-                            {step.size && <span>{t('chains.whSizeLabel')}: {sizeLabel(step.size)}</span>}
-                          </div>
-                        )}
+                        {step.kind === 'wormhole' && !step.broken && step.whType && (() => {
+                          const size = sizeLabel(step.whType);
+                          return (
+                            <div className="chain-step__meta">
+                              <span>{t('chains.whTypeLabel')}: {step.whType}</span>
+                              {size && <span>{t('chains.whSizeLabel')}: {size}</span>}
+                            </div>
+                          );
+                        })()}
                       </li>
                     ))}
                   </ol>

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -62,6 +62,17 @@ export function ChainsPane() {
     return () => { cancelled = true; };
   }, [expandedId, map.id, map.routes]);
 
+  // Wormhole size class -> label (reuses the connection-panel size strings).
+  const sizeLabel = (size: string) => {
+    switch (size) {
+      case 'xl':     return t('connPanel.sizeXl');
+      case 'large':  return t('connPanel.sizeLarge');
+      case 'medium': return t('connPanel.sizeMedium');
+      case 'small':  return t('connPanel.sizeSmall');
+      default:       return size;
+    }
+  };
+
   const create = () => {
     if (!fromId || !toId || fromId === toId) return;
     const path = buildChainPath(map, fromId, toId);
@@ -177,10 +188,15 @@ export function ChainsPane() {
                               {step.sigId
                                 ? t('chains.warpSig', { sig: step.sigId })
                                 : t('chains.warpWormhole')}
-                              {step.whType ? <span className="chain-step__wh">{step.whType}</span> : null}
                             </span>
                           )}
                         </div>
+                        {step.kind === 'wormhole' && !step.broken && (step.whType || step.size) && (
+                          <div className="chain-step__meta">
+                            {step.whType && <span>{t('chains.whTypeLabel')}: {step.whType}</span>}
+                            {step.size && <span>{t('chains.whSizeLabel')}: {sizeLabel(step.size)}</span>}
+                          </div>
+                        )}
                       </li>
                     ))}
                   </ol>

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -28,9 +28,9 @@ export function ChainsPane() {
   const [toId, setToId]     = useState('');
   const [name, setName]     = useState('');
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  // uuid -> Signature for the expanded chain's endpoint systems, so steps can
-  // show the exact sig code you warp to.
-  const [sigsById, setSigsById] = useState<Map<string, Signature>>(new Map());
+  // systemId -> its signatures, for the expanded chain's from-systems, so steps
+  // can name the sig to warp to (explicit link or auto-matched by "leads to").
+  const [sigsBySystem, setSigsBySystem] = useState<Map<string, Signature[]>>(new Map());
 
   const sortedSystems = useMemo(
     () => [...map.systems].sort((a, b) => a.name.localeCompare(b.name)),
@@ -55,9 +55,9 @@ export function ChainsPane() {
       ),
     ).then((lists) => {
       if (cancelled) return;
-      const next = new Map<string, Signature>();
-      for (const list of lists) for (const sig of list) next.set(sig.id, sig);
-      setSigsById(next);
+      const next = new Map<string, Signature[]>();
+      fromSystems.forEach((sysId, i) => next.set(sysId, lists[i] ?? []));
+      setSigsBySystem(next);
     });
     return () => { cancelled = true; };
   }, [expandedId, map.id, map.routes]);
@@ -117,7 +117,7 @@ export function ChainsPane() {
           {map.routes.map((route) => {
             const open  = expandedId === route.id;
             const hops  = route.connectionIds.length;
-            const steps = open ? buildChainSteps(route, map, sigsById) : [];
+            const steps = open ? buildChainSteps(route, map, sigsBySystem) : [];
             return (
               <li key={route.id} className="chain-item">
                 <div className="chain-item__head">

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -6,6 +6,7 @@ import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { api } from '../../api/client';
 import { toast } from './Toaster';
 import { buildChainPath, buildChainSteps } from '../../utils/chains';
+import { whSizeForType, whSizeLabel } from '../../utils/wormholeSize';
 import { SystemCombobox } from './SystemCombobox';
 import type { Signature } from '../../types';
 import {
@@ -64,18 +65,10 @@ export function ChainsPane() {
     return () => { cancelled = true; };
   }, [expandedId, map.id, map.routes]);
 
-  // Derive a wormhole's size class from its SDE max-jumpable-mass (attr 1383,
-  // served via /api/wormholes/types), mapped to the connection-panel size
-  // labels. Returns null for unknown codes (e.g. K162, which has no dogma).
+  // Wormhole size derived from the SDE per-jump cap (shared helper).
   const sizeLabel = (whType: string | null): string | null => {
-    if (!whType) return null;
-    const spec = whTypes[whType.toUpperCase()];
-    const m = spec?.maxJumpMass ?? 0;
-    if (!m) return null;
-    if (m >= 1_000_000_000) return t('connPanel.sizeXl');
-    if (m >= 300_000_000)   return t('connPanel.sizeLarge');
-    if (m >= 62_000_000)    return t('connPanel.sizeMedium');
-    return t('connPanel.sizeSmall');
+    const cls = whSizeForType(whType, whTypes);
+    return cls ? whSizeLabel(t, cls) : null;
   };
 
   const create = () => {

--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { mass } from '../../i18n/format';
 import { useMapStore } from '../../store/mapStore';
@@ -7,6 +7,7 @@ import { useNow30s } from '../../hooks/useNow30s';
 import { useCanEdit } from '../../hooks/useCanEdit';
 import { useCharacterLocation } from '../../hooks/useCharacterLocation';
 import { WHTypeInfo } from './WHTypeInfo';
+import { whSizeForType } from '../../utils/wormholeSize';
 import { ConfirmModal } from './ConfirmModal';
 import { XIcon } from '@phosphor-icons/react';
 import { api } from '../../api/client';
@@ -142,6 +143,24 @@ export function ConnectionPanel() {
     updateConnection(conn.id, { type: detected });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conn?.id, endpointSigs]);
+
+  // Default the connection's size from its wormhole type's SDE max-jump-mass,
+  // once per (connection, type). Leaves manual size changes intact (the key
+  // only changes when the *type* changes), and never overrides a code we can't
+  // size yet (waits for the types to load). Wormhole connections only.
+  const sizeSyncedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!conn || conn.connectionType !== 'standard') return;
+    const code = conn.type?.toUpperCase();
+    if (!code) return;
+    const key = `${conn.id}:${code}`;
+    if (key === sizeSyncedFor.current) return;
+    const cls = whSizeForType(code, whTypes);
+    if (!cls) return; // types not loaded yet / unknown code — retry on load
+    sizeSyncedFor.current = key;
+    if (cls !== conn.size) updateConnection(conn.id, { size: cls });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conn?.id, conn?.type, conn?.connectionType, whTypes]);
 
   // Persist the roller config whenever the pilot tweaks it.
   useEffect(() => { saveRoller(roller); }, [roller]);

--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { useScoutConnections } from '../../hooks/useScoutConnections';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
+import { whSizeForType, whSizeShort } from '../../utils/wormholeSize';
 import { useRouteOrigin } from '../../hooks/useRouteOrigin';
 import { useRoute } from '../../hooks/useRoute';
 import { setWaypoint, RouteSquares } from './routeUi';
@@ -64,6 +66,7 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
   const all      = useScoutConnections();
   const origin   = useRouteOrigin();
   const routeMode = useMapStore((s) => s.routeMode);
+  const whTypes  = useWormholeTypes();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [sortBy, setSortBy] = useState<ScoutSort>(() => readScoutSort(scoutSystem));
 
@@ -172,7 +175,12 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
             <div className="scout-row__meta">
               <span className="scout-row__wh">{c.whType}</span>
               <span className="scout-row__size">
-                {SIZE_LABELS[c.maxShipSize] ?? c.maxShipSize}
+                {/* Prefer the SDE-derived size from the WH type; fall back to
+                    eve-scout's own maxShipSize if the type isn't in our data. */}
+                {(() => {
+                  const cls = whSizeForType(c.whType, whTypes);
+                  return cls ? whSizeShort(cls) : (SIZE_LABELS[c.maxShipSize] ?? c.maxShipSize);
+                })()}
               </span>
               <span className="scout-row__sig">{c.inSignature}</span>
             </div>

--- a/web/src/components/ui/WhTypeChartModal.tsx
+++ b/web/src/components/ui/WhTypeChartModal.tsx
@@ -6,8 +6,26 @@ import { CLASS_COLORS } from '../../data/wormholes';
 import type { SystemClass } from '../../types';
 import {
   WH_CHART, RESPAWN_ORDER, SPAWN_ORDER, LEADS_ORDER, SHIP_ORDER, MASS_ORDER, LIFE_ORDER,
-  type WhChartEntry, type Respawn,
+  type WhChartEntry, type Respawn, type ShipSize,
 } from '../../data/whTypeChart';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
+
+// The chart's ship-size column is derived live from the SDE per-jump cap
+// (wormholeMaxJumpMass) so it can't drift from a CCP rebalance. Maps to the
+// chart's five descriptive tiers; null when a code has no dogma (keeps the
+// curated value).
+function shipSizeFromSde(
+  code: string,
+  whTypes: Record<string, { maxJumpMass?: number } | undefined>,
+): ShipSize | null {
+  const m = whTypes[code.toUpperCase()]?.maxJumpMass;
+  if (!m) return null;
+  if (m >= 2_000_000_000) return 'up to Capital';
+  if (m >= 1_000_000_000) return 'up to Freighter';
+  if (m >= 300_000_000)   return 'up to Battleship';
+  if (m >= 62_000_000)    return 'up to Battlecruiser';
+  return 'up to Destroyer';
+}
 
 // A Nexum take on whtype.info: hover ANY cell — a wormhole code OR an attribute
 // value — and lines connect a code to its values (or a value to every code that
@@ -67,6 +85,12 @@ function attrKeysFor(e: WhChartEntry): string[] {
 
 export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
+  const whTypes = useWormholeTypes();
+  // Override each entry's hardcoded ship_size with the SDE-derived size.
+  const chart = useMemo(
+    () => WH_CHART.map((e) => ({ ...e, ship_size: shipSizeFromSde(e.wormhole, whTypes) ?? e.ship_size })),
+    [whTypes],
+  );
   const [active, setActive] = useState<Active>(null);
   // Pinned (clicked) selections persist on mouse-out so you can read the
   // highlighted result; hovering only previews while nothing is pinned.
@@ -88,8 +112,8 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
 
   const codes = useMemo(() => {
     const q = search.trim().toUpperCase();
-    return WH_CHART.filter((w) => !q || w.wormhole.toUpperCase().includes(q));
-  }, [search]);
+    return chart.filter((w) => !q || w.wormhole.toUpperCase().includes(q));
+  }, [search, chart]);
 
   // From the active selection, compute the connection pairs (each = a code row
   // to an attribute-value row), the highlight set, and the line colour. Works
@@ -99,7 +123,7 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
     const hl = new Set<string>();
     let color = ACCENT;
     if (active?.kind === 'code') {
-      const e = WH_CHART.find((w) => w.wormhole === active.code);
+      const e = chart.find((w) => w.wormhole === active.code);
       if (e) {
         color = codeLineColor(e);
         hl.add(`code:${e.wormhole}`);
@@ -109,7 +133,7 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
       const attrKey = `${active.col}:${active.val}`;
       hl.add(attrKey);
       color = labelColor(active.val) ?? ACCENT;
-      for (const e of WH_CHART) {
+      for (const e of chart) {
         if (entryHasAttr(e, active.col, active.val)) {
           hl.add(`code:${e.wormhole}`);
           pairs.push({ code: e.wormhole, attrKey });
@@ -117,7 +141,7 @@ export function WhTypeChartModal({ onClose }: { onClose: () => void }) {
       }
     }
     return { pairs, highlight: hl, lineColor: color };
-  }, [active]);
+  }, [active, chart]);
 
   const [lines, setLines] = useState<Line[]>([]);
 

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "Sprung unterbrochen – neu scouten",
     "viaGate": "Zum Stargate warpen",
     "viaJumpBridge": "Sprungbrücke nutzen",
+    "whTypeLabel": "Typ",
+    "whSizeLabel": "Größe",
     "warpSig": "Zu {{sig}} warpen",
     "warpWormhole": "Zum Wurmloch warpen",
     "noMatch": "Kein passendes System",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "Hop broken — re-scout",
     "viaGate": "Warp to gate",
     "viaJumpBridge": "Take the jump bridge",
+    "whTypeLabel": "Type",
+    "whSizeLabel": "Size",
     "warpSig": "Warp to {{sig}}",
     "warpWormhole": "Warp to the wormhole",
     "noMatch": "No matching system",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "Salto roto — vuelve a explorar",
     "viaGate": "Warp a la puerta estelar",
     "viaJumpBridge": "Usar el puente de salto",
+    "whTypeLabel": "Tipo",
+    "whSizeLabel": "Tamaño",
     "warpSig": "Warp a {{sig}}",
     "warpWormhole": "Warp al agujero de gusano",
     "noMatch": "Ningún sistema coincidente",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "Saut rompu — à re-scanner",
     "viaGate": "Warp vers la stargate",
     "viaJumpBridge": "Emprunter le pont de saut",
+    "whTypeLabel": "Type",
+    "whSizeLabel": "Taille",
     "warpSig": "Warp vers {{sig}}",
     "warpWormhole": "Warp vers le trou de ver",
     "noMatch": "Aucun système correspondant",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "ホップが切断 — 再スカウトが必要",
     "viaGate": "スターゲートへワープ",
     "viaJumpBridge": "ジャンプブリッジを使用",
+    "whTypeLabel": "タイプ",
+    "whSizeLabel": "サイズ",
     "warpSig": "{{sig}} へワープ",
     "warpWormhole": "ワームホールへワープ",
     "noMatch": "一致する星系なし",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "끊긴 점프 — 재정찰 필요",
     "viaGate": "스타게이트로 워프",
     "viaJumpBridge": "점프 브리지 이용",
+    "whTypeLabel": "유형",
+    "whSizeLabel": "크기",
     "warpSig": "{{sig}}(으)로 워프",
     "warpWormhole": "웜홀로 워프",
     "noMatch": "일치하는 성계 없음",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "Salto quebrado — explore novamente",
     "viaGate": "Warp para o portão estelar",
     "viaJumpBridge": "Usar a ponte de salto",
+    "whTypeLabel": "Tipo",
+    "whSizeLabel": "Tamanho",
     "warpSig": "Warp para {{sig}}",
     "warpWormhole": "Warp para o buraco de minhoca",
     "noMatch": "Nenhum sistema correspondente",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "Прыжок разорван — нужна разведка",
     "viaGate": "Варп к старгейту",
     "viaJumpBridge": "Использовать прыжковый мост",
+    "whTypeLabel": "Тип",
+    "whSizeLabel": "Размер",
     "warpSig": "Варп к {{sig}}",
     "warpWormhole": "Варп к червоточине",
     "noMatch": "Нет подходящих систем",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -13,6 +13,8 @@
     "brokenHop": "该跳已断开 — 需重新探测",
     "viaGate": "跃迁至星门",
     "viaJumpBridge": "使用跳跃桥",
+    "whTypeLabel": "类型",
+    "whSizeLabel": "大小",
     "warpSig": "跃迁至 {{sig}}",
     "warpWormhole": "跃迁至虫洞",
     "noMatch": "无匹配星系",

--- a/web/src/utils/chains.ts
+++ b/web/src/utils/chains.ts
@@ -66,7 +66,6 @@ export interface ChainStep {
   toName: string;
   kind: ChainStepKind;      // jump a gate, or warp a wormhole
   whType: string | null;    // wormhole code (connection's, else the matched sig's)
-  size: string | null;      // connection size class (xl/large/medium/small)
   sigId: string | null;     // the in-system sig code (ABC-123) to warp to, if linked
   broken: boolean;          // connection removed or quarantined — needs re-scouting
 }
@@ -99,7 +98,6 @@ export function buildChainSteps(
 
     let kind: ChainStepKind = 'wormhole';
     let whType: string | null = null;
-    let size: string | null = null;
     let sigId: string | null = null;
     let broken = true;
 
@@ -108,7 +106,6 @@ export function buildChainSteps(
              : conn.connectionType === 'jumpgate' ? 'jumpgate'
              : 'wormhole';
       whType = conn.type ?? null;
-      size   = conn.size ?? null;
       broken = conn.broken;
       if (!broken && kind === 'wormhole') {
         // The sig you warp to lives in the FROM system. Prefer the explicitly
@@ -135,7 +132,7 @@ export function buildChainSteps(
       fromId, toId,
       fromName: sysById.get(fromId)?.name ?? '?',
       toName:   sysById.get(toId)?.name ?? '?',
-      kind, whType, size, sigId, broken,
+      kind, whType, sigId, broken,
     });
   }
   return steps;

--- a/web/src/utils/chains.ts
+++ b/web/src/utils/chains.ts
@@ -65,7 +65,8 @@ export interface ChainStep {
   fromName: string;
   toName: string;
   kind: ChainStepKind;      // jump a gate, or warp a wormhole
-  whType: string | null;    // wormhole code on the connection, if recorded
+  whType: string | null;    // wormhole code (connection's, else the matched sig's)
+  size: string | null;      // connection size class (xl/large/medium/small)
   sigId: string | null;     // the in-system sig code (ABC-123) to warp to, if linked
   broken: boolean;          // connection removed or quarantined — needs re-scouting
 }
@@ -98,6 +99,7 @@ export function buildChainSteps(
 
     let kind: ChainStepKind = 'wormhole';
     let whType: string | null = null;
+    let size: string | null = null;
     let sigId: string | null = null;
     let broken = true;
 
@@ -106,6 +108,7 @@ export function buildChainSteps(
              : conn.connectionType === 'jumpgate' ? 'jumpgate'
              : 'wormhole';
       whType = conn.type ?? null;
+      size   = conn.size ?? null;
       broken = conn.broken;
       if (!broken && kind === 'wormhole') {
         // The sig you warp to lives in the FROM system. Prefer the explicitly
@@ -120,7 +123,10 @@ export function buildChainSteps(
           const to = sysById.get(toId);
           sig = fromSigs.find((s) => s.sigType === 'wormhole' && sigLeadsTo(s, to));
         }
-        if (sig) sigId = sig.sigId || null;
+        if (sig) {
+          sigId = sig.sigId || null;
+          if (!whType) whType = sig.whType || null; // fall back to the sig's code
+        }
       }
     }
 
@@ -129,7 +135,7 @@ export function buildChainSteps(
       fromId, toId,
       fromName: sysById.get(fromId)?.name ?? '?',
       toName:   sysById.get(toId)?.name ?? '?',
-      kind, whType, sigId, broken,
+      kind, whType, size, sigId, broken,
     });
   }
   return steps;

--- a/web/src/utils/chains.ts
+++ b/web/src/utils/chains.ts
@@ -1,4 +1,4 @@
-import type { WormholeMap, SavedRoute, Signature } from '../types';
+import type { WormholeMap, MapSystem, SavedRoute, Signature } from '../types';
 
 // A computed path through the map's own connections: the ordered system ids and
 // the connection traversed between each consecutive pair (length = systems - 1).
@@ -70,14 +70,22 @@ export interface ChainStep {
   broken: boolean;          // connection removed or quarantined — needs re-scouting
 }
 
-// Resolve a saved chain's stored step sequence against the current map (and a
-// uuid->Signature lookup for the linked backing sigs) into displayable steps.
-// A hop whose connection is gone or quarantined is flagged `broken` rather than
-// silently re-routed, so the user knows that leg needs re-scouting.
+// Does a signature's "leads to" point at the given system (by name or class)?
+function sigLeadsTo(sig: Signature, to: MapSystem | undefined): boolean {
+  if (!to || !sig.whLeadsTo) return false;
+  const t = sig.whLeadsTo.trim().toUpperCase();
+  return t === to.name.toUpperCase() || t === to.systemClass.toUpperCase();
+}
+
+// Resolve a saved chain's stored step sequence against the current map into
+// displayable steps. `sigsBySystem` is the wormhole/scan signatures per system
+// (the from-system's are used to name the sig to warp to). A hop whose
+// connection is gone or quarantined is flagged `broken` rather than silently
+// re-routed, so the user knows that leg needs re-scouting.
 export function buildChainSteps(
   route: SavedRoute,
   map: WormholeMap,
-  sigsById: Map<string, Signature>,
+  sigsBySystem: Map<string, Signature[]>,
 ): ChainStep[] {
   const sysById  = new Map(map.systems.map((s) => [s.id, s]));
   const connById = new Map(map.connections.map((c) => [c.id, c]));
@@ -100,12 +108,18 @@ export function buildChainSteps(
       whType = conn.type ?? null;
       broken = conn.broken;
       if (!broken && kind === 'wormhole') {
-        // The sig you warp to lives in the FROM system: pick the end of the
-        // connection that matches this hop's direction.
+        // The sig you warp to lives in the FROM system. Prefer the explicitly
+        // linked sig for this hop's direction; otherwise auto-match the
+        // from-system wormhole sig whose "leads to" points at the target.
+        const fromSigs = sigsBySystem.get(fromId) ?? [];
         const sigRef = conn.sourceId === fromId ? conn.sourceSignatureId
                      : conn.targetId === fromId ? conn.targetSignatureId
                      : null;
-        const sig = sigRef ? sigsById.get(sigRef) : undefined;
+        let sig = sigRef ? fromSigs.find((s) => s.id === sigRef) : undefined;
+        if (!sig) {
+          const to = sysById.get(toId);
+          sig = fromSigs.find((s) => s.sigType === 'wormhole' && sigLeadsTo(s, to));
+        }
         if (sig) sigId = sig.sigId || null;
       }
     }

--- a/web/src/utils/wormholeSize.ts
+++ b/web/src/utils/wormholeSize.ts
@@ -1,0 +1,39 @@
+import type { TFunction } from 'i18next';
+
+// One source of truth for "what size is this wormhole". The size class is the
+// largest ship that can pass, i.e. the SDE per-jump cap (wormholeMaxJumpMass,
+// attr 1385) served by /api/wormholes/types. Thresholds match the SDE's actual
+// value clusters: 5M -> S, 62M -> M, 375M/410M -> L, 1B/2B -> XL.
+export type WhSizeClass = 'xl' | 'large' | 'medium' | 'small';
+
+export function whSizeClass(maxJumpMass: number | null | undefined): WhSizeClass | null {
+  if (!maxJumpMass || maxJumpMass <= 0) return null;
+  if (maxJumpMass >= 1_000_000_000) return 'xl';
+  if (maxJumpMass >= 300_000_000)   return 'large';
+  if (maxJumpMass >= 62_000_000)    return 'medium';
+  return 'small';
+}
+
+// Size class for a wormhole code, given the loaded /api/wormholes/types map.
+export function whSizeForType(
+  code: string | null | undefined,
+  whTypes: Record<string, { maxJumpMass?: number } | undefined>,
+): WhSizeClass | null {
+  if (!code) return null;
+  return whSizeClass(whTypes[code.toUpperCase()]?.maxJumpMass);
+}
+
+// Verbose label (reuses the connection-panel size strings, e.g. "Large (Battleship)").
+// Literal keys (not a lookup table) so the typed `t` accepts them.
+export function whSizeLabel(t: TFunction, cls: WhSizeClass): string {
+  switch (cls) {
+    case 'xl':     return t('connPanel.sizeXl');
+    case 'large':  return t('connPanel.sizeLarge');
+    case 'medium': return t('connPanel.sizeMedium');
+    case 'small':  return t('connPanel.sizeSmall');
+  }
+}
+
+// Compact label for tight rows: XL / L / M / S.
+const SHORT: Record<WhSizeClass, string> = { xl: 'XL', large: 'L', medium: 'M', small: 'S' };
+export function whSizeShort(cls: WhSizeClass): string { return SHORT[cls]; }


### PR DESCRIPTION
A wormhole chain hop showed "Warp to the wormhole [K346]" instead of the sig code (CBL-576), because it only used an *explicit* connection->signature link - which usually isn't set. You expected it to derive the sig from the system's scanned signatures, which is what this does.

## Data (from the reported case)
- Connection SN9S-N -> J001769: `source/target_signature_id` both null, `wh_type=K346` (auto-detected from J001769's side).
- SN9S-N has wormhole sig **CBL-576** (`wh_type=K162`, `wh_leads_to="J001769"`).

So the chain had everything it needed - it just wasn't looking at the system's sigs.

## Fix
When a wormhole hop has no explicit sig link, derive it from the **from-system's scanned signatures**: pick the wormhole sig whose `whLeadsTo` points at the hop's target (by name or class). Explicit links still take priority.

- `chains.ts`: `buildChainSteps` now takes `Map<systemId, Signature[]>`; for a wormhole hop it tries the linked sig first, then auto-matches `whLeadsTo` -> target.
- `ChainsPane`: fetches the from-systems' signatures grouped by system id.

Result: `SN9S-N -> J001769` reads **"Warp to CBL-576"**.

## Test
- `tsc` + `yarn build` clean; lint unchanged.
- Open the chain: the wormhole hop now shows the scanned sig code; if the user *did* explicitly link a sig, that still wins; ambiguous/unscanned hops fall back to "Warp to the wormhole".