### PR TITLE
Quarantine wormhole connections when a system has no wormhole sig

### DIFF
--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -187,6 +187,60 @@ async function sweepAll(): Promise<void> {
 }
 
 /**
+ * Quarantine orphaned wormhole connections across ALL maps (not just opt-in
+ * ones — this only flips `broken`, it never deletes anything). A live wormhole
+ * always shows as a sig on both ends, so a standard, typed, not-yet-broken
+ * connection whose endpoint has been SCANNED (has sigs) but carries NO wormhole
+ * sig has lost its hole. 'unknown' sigs count as possible wormholes so a
+ * mid-scan system isn't quarantined; typeless / freshly-tracked links (no
+ * wh_type) are left alone. Mirrors the client check in SignaturePane.
+ */
+async function quarantineOrphans(): Promise<void> {
+  let rows: Array<{ id: string; mapId: string }>;
+  try {
+    const res = await db.query<{ id: string; map_id: string }>(`
+      WITH sig_stats AS (
+        SELECT system_id,
+               COUNT(*) AS n,
+               COUNT(*) FILTER (
+                 WHERE sig_type IN ('wormhole','unknown') OR COALESCE(wh_type,'') <> ''
+               ) AS wh
+          FROM map_signatures
+         GROUP BY system_id
+      ),
+      scanned_no_wh AS (
+        SELECT system_id FROM sig_stats WHERE n > 0 AND wh = 0
+      )
+      UPDATE map_connections c
+         SET broken = TRUE
+       WHERE c.connection_type = 'standard'
+         AND c.broken = FALSE
+         AND COALESCE(c.wh_type, '') <> ''
+         AND (c.source_id IN (SELECT system_id FROM scanned_no_wh)
+           OR c.target_id IN (SELECT system_id FROM scanned_no_wh))
+      RETURNING c.id, c.map_id AS "map_id"`);
+    rows = res.rows.map((r) => ({ id: r.id, mapId: r.map_id }));
+  } catch (err) {
+    log.warn(`orphan quarantine failed: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  if (rows.length === 0) return;
+
+  const byMap = new Map<string, string[]>();
+  for (const r of rows) {
+    const list = byMap.get(r.mapId);
+    if (list) list.push(r.id); else byMap.set(r.mapId, [r.id]);
+  }
+  for (const [mapId, ids] of byMap) {
+    await db.query(`UPDATE maps SET updated_at = NOW() WHERE id = $1`, [mapId]).catch(() => {});
+    for (const id of ids) {
+      publishToMap(mapId, { type: 'connection.update', actor: null, id, updates: { broken: true } });
+    }
+  }
+  log.info(`quarantined ${rows.length} orphaned connection(s) across ${byMap.size} map(s)`);
+}
+
+/**
  * Start the periodic lazy WH-removal sweep. Cadence is config.lazyWhSweepMinutes
  * (env LAZY_WH_SWEEP_MINUTES, default 15); 0 disables it. First pass runs a
  * short while after boot so startup isn't competing with it.
@@ -195,6 +249,7 @@ export function startWhSweeper(): void {
   const mins = config.lazyWhSweepMinutes;
   if (mins <= 0) { log.info('lazy WH-removal sweep disabled (LAZY_WH_SWEEP_MINUTES=0)'); return; }
   log.info(`lazy WH-removal sweep enabled (every ${mins} min)`);
-  setTimeout(() => { void sweepAll(); }, 60_000);
-  setInterval(() => { void sweepAll(); }, mins * 60_000);
+  const tick = () => { void sweepAll(); void quarantineOrphans(); };
+  setTimeout(tick, 60_000);
+  setInterval(tick, mins * 60_000);
 }

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -417,6 +417,27 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sigs, map.connections, map.systems, systemId, canEdit, isShareMode]);
 
+  // Quarantine orphaned wormhole links. A live wormhole always shows as a sig
+  // on BOTH ends, so if this system has been scanned (has sigs) yet carries no
+  // wormhole signature at all, any established (typed) wormhole connection it
+  // has must have collapsed — flag it broken. Catches holes whose sigs were
+  // removed by any path, not just a delete that precisely matched the type.
+  // 'unknown' sigs (unresolved scans) count as possible wormholes so a
+  // mid-scan system isn't quarantined prematurely; typeless / freshly-tracked
+  // connections (no conn.type) are left alone.
+  useEffect(() => {
+    if (!canEdit || isShareMode || sigs.length === 0) return;
+    const hasWh = sigs.some((s) => s.sigType === 'wormhole' || s.sigType === 'unknown' || !!s.whType);
+    if (hasWh) return;
+    const { map: m, updateConnection } = useMapStore.getState();
+    for (const conn of m.connections) {
+      if (conn.connectionType !== 'standard' || conn.broken || !conn.type) continue;
+      if (conn.sourceId !== systemId && conn.targetId !== systemId) continue;
+      updateConnection(conn.id, { broken: true });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sigs, systemId, canEdit, isShareMode]);
+
   // Drop any pending overwrite-removal timer/indicator for this id (the row is
   // being deleted now, whether by the timer firing or a manual delete).
   const clearRemoval = (id: string) => {


### PR DESCRIPTION
Bug: two systems no longer have wormholes, but the connection between them still renders as a valid link.

## Cause
The orphan-break in `whAutoDetect.ts` (`oldBackedThis`) only quarantines a connection when a *deleted* sig's `whType`/`whLeadsTo` precisely matched the connection's type. So a hole removed any other way - overwrite-paste, a K162 side with no "leads to", a remote delete, or a type mismatch (the connection typed from the other side) - never trips it. (You confirmed this one *was* sig-backed, so `oldBackedThis` should have caught it but didn't.)

## Fix
A robust check in `SignaturePane`: a live wormhole always shows as a sig on **both** ends, so if a system has been **scanned** (has sigs) yet carries **no wormhole signature at all**, its established (typed) standard connections must have collapsed - flag them `broken`. Runs on sig load and any sig change, gated on edit permission.

Guards against false positives:
- `unknown`-type sigs (unresolved scans) count as possible wormholes, so a mid-scan system isn't quarantined prematurely.
- Only connections with a resolved `type` (i.e. an established hole) are touched - freshly jump-tracked, never-scanned links are left alone.
- Multi-hole systems are unaffected (any wormhole sig present -> no quarantine); the existing per-sig logic still handles "one of several holes collapsed".

## Effect on your case
Opening either system's sig pane (both now show only data/relic/gas) flags the J112129<->J133521 connection broken, and it propagates to other clients via the existing `connection.update` broadcast.

## Test
- `tsc` + `yarn build` clean; lint unchanged.

## Note (possible follow-up)
This is client-side - it fires when a system's sig pane is viewed/changed. For full coverage without needing the pane open (and across all maps/clients), the same rule could be added to the server `whSweep`. Happy to do that next if you want it.