### PR TITLE
Release v1.10.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -187,6 +187,60 @@ async function sweepAll(): Promise<void> {
 }
 
 /**
+ * Quarantine orphaned wormhole connections across ALL maps (not just opt-in
+ * ones — this only flips `broken`, it never deletes anything). A live wormhole
+ * always shows as a sig on both ends, so a standard, typed, not-yet-broken
+ * connection whose endpoint has been SCANNED (has sigs) but carries NO wormhole
+ * sig has lost its hole. 'unknown' sigs count as possible wormholes so a
+ * mid-scan system isn't quarantined; typeless / freshly-tracked links (no
+ * wh_type) are left alone. Mirrors the client check in SignaturePane.
+ */
+async function quarantineOrphans(): Promise<void> {
+  let rows: Array<{ id: string; mapId: string }>;
+  try {
+    const res = await db.query<{ id: string; map_id: string }>(`
+      WITH sig_stats AS (
+        SELECT system_id,
+               COUNT(*) AS n,
+               COUNT(*) FILTER (
+                 WHERE sig_type IN ('wormhole','unknown') OR COALESCE(wh_type,'') <> ''
+               ) AS wh
+          FROM map_signatures
+         GROUP BY system_id
+      ),
+      scanned_no_wh AS (
+        SELECT system_id FROM sig_stats WHERE n > 0 AND wh = 0
+      )
+      UPDATE map_connections c
+         SET broken = TRUE
+       WHERE c.connection_type = 'standard'
+         AND c.broken = FALSE
+         AND COALESCE(c.wh_type, '') <> ''
+         AND (c.source_id IN (SELECT system_id FROM scanned_no_wh)
+           OR c.target_id IN (SELECT system_id FROM scanned_no_wh))
+      RETURNING c.id, c.map_id AS "map_id"`);
+    rows = res.rows.map((r) => ({ id: r.id, mapId: r.map_id }));
+  } catch (err) {
+    log.warn(`orphan quarantine failed: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  if (rows.length === 0) return;
+
+  const byMap = new Map<string, string[]>();
+  for (const r of rows) {
+    const list = byMap.get(r.mapId);
+    if (list) list.push(r.id); else byMap.set(r.mapId, [r.id]);
+  }
+  for (const [mapId, ids] of byMap) {
+    await db.query(`UPDATE maps SET updated_at = NOW() WHERE id = $1`, [mapId]).catch(() => {});
+    for (const id of ids) {
+      publishToMap(mapId, { type: 'connection.update', actor: null, id, updates: { broken: true } });
+    }
+  }
+  log.info(`quarantined ${rows.length} orphaned connection(s) across ${byMap.size} map(s)`);
+}
+
+/**
  * Start the periodic lazy WH-removal sweep. Cadence is config.lazyWhSweepMinutes
  * (env LAZY_WH_SWEEP_MINUTES, default 15); 0 disables it. First pass runs a
  * short while after boot so startup isn't competing with it.
@@ -195,6 +249,7 @@ export function startWhSweeper(): void {
   const mins = config.lazyWhSweepMinutes;
   if (mins <= 0) { log.info('lazy WH-removal sweep disabled (LAZY_WH_SWEEP_MINUTES=0)'); return; }
   log.info(`lazy WH-removal sweep enabled (every ${mins} min)`);
-  setTimeout(() => { void sweepAll(); }, 60_000);
-  setInterval(() => { void sweepAll(); }, mins * 60_000);
+  const tick = () => { void sweepAll(); void quarantineOrphans(); };
+  setTimeout(tick, 60_000);
+  setInterval(tick, mins * 60_000);
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -417,6 +417,27 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sigs, map.connections, map.systems, systemId, canEdit, isShareMode]);
 
+  // Quarantine orphaned wormhole links. A live wormhole always shows as a sig
+  // on BOTH ends, so if this system has been scanned (has sigs) yet carries no
+  // wormhole signature at all, any established (typed) wormhole connection it
+  // has must have collapsed — flag it broken. Catches holes whose sigs were
+  // removed by any path, not just a delete that precisely matched the type.
+  // 'unknown' sigs (unresolved scans) count as possible wormholes so a
+  // mid-scan system isn't quarantined prematurely; typeless / freshly-tracked
+  // connections (no conn.type) are left alone.
+  useEffect(() => {
+    if (!canEdit || isShareMode || sigs.length === 0) return;
+    const hasWh = sigs.some((s) => s.sigType === 'wormhole' || s.sigType === 'unknown' || !!s.whType);
+    if (hasWh) return;
+    const { map: m, updateConnection } = useMapStore.getState();
+    for (const conn of m.connections) {
+      if (conn.connectionType !== 'standard' || conn.broken || !conn.type) continue;
+      if (conn.sourceId !== systemId && conn.targetId !== systemId) continue;
+      updateConnection(conn.id, { broken: true });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sigs, systemId, canEdit, isShareMode]);
+
   // Drop any pending overwrite-removal timer/indicator for this id (the row is
   // being deleted now, whether by the timer firing or a manual delete).
   const clearRemoval = (id: string) => {


### PR DESCRIPTION
Promotes `release` to `main`. Bumps version **1.10.0 -> 1.10.1** (web + server). Patch release - one bug fix.

## Fix: orphaned wormhole connections (#310)
A wormhole connection whose backing signatures are gone still rendered as a valid link. Now a connection is quarantined (`broken`) when an endpoint has been **scanned** (has sigs) but carries **no wormhole signature** - a live hole always shows as a sig on both ends, so this catches collapses removed by any path (overwrite-paste, K162 side with no "leads to", remote delete, type mismatch).

- **Client** (`SignaturePane`): flags it the moment you view/scan such a system.
- **Server** (`whSweep.quarantineOrphans`): runs on the sweep tick across all maps, no pane needed; broadcasts `connection.update`.

Safe rule both places: only established (typed) standard connections; `unknown` sigs count as possible wormholes (no mid-scan false positives); only flips `broken`, never deletes.

## Post-merge
Cut a `v1.10.1` GitHub release (tag `v1.10.1`).