### PR TITLE
Chain hover: pop route members and spotlight a single hop

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2679,6 +2679,13 @@
   transition: opacity 0.15s ease, filter 0.15s ease;
 }
 
+/* A system that IS on the hovered chain's route — lift it with a glow ring. */
+.system-node--route {
+  box-shadow: 0 0 0 2px var(--cv-conn-highlight),
+              0 0 14px 2px color-mix(in srgb, var(--cv-conn-highlight) 55%, transparent);
+  transition: box-shadow 0.15s ease;
+}
+
 .system-node--content-match {
   box-shadow: 0 0 0 2px var(--accent, #5b9bff), 0 0 12px 1px rgba(91,155,255,0.45);
 }

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -89,12 +89,12 @@ interface CtxMenu {
   selectedNodeIds?: string[]; // snapshot taken at right-click time before RF resets selection
 }
 
-function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true, dimmed = false): Node {
+function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true, dimmed = false, routeHighlighted = false): Node {
   return {
     id: sys.id,
     type: 'system',
     position: sys.position,
-    data: { ...sys, selected: sys.id === selectedId, dimmed },
+    data: { ...sys, selected: sys.id === selectedId, dimmed, routeHighlighted },
     draggable: canEdit && !sys.locked,
     dragHandle: easyConnect ? '.drag-handle' : undefined,
   };
@@ -420,7 +420,10 @@ export function MapCanvas() {
 
   useEffect(() => {
     const hl = routeHighlight ? new Set(routeHighlight.systemIds) : null;
-    setNodes(systems.map((s) => systemToNode(s, selectedSystemId, easyConnect, canEdit, !!hl && !hl.has(s.id))));
+    setNodes(systems.map((s) => {
+      const inRoute = !!hl && hl.has(s.id);
+      return systemToNode(s, selectedSystemId, easyConnect, canEdit, !!hl && !inRoute, inRoute);
+    }));
   }, [systems, selectedSystemId, easyConnect, setNodes, canEdit, routeHighlight]);
 
   useEffect(() => {
@@ -597,9 +600,10 @@ export function MapCanvas() {
         // Hover-only: a *selected* system would keep its links lit permanently
         // (e.g. your located system on a 2-node map), which reads as a stuck
         // hover effect — so highlight only follows the mouse.
+        const inRoute = !!routeConns && routeConns.has(c.id);
         const highlighted =
-          hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId);
-        const dimmed = !!routeConns && !routeConns.has(c.id);
+          inRoute || (hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId));
+        const dimmed = !!routeConns && !inRoute;
         return {
           id: c.id,
           source: c.sourceId,

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -36,7 +36,7 @@ import { heatValue, heatColor } from '../../utils/heatmap';
 import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
-type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean };
+type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean; routeHighlighted?: boolean };
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();
@@ -214,7 +214,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   return (
     <div
       ref={nodeRef}
-      className={`system-node${sys.locked ? ' nopan' : ''}${isTarget ? ' system-node--connect-target' : ''}${isStale ? ' system-node--stale' : ''}${isSovHostile ? ' system-node--sov-hostile' : ''}${isSovBlue ? ' system-node--sov-blue' : ''}${uniformSize ? ' system-node--uniform' : ''}${compactMode ? ' system-node--compact' : ''}${watchDef ? ' system-node--watched' : ''}${filteredOut ? ' system-node--filtered-out' : ''}${contentMatch ? ' system-node--content-match' : ''}${sys.dimmed ? ' system-node--dimmed' : ''}`}
+      className={`system-node${sys.locked ? ' nopan' : ''}${isTarget ? ' system-node--connect-target' : ''}${isStale ? ' system-node--stale' : ''}${isSovHostile ? ' system-node--sov-hostile' : ''}${isSovBlue ? ' system-node--sov-blue' : ''}${uniformSize ? ' system-node--uniform' : ''}${compactMode ? ' system-node--compact' : ''}${watchDef ? ' system-node--watched' : ''}${filteredOut ? ' system-node--filtered-out' : ''}${contentMatch ? ' system-node--content-match' : ''}${sys.dimmed ? ' system-node--dimmed' : ''}${sys.routeHighlighted ? ' system-node--route' : ''}`}
       style={{
         '--class-color': color,
         ...(intelColor ? { '--intel-color': intelColor } : null),

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -160,7 +160,20 @@ export function ChainsPane() {
                 {open && (
                   <ol className="chain-steps">
                     {steps.map((step) => (
-                      <li key={step.index} className={`chain-step${step.broken ? ' chain-step--broken' : ''}`}>
+                      <li
+                        key={step.index}
+                        className={`chain-step${step.broken ? ' chain-step--broken' : ''}`}
+                        // Narrow the map highlight to just this hop on hover;
+                        // back to the whole chain on leave (still in the row).
+                        onMouseEnter={() => setRouteHighlight({
+                          systemIds: [step.fromId, step.toId],
+                          connectionIds: [route.connectionIds[step.index - 1]],
+                        })}
+                        onMouseLeave={() => setRouteHighlight({
+                          systemIds: route.systemIds,
+                          connectionIds: route.connectionIds,
+                        })}
+                      >
                         <button
                           type="button"
                           className="chain-step__systems"


### PR DESCRIPTION
Follow-up to #312.

- Route members now stand out, not just the rest dimming: route edges get the highlight treatment (recolour/glow/lift) and route systems get a glow ring (`system-node--route`), while everything off-route still dims.
- Hovering an individual step narrows the highlight to just that hop (its two systems + the one connection); leaving the step restores the whole-chain highlight.