### PR TITLE
Release v1.11.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.10.1",
+  "version": "1.11.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.11.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2672,6 +2672,13 @@
   filter: none;
 }
 
+/* Dimmed while a saved chain is hovered (everything not on its route). */
+.system-node--dimmed {
+  opacity: 0.12;
+  filter: saturate(0.4);
+  transition: opacity 0.15s ease, filter 0.15s ease;
+}
+
 .system-node--content-match {
   box-shadow: 0 0 0 2px var(--accent, #5b9bff), 0 0 12px 1px rgba(91,155,255,0.45);
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2679,6 +2679,13 @@
   transition: opacity 0.15s ease, filter 0.15s ease;
 }
 
+/* A system that IS on the hovered chain's route — lift it with a glow ring. */
+.system-node--route {
+  box-shadow: 0 0 0 2px var(--cv-conn-highlight),
+              0 0 14px 2px color-mix(in srgb, var(--cv-conn-highlight) 55%, transparent);
+  transition: box-shadow 0.15s ease;
+}
+
 .system-node--content-match {
   box-shadow: 0 0 0 2px var(--accent, #5b9bff), 0 0 12px 1px rgba(91,155,255,0.45);
 }

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -66,6 +66,7 @@ export const ConnectionEdge = memo(({
     edgeStyle?: string;
     connectionThickness?: 'thin' | 'standard' | 'thick' | 'extra';
     highlighted?: boolean;
+    dimmed?: boolean;
     parallelIndex?: number;
     parallelCount?: number;
   };
@@ -180,7 +181,7 @@ export const ConnectionEdge = memo(({
             emphasized ? `drop-shadow(0 0 6px ${strokeColor})` : null,
             watchColor ? `drop-shadow(0 0 5px ${watchColor}) drop-shadow(0 0 2px ${watchColor})` : null,
           ].filter(Boolean).join(' ') || undefined,
-          opacity: broken ? 0.7 : emphasized || watchColor ? 1 : 0.85,
+          opacity: conn?.dimmed ? 0.1 : broken ? 0.7 : emphasized || watchColor ? 1 : 0.85,
         }}
         markerEnd={undefined}
       />

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -89,12 +89,12 @@ interface CtxMenu {
   selectedNodeIds?: string[]; // snapshot taken at right-click time before RF resets selection
 }
 
-function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true, dimmed = false): Node {
+function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true, dimmed = false, routeHighlighted = false): Node {
   return {
     id: sys.id,
     type: 'system',
     position: sys.position,
-    data: { ...sys, selected: sys.id === selectedId, dimmed },
+    data: { ...sys, selected: sys.id === selectedId, dimmed, routeHighlighted },
     draggable: canEdit && !sys.locked,
     dragHandle: easyConnect ? '.drag-handle' : undefined,
   };
@@ -420,7 +420,10 @@ export function MapCanvas() {
 
   useEffect(() => {
     const hl = routeHighlight ? new Set(routeHighlight.systemIds) : null;
-    setNodes(systems.map((s) => systemToNode(s, selectedSystemId, easyConnect, canEdit, !!hl && !hl.has(s.id))));
+    setNodes(systems.map((s) => {
+      const inRoute = !!hl && hl.has(s.id);
+      return systemToNode(s, selectedSystemId, easyConnect, canEdit, !!hl && !inRoute, inRoute);
+    }));
   }, [systems, selectedSystemId, easyConnect, setNodes, canEdit, routeHighlight]);
 
   useEffect(() => {
@@ -597,9 +600,10 @@ export function MapCanvas() {
         // Hover-only: a *selected* system would keep its links lit permanently
         // (e.g. your located system on a 2-node map), which reads as a stuck
         // hover effect — so highlight only follows the mouse.
+        const inRoute = !!routeConns && routeConns.has(c.id);
         const highlighted =
-          hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId);
-        const dimmed = !!routeConns && !routeConns.has(c.id);
+          inRoute || (hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId));
+        const dimmed = !!routeConns && !inRoute;
         return {
           id: c.id,
           source: c.sourceId,

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -89,12 +89,12 @@ interface CtxMenu {
   selectedNodeIds?: string[]; // snapshot taken at right-click time before RF resets selection
 }
 
-function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true): Node {
+function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true, dimmed = false): Node {
   return {
     id: sys.id,
     type: 'system',
     position: sys.position,
-    data: { ...sys, selected: sys.id === selectedId },
+    data: { ...sys, selected: sys.id === selectedId, dimmed },
     draggable: canEdit && !sys.locked,
     dragHandle: easyConnect ? '.drag-handle' : undefined,
   };
@@ -108,6 +108,7 @@ export function MapCanvas() {
   const connections          = useMapStore((s) => s.map.connections);
   const selectedSystemId     = useMapStore((s) => s.selectedSystemId);
   const selectedConnectionId = useMapStore((s) => s.selectedConnectionId);
+  const routeHighlight       = useMapStore((s) => s.routeHighlight);
   const snapToGrid           = useMapStore((s) => s.snapToGrid);
   const showMinimap          = useMapStore((s) => s.showMinimap);
   const [minimapPosition]    = useMinimapPosition();
@@ -418,8 +419,9 @@ export function MapCanvas() {
   }, []);
 
   useEffect(() => {
-    setNodes(systems.map((s) => systemToNode(s, selectedSystemId, easyConnect, canEdit)));
-  }, [systems, selectedSystemId, easyConnect, setNodes, canEdit]);
+    const hl = routeHighlight ? new Set(routeHighlight.systemIds) : null;
+    setNodes(systems.map((s) => systemToNode(s, selectedSystemId, easyConnect, canEdit, !!hl && !hl.has(s.id))));
+  }, [systems, selectedSystemId, easyConnect, setNodes, canEdit, routeHighlight]);
 
   useEffect(() => {
     if (!selectedSystemId) return;
@@ -586,6 +588,8 @@ export function MapCanvas() {
         if (g) g.push(c.id);
         else pairGroups.set(key, [c.id]);
       }
+      // While a saved chain is hovered, dim every edge that isn't on its route.
+      const routeConns = routeHighlight ? new Set(routeHighlight.connectionIds) : null;
       return connections.map((c) => {
         const ov = dragHandles.get(c.id);
         const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
@@ -595,6 +599,7 @@ export function MapCanvas() {
         // hover effect — so highlight only follows the mouse.
         const highlighted =
           hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId);
+        const dimmed = !!routeConns && !routeConns.has(c.id);
         return {
           id: c.id,
           source: c.sourceId,
@@ -605,14 +610,14 @@ export function MapCanvas() {
           // Lift highlighted edges above the rest so the traced link sits on top.
           zIndex: highlighted ? 10 : 0,
           data: {
-            ...c, edgeStyle, connectionThickness, highlighted,
+            ...c, edgeStyle, connectionThickness, highlighted, dimmed,
             parallelIndex: group.indexOf(c.id), parallelCount: group.length,
           } as unknown as Record<string, unknown>,
           selected: c.id === selectedConnectionId,
         };
       });
     },
-    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId],
+    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId, routeHighlight],
   );
 
   const onEdgesChange = useCallback(

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -36,7 +36,7 @@ import { heatValue, heatColor } from '../../utils/heatmap';
 import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
-type SystemNodeData = MapSystem & { selected: boolean };
+type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean };
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();
@@ -214,7 +214,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   return (
     <div
       ref={nodeRef}
-      className={`system-node${sys.locked ? ' nopan' : ''}${isTarget ? ' system-node--connect-target' : ''}${isStale ? ' system-node--stale' : ''}${isSovHostile ? ' system-node--sov-hostile' : ''}${isSovBlue ? ' system-node--sov-blue' : ''}${uniformSize ? ' system-node--uniform' : ''}${compactMode ? ' system-node--compact' : ''}${watchDef ? ' system-node--watched' : ''}${filteredOut ? ' system-node--filtered-out' : ''}${contentMatch ? ' system-node--content-match' : ''}`}
+      className={`system-node${sys.locked ? ' nopan' : ''}${isTarget ? ' system-node--connect-target' : ''}${isStale ? ' system-node--stale' : ''}${isSovHostile ? ' system-node--sov-hostile' : ''}${isSovBlue ? ' system-node--sov-blue' : ''}${uniformSize ? ' system-node--uniform' : ''}${compactMode ? ' system-node--compact' : ''}${watchDef ? ' system-node--watched' : ''}${filteredOut ? ' system-node--filtered-out' : ''}${contentMatch ? ' system-node--content-match' : ''}${sys.dimmed ? ' system-node--dimmed' : ''}`}
       style={{
         '--class-color': color,
         ...(intelColor ? { '--intel-color': intelColor } : null),

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -36,7 +36,7 @@ import { heatValue, heatColor } from '../../utils/heatmap';
 import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
-type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean };
+type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean; routeHighlighted?: boolean };
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();
@@ -214,7 +214,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   return (
     <div
       ref={nodeRef}
-      className={`system-node${sys.locked ? ' nopan' : ''}${isTarget ? ' system-node--connect-target' : ''}${isStale ? ' system-node--stale' : ''}${isSovHostile ? ' system-node--sov-hostile' : ''}${isSovBlue ? ' system-node--sov-blue' : ''}${uniformSize ? ' system-node--uniform' : ''}${compactMode ? ' system-node--compact' : ''}${watchDef ? ' system-node--watched' : ''}${filteredOut ? ' system-node--filtered-out' : ''}${contentMatch ? ' system-node--content-match' : ''}${sys.dimmed ? ' system-node--dimmed' : ''}`}
+      className={`system-node${sys.locked ? ' nopan' : ''}${isTarget ? ' system-node--connect-target' : ''}${isStale ? ' system-node--stale' : ''}${isSovHostile ? ' system-node--sov-hostile' : ''}${isSovBlue ? ' system-node--sov-blue' : ''}${uniformSize ? ' system-node--uniform' : ''}${compactMode ? ' system-node--compact' : ''}${watchDef ? ' system-node--watched' : ''}${filteredOut ? ' system-node--filtered-out' : ''}${contentMatch ? ' system-node--content-match' : ''}${sys.dimmed ? ' system-node--dimmed' : ''}${sys.routeHighlighted ? ' system-node--route' : ''}`}
       style={{
         '--class-color': color,
         ...(intelColor ? { '--intel-color': intelColor } : null),

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -160,7 +160,20 @@ export function ChainsPane() {
                 {open && (
                   <ol className="chain-steps">
                     {steps.map((step) => (
-                      <li key={step.index} className={`chain-step${step.broken ? ' chain-step--broken' : ''}`}>
+                      <li
+                        key={step.index}
+                        className={`chain-step${step.broken ? ' chain-step--broken' : ''}`}
+                        // Narrow the map highlight to just this hop on hover;
+                        // back to the whole chain on leave (still in the row).
+                        onMouseEnter={() => setRouteHighlight({
+                          systemIds: [step.fromId, step.toId],
+                          connectionIds: [route.connectionIds[step.index - 1]],
+                        })}
+                        onMouseLeave={() => setRouteHighlight({
+                          systemIds: route.systemIds,
+                          connectionIds: route.connectionIds,
+                        })}
+                      >
                         <button
                           type="button"
                           className="chain-step__systems"

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -24,6 +24,7 @@ export function ChainsPane() {
   const addRoute          = useMapStore((s) => s.addRoute);
   const removeRoute       = useMapStore((s) => s.removeRoute);
   const requestCenterOnNode = useMapStore((s) => s.requestCenterOnNode);
+  const setRouteHighlight = useMapStore((s) => s.setRouteHighlight);
   const canEdit           = useCanEdit();
   const whTypes           = useWormholeTypes();
 
@@ -128,7 +129,12 @@ export function ChainsPane() {
             const hops  = route.connectionIds.length;
             const steps = open ? buildChainSteps(route, map, sigsBySystem) : [];
             return (
-              <li key={route.id} className="chain-item">
+              <li
+                key={route.id}
+                className="chain-item"
+                onMouseEnter={() => setRouteHighlight({ systemIds: route.systemIds, connectionIds: route.connectionIds })}
+                onMouseLeave={() => setRouteHighlight(null)}
+              >
                 <div className="chain-item__head">
                   <button
                     type="button"

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -199,6 +199,12 @@ interface MapStore {
   requestCenterOnNode: (nodeId: string) => void;
   clearCenterRequest: () => void;
 
+  // Transient "highlight this saved chain on the map" — set while a chain row
+  // is hovered in the sidebar; the canvas dims every system/connection that
+  // isn't part of the route. null = nothing highlighted.
+  routeHighlight: { systemIds: string[]; connectionIds: string[] } | null;
+  setRouteHighlight: (v: { systemIds: string[]; connectionIds: string[] } | null) => void;
+
   // Route/centre origin override: point jump calcs + centring at another of
   // the account's characters (e.g. a scout on the chain exit) instead of the
   // active character. null = use the active character's live location.
@@ -485,6 +491,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
     fitViewPending: false,
     centerRequestEveId: null,
     centerRequestNodeId: null,
+    routeHighlight: null,
     routeOrigin: null,
     sigRev: {},
     structRev: {},
@@ -792,6 +799,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
     requestCenterOnEveSystem: (eveSystemId) => set({ centerRequestEveId: eveSystemId }),
     requestCenterOnNode: (nodeId) => set({ centerRequestNodeId: nodeId }),
     clearCenterRequest: () => set({ centerRequestEveId: null, centerRequestNodeId: null }),
+    setRouteHighlight: (v) => set({ routeHighlight: v }),
 
     setRouteOrigin: (o) => set({ routeOrigin: o }),
 


### PR DESCRIPTION
Promote release to main.

## Highlights since v1.10.0
- Chain hover highlight (#312): hovering a saved chain dims everything off its route.
- Pop + per-step spotlight (#313): route members lift/recolour; hovering a step narrows the highlight to just that hop.
- Server-side orphan-connection quarantine in the sweep (#310).

Bumps web + server to 1.11.0.