### PR TITLE
Drag-and-drop reorder saved chains

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -275,6 +275,10 @@ export async function migrate() {
       updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
     CREATE INDEX IF NOT EXISTS idx_map_routes_map ON map_routes (map_id);
+    -- User-defined ordering for the chains list (drag-and-drop reorder).
+    -- Existing rows default to 0 and fall back to created_at, preserving their
+    -- current order until the user reorders.
+    ALTER TABLE map_routes ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
 
     -- Tracks one-shot data migrations that must NOT re-run on every boot
     -- (unlike the idempotent DDL above) — e.g. a backfill we don't want to

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1719,9 +1719,11 @@ mapsRouter.post('/:mapId/routes', async (req, res) => {
     return;
   }
   const me = authUser(req);
+  // New chains append to the bottom of the list (next sort_order for the map).
   await db.query(
-    `INSERT INTO map_routes (id, map_id, name, system_ids, connection_ids, created_by_user_id)
-     VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (id) DO NOTHING`,
+    `INSERT INTO map_routes (id, map_id, name, system_ids, connection_ids, created_by_user_id, sort_order)
+     SELECT $1,$2,$3,$4,$5,$6, COALESCE(MAX(sort_order) + 1, 0) FROM map_routes WHERE map_id = $2
+     ON CONFLICT (id) DO NOTHING`,
     [id, mapId, name, systemIds, connectionIds ?? [], me.userId],
   );
   await touchMap(mapId);
@@ -1752,6 +1754,30 @@ mapsRouter.patch('/:mapId/routes/:routeId', async (req, res) => {
   );
   await touchMap(mapId);
   publishToMap(mapId, { type: 'route.update', actor: req.get('x-client-id') ?? null, id: routeId, updates });
+  res.json({ ok: true });
+});
+
+// Persist a drag-and-drop reorder of the chains list. Writes sort_order = the
+// position in `orderedIds` for every chain that belongs to the map; ids not in
+// the map are ignored, ids omitted keep their old sort_order (harmless tie).
+mapsRouter.put('/:mapId/routes/order', async (req, res) => {
+  const { mapId } = req.params;
+  const access = await requireMapContentWrite(res, mapId, req);
+  if (!access) return;
+  const { orderedIds } = req.body as { orderedIds?: string[] };
+  if (!Array.isArray(orderedIds) || !orderedIds.length) {
+    res.status(400).json({ error: 'orderedIds must be a non-empty array' });
+    return;
+  }
+  await db.query(
+    `UPDATE map_routes AS r
+        SET sort_order = o.ord - 1, updated_at = NOW()
+       FROM unnest($1::uuid[]) WITH ORDINALITY AS o(id, ord)
+      WHERE r.id = o.id AND r.map_id = $2`,
+    [orderedIds, mapId],
+  );
+  await touchMap(mapId);
+  publishToMap(mapId, { type: 'route.reorder', actor: req.get('x-client-id') ?? null, orderedIds });
   res.json({ ok: true });
 });
 

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -100,7 +100,7 @@ export async function loadFullMap(mapId: string) {
     db.query(
       `SELECT id, name, system_ids AS "systemIds", connection_ids AS "connectionIds",
               created_at AS "createdAt", updated_at AS "updatedAt"
-       FROM map_routes WHERE map_id = $1 ORDER BY created_at`,
+       FROM map_routes WHERE map_id = $1 ORDER BY sort_order, created_at`,
       [mapId],
     ),
   ]);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3790,6 +3790,15 @@ div.system-node__easy-handle {
 
 .chain-item { border: 1px solid #1a2240; border-radius: 6px; background: #0b0e16; }
 .chain-item__head { display: flex; align-items: center; }
+.chain-item__drag-handle {
+  flex: none;
+  background: none; border: none;
+  color: #6a80a0; cursor: grab; user-select: none;
+  padding: 0 2px 0 6px;
+  font-size: calc(13px * var(--font-scale, 1)); line-height: 1;
+}
+.chain-item__drag-handle:hover { color: #8a9ab8; }
+.chain-item__drag-handle:active { cursor: grabbing; }
 .chain-item__toggle {
   flex: 1; min-width: 0;
   display: flex; align-items: center; gap: 6px;

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -1,18 +1,30 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import type { DragEndEvent, Modifier } from '@dnd-kit/core';
+import {
+  SortableContext, verticalListSortingStrategy, arrayMove, useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useMapStore } from '../../store/mapStore';
 import { useCanEdit } from '../../hooks/useCanEdit';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { api } from '../../api/client';
 import { toast } from './Toaster';
 import { buildChainPath, buildChainSteps } from '../../utils/chains';
+import type { ChainStep } from '../../utils/chains';
 import { whSizeForType, whSizeLabel } from '../../utils/wormholeSize';
 import { SystemCombobox } from './SystemCombobox';
-import type { Signature } from '../../types';
+import type { Signature, SavedRoute } from '../../types';
 import {
   CaretRightIcon, CaretDownIcon, TrashIcon, ArrowRightIcon,
   ArrowBendUpRightIcon, WarningIcon,
 } from '@phosphor-icons/react';
+
+// A chain row is dragged only up/down within the list; zero the X component so
+// both the drag transform and collision detection lock to the vertical axis
+// (same one-liner the Sidebar uses for its panel reorder).
+const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 });
 
 // Recorded chains: pick a start + end system, the tool finds the shortest path
 // through the map's own connections and saves it; expanding a chain shows the
@@ -22,11 +34,21 @@ export function ChainsPane() {
   const { t } = useTranslation();
   const map               = useMapStore((s) => s.map);
   const addRoute          = useMapStore((s) => s.addRoute);
-  const removeRoute       = useMapStore((s) => s.removeRoute);
-  const requestCenterOnNode = useMapStore((s) => s.requestCenterOnNode);
-  const setRouteHighlight = useMapStore((s) => s.setRouteHighlight);
+  const reorderRoutes     = useMapStore((s) => s.reorderRoutes);
   const canEdit           = useCanEdit();
   const whTypes           = useWormholeTypes();
+
+  const sensors  = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const routeIds = useMemo(() => map.routes.map((r) => r.id), [map.routes]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = routeIds.indexOf(String(active.id));
+    const to   = routeIds.indexOf(String(over.id));
+    if (from === -1 || to === -1) return;
+    reorderRoutes(arrayMove(routeIds, from, to));
+  };
 
   const [fromId, setFromId] = useState('');
   const [toId, setToId]     = useState('');
@@ -123,109 +145,171 @@ export function ChainsPane() {
       {map.routes.length === 0 ? (
         <div className="chains-empty">{t('chains.empty')}</div>
       ) : (
-        <ul className="chains-list">
-          {map.routes.map((route) => {
-            const open  = expandedId === route.id;
-            const hops  = route.connectionIds.length;
-            const steps = open ? buildChainSteps(route, map, sigsBySystem) : [];
-            return (
-              <li
-                key={route.id}
-                className="chain-item"
-                onMouseEnter={() => setRouteHighlight({ systemIds: route.systemIds, connectionIds: route.connectionIds })}
-                onMouseLeave={() => setRouteHighlight(null)}
-              >
-                <div className="chain-item__head">
-                  <button
-                    type="button"
-                    className="chain-item__toggle"
-                    onClick={() => setExpandedId(open ? null : route.id)}
-                  >
-                    {open ? <CaretDownIcon size={12} weight="bold" /> : <CaretRightIcon size={12} weight="bold" />}
-                    <span className="chain-item__name">{route.name || t('chains.unnamed')}</span>
-                    <span className="chain-item__hops">{t('chains.hops', { count: hops })}</span>
-                  </button>
-                  {canEdit && (
-                    <button
-                      type="button"
-                      className="icon-btn chain-item__del"
-                      title={t('chains.remove')}
-                      onClick={() => removeRoute(route.id)}
-                    >
-                      <TrashIcon size={13} weight="regular" />
-                    </button>
-                  )}
-                </div>
-
-                {open && (
-                  <ol className="chain-steps">
-                    {steps.map((step) => (
-                      <li
-                        key={step.index}
-                        className={`chain-step${step.broken ? ' chain-step--broken' : ''}`}
-                        // Narrow the map highlight to just this hop on hover;
-                        // back to the whole chain on leave (still in the row).
-                        onMouseEnter={() => setRouteHighlight({
-                          systemIds: [step.fromId, step.toId],
-                          connectionIds: [route.connectionIds[step.index - 1]],
-                        })}
-                        onMouseLeave={() => setRouteHighlight({
-                          systemIds: route.systemIds,
-                          connectionIds: route.connectionIds,
-                        })}
-                      >
-                        <button
-                          type="button"
-                          className="chain-step__systems"
-                          title={t('chains.centerOn', { system: step.fromName })}
-                          onClick={() => requestCenterOnNode(step.fromId)}
-                        >
-                          <span className="chain-step__from">{step.fromName}</span>
-                          <ArrowRightIcon size={11} weight="bold" />
-                          <span className="chain-step__to">{step.toName}</span>
-                        </button>
-                        <div className="chain-step__via">
-                          {step.broken ? (
-                            <span className="chain-step__broken">
-                              <WarningIcon size={11} weight="fill" /> {t('chains.brokenHop')}
-                            </span>
-                          ) : step.kind === 'gate' ? (
-                            <span className="chain-step__warp">
-                              <ArrowBendUpRightIcon size={11} weight="bold" />
-                              {t('chains.viaGate')}
-                            </span>
-                          ) : step.kind === 'jumpgate' ? (
-                            <span className="chain-step__warp">
-                              <ArrowBendUpRightIcon size={11} weight="bold" />
-                              {t('chains.viaJumpBridge')}
-                            </span>
-                          ) : (
-                            <span className="chain-step__warp">
-                              <ArrowBendUpRightIcon size={11} weight="bold" />
-                              {step.sigId
-                                ? t('chains.warpSig', { sig: step.sigId })
-                                : t('chains.warpWormhole')}
-                            </span>
-                          )}
-                        </div>
-                        {step.kind === 'wormhole' && !step.broken && step.whType && (() => {
-                          const size = sizeLabel(step.whType);
-                          return (
-                            <div className="chain-step__meta">
-                              <span>{t('chains.whTypeLabel')}: {step.whType}</span>
-                              {size && <span>{t('chains.whSizeLabel')}: {size}</span>}
-                            </div>
-                          );
-                        })()}
-                      </li>
-                    ))}
-                  </ol>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          modifiers={[restrictToVerticalAxis]}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext items={routeIds} strategy={verticalListSortingStrategy}>
+            <ul className="chains-list">
+              {map.routes.map((route) => {
+                const open  = expandedId === route.id;
+                const steps = open ? buildChainSteps(route, map, sigsBySystem) : [];
+                return (
+                  <SortableChainItem
+                    key={route.id}
+                    route={route}
+                    open={open}
+                    steps={steps}
+                    canEdit={canEdit}
+                    draggable={canEdit && map.routes.length > 1}
+                    onToggle={() => setExpandedId(open ? null : route.id)}
+                    sizeLabel={sizeLabel}
+                  />
+                );
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
       )}
     </div>
+  );
+}
+
+interface SortableChainItemProps {
+  route: SavedRoute;
+  open: boolean;
+  steps: ChainStep[];
+  canEdit: boolean;
+  draggable: boolean;
+  onToggle: () => void;
+  sizeLabel: (whType: string | null) => string | null;
+}
+
+// One chain row: drag handle + collapsible header + per-hop steps. Pulls its
+// own store actions so the parent only threads view state through props.
+function SortableChainItem({ route, open, steps, canEdit, draggable, onToggle, sizeLabel }: SortableChainItemProps) {
+  const { t } = useTranslation();
+  const removeRoute         = useMapStore((s) => s.removeRoute);
+  const setRouteHighlight   = useMapStore((s) => s.setRouteHighlight);
+  const requestCenterOnNode = useMapStore((s) => s.requestCenterOnNode);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: route.id, disabled: !draggable });
+  const hops = route.connectionIds.length;
+
+  return (
+    <li
+      ref={setNodeRef}
+      className="chain-item"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+        zIndex: isDragging ? 10 : undefined,
+      }}
+      // Highlight the whole chain on the map while hovered (suppressed mid-drag).
+      onMouseEnter={() => { if (!isDragging) setRouteHighlight({ systemIds: route.systemIds, connectionIds: route.connectionIds }); }}
+      onMouseLeave={() => setRouteHighlight(null)}
+    >
+      <div className="chain-item__head">
+        {draggable && (
+          <button
+            type="button"
+            className="chain-item__drag-handle"
+            {...listeners}
+            {...attributes}
+            onClick={(e) => e.stopPropagation()}
+            title={t('closest.dragToReorder')}
+          >
+            ⠿
+          </button>
+        )}
+        <button
+          type="button"
+          className="chain-item__toggle"
+          onClick={onToggle}
+        >
+          {open ? <CaretDownIcon size={12} weight="bold" /> : <CaretRightIcon size={12} weight="bold" />}
+          <span className="chain-item__name">{route.name || t('chains.unnamed')}</span>
+          <span className="chain-item__hops">{t('chains.hops', { count: hops })}</span>
+        </button>
+        {canEdit && (
+          <button
+            type="button"
+            className="icon-btn chain-item__del"
+            title={t('chains.remove')}
+            onClick={() => removeRoute(route.id)}
+          >
+            <TrashIcon size={13} weight="regular" />
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <ol className="chain-steps">
+          {steps.map((step) => (
+            <li
+              key={step.index}
+              className={`chain-step${step.broken ? ' chain-step--broken' : ''}`}
+              // Narrow the map highlight to just this hop on hover;
+              // back to the whole chain on leave (still in the row).
+              onMouseEnter={() => setRouteHighlight({
+                systemIds: [step.fromId, step.toId],
+                connectionIds: [route.connectionIds[step.index - 1]],
+              })}
+              onMouseLeave={() => setRouteHighlight({
+                systemIds: route.systemIds,
+                connectionIds: route.connectionIds,
+              })}
+            >
+              <button
+                type="button"
+                className="chain-step__systems"
+                title={t('chains.centerOn', { system: step.fromName })}
+                onClick={() => requestCenterOnNode(step.fromId)}
+              >
+                <span className="chain-step__from">{step.fromName}</span>
+                <ArrowRightIcon size={11} weight="bold" />
+                <span className="chain-step__to">{step.toName}</span>
+              </button>
+              <div className="chain-step__via">
+                {step.broken ? (
+                  <span className="chain-step__broken">
+                    <WarningIcon size={11} weight="fill" /> {t('chains.brokenHop')}
+                  </span>
+                ) : step.kind === 'gate' ? (
+                  <span className="chain-step__warp">
+                    <ArrowBendUpRightIcon size={11} weight="bold" />
+                    {t('chains.viaGate')}
+                  </span>
+                ) : step.kind === 'jumpgate' ? (
+                  <span className="chain-step__warp">
+                    <ArrowBendUpRightIcon size={11} weight="bold" />
+                    {t('chains.viaJumpBridge')}
+                  </span>
+                ) : (
+                  <span className="chain-step__warp">
+                    <ArrowBendUpRightIcon size={11} weight="bold" />
+                    {step.sigId
+                      ? t('chains.warpSig', { sig: step.sigId })
+                      : t('chains.warpWormhole')}
+                  </span>
+                )}
+              </div>
+              {step.kind === 'wormhole' && !step.broken && step.whType && (() => {
+                const size = sizeLabel(step.whType);
+                return (
+                  <div className="chain-step__meta">
+                    <span>{t('chains.whTypeLabel')}: {step.whType}</span>
+                    {size && <span>{t('chains.whSizeLabel')}: {size}</span>}
+                  </div>
+                );
+              })()}
+            </li>
+          ))}
+        </ol>
+      )}
+    </li>
   );
 }

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -268,6 +268,7 @@ interface MapStore {
   addRoute: (name: string, systemIds: string[], connectionIds: string[]) => string | null;
   renameRoute: (id: string, name: string) => void;
   removeRoute: (id: string) => void;
+  reorderRoutes: (orderedIds: string[]) => void;
 
   // Selection
   selectSystem: (id: string | null) => void;
@@ -317,6 +318,7 @@ export type RemoteEvent =
   | { type: 'route.add';         route: SavedRoute }
   | { type: 'route.update';      id: string; updates: Partial<SavedRoute> }
   | { type: 'route.remove';      id: string }
+  | { type: 'route.reorder';     orderedIds: string[] }
   | { type: 'map.meta';          name?: string; locked?: boolean }
   | { type: 'map.resync' }
   | { type: 'sig.changed';       systemId: string }
@@ -1117,6 +1119,24 @@ export const useMapStore = create<MapStore>()((set, get) => {
       }
     },
 
+    reorderRoutes: (orderedIds) => {
+      const { activeMapId } = get();
+      // Optimistically re-sort the local list to match the dropped order; any
+      // route id not in orderedIds (shouldn't happen) keeps its relative tail
+      // position so nothing silently disappears.
+      set((s) => {
+        const byId = new Map((s.map.routes ?? []).map((r) => [r.id, r]));
+        const ordered = orderedIds.map((id) => byId.get(id)).filter((r): r is SavedRoute => !!r);
+        const rest = (s.map.routes ?? []).filter((r) => !orderedIds.includes(r.id));
+        return { map: { ...s.map, routes: [...ordered, ...rest] } };
+      });
+      if (activeMapId) {
+        const url  = `/api/maps/${activeMapId}/routes/order`;
+        const body = JSON.stringify({ orderedIds });
+        api(url, { method: 'PUT', body }).catch(() => enqueue(`reorderRoutes:${activeMapId}`, url, 'PUT', body));
+      }
+    },
+
     selectSystem: (id) => set({ selectedSystemId: id, selectedConnectionId: null }),
     selectConnection: (id) => set({ selectedConnectionId: id, selectedSystemId: null }),
     setCurrentSystem: (id) => set({ currentSystemId: id }),
@@ -1186,6 +1206,15 @@ export const useMapStore = create<MapStore>()((set, get) => {
           set((s) => ({
             map: { ...s.map, routes: (s.map.routes ?? []).filter((r) => r.id !== event.id) },
           }));
+          break;
+        }
+        case 'route.reorder': {
+          set((s) => {
+            const byId = new Map((s.map.routes ?? []).map((r) => [r.id, r]));
+            const ordered = event.orderedIds.map((id) => byId.get(id)).filter((r): r is SavedRoute => !!r);
+            const rest = (s.map.routes ?? []).filter((r) => !event.orderedIds.includes(r.id));
+            return { map: { ...s.map, routes: [...ordered, ...rest] } };
+          });
           break;
         }
         case 'map.meta': {


### PR DESCRIPTION
Saved wormhole chains can now be reordered by drag-and-drop; the order persists per map.

## Changes
- **DB**: `map_routes.sort_order` column; chains load `ORDER BY sort_order, created_at`. Existing rows keep their current order (default 0); new chains append to the bottom.
- **Server**: `PUT /api/maps/:mapId/routes/order` persists the order and broadcasts a `route.reorder` SSE event.
- **Store**: `reorderRoutes` (optimistic + offline-enqueue); `applyRemote` handles `route.reorder` for live multi-client sync.
- **UI**: dnd-kit reorder in ChainsPane (vertical-axis lock, matching the sidebar). Drag handle gated behind edit rights, shown only with >1 chain.

No new user-facing strings (reuses `closest.dragToReorder`). web + server typecheck, lint, and build clean.