### PR TITLE
Wormhole jump-confirm: pin a hole's destination on jump

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2834,9 +2834,12 @@
     border-style: double;
   }
 
+  /* The system you're currently in: white border + soft white glow. White so
+     it reads as "you" without colliding with the gold home border, the yellow
+     A0 sun icon, or any class colour. */
   &[data-current='true'] {
-    border-color: #f5c518;
-    box-shadow: 0 0 0 2px rgba(245, 197, 24, 0.35), 0 0 14px rgba(245, 197, 24, 0.25);
+    border-color: #ffffff;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.55), 0 0 14px rgba(255, 255, 255, 0.4);
   }
 
   &.system-node--connect-target {
@@ -7649,6 +7652,59 @@ select.sig-toolbar-btn option {
 .toast--error   { border-left-color: #f87171; background: #1a1014; }
 .toast--info    { border-left-color: #60a5fa; background: #0f1620; }
 .toast--success { border-left-color: #4ade80; background: #0f1a14; }
+
+/* Actionable toast: message + close on one row, buttons wrapping below. Wider
+   so several hole buttons fit before wrapping. */
+.toast--actionable { max-width: 420px; }
+
+.toast__body {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.toast__msg { flex: 1; }
+
+.toast__close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #8a93a6;
+  font-size: calc(16px * var(--font-scale, 1));
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.toast__close:hover { color: #c8d0e0; }
+
+.toast__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.toast__action {
+  background: #1c2230;
+  border: 1px solid #2e3a4f;
+  border-radius: 4px;
+  color: #c8d0e0;
+  font-size: calc(12px * var(--font-scale, 1));
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.toast__action:hover { border-color: #4a5a78; background: #232b3b; }
+
+.toast__action--primary {
+  background: #1e3a5f;
+  border-color: #3b6ea5;
+  color: #dbe7f5;
+}
+
+.toast__action--primary:hover { background: #244873; }
 
 /* ── Role badge ──────────────────────────────────────────── */
 .role-badge {

--- a/web/src/components/ui/Toaster.tsx
+++ b/web/src/components/ui/Toaster.tsx
@@ -6,10 +6,34 @@ import { useEffect, useState } from 'react';
 
 export type ToastKind = 'error' | 'info' | 'success';
 
+export interface ToastAction {
+  label:    string;
+  onClick:  () => void;
+  /** Highlighted (filled) button — use for the default/confirm action. */
+  primary?: boolean;
+}
+
+interface ToastOptions {
+  kind?:      ToastKind;
+  /** Auto-dismiss delay; ignored when `sticky`. */
+  ttlMs?:     number;
+  /** Buttons rendered in the toast. A click runs onClick then dismisses. */
+  actions?:   ToastAction[];
+  /** Never auto-dismiss — stays until an action or the close button is used.
+      Use for a pending decision (e.g. the wormhole jump-confirm prompt). */
+  sticky?:    boolean;
+  /** If a live toast already shares this key, the new one is dropped. Lets
+      callers raise an idempotent prompt without re-toasting on re-render. */
+  dedupeKey?: string;
+}
+
 interface Toast {
-  id:   number;
-  kind: ToastKind;
-  msg:  string;
+  id:         number;
+  kind:       ToastKind;
+  msg:        string;
+  actions?:   ToastAction[];
+  sticky?:    boolean;
+  dedupeKey?: string;
 }
 
 const subscribers = new Set<(toasts: Toast[]) => void>();
@@ -20,20 +44,32 @@ function notify() {
   subscribers.forEach((fn) => fn(current));
 }
 
-function push(kind: ToastKind, msg: string, ttlMs = 5000) {
-  const id = nextId++;
-  current = [...current, { id, kind, msg }];
+function dismiss(id: number) {
+  current = current.filter((t) => t.id !== id);
   notify();
-  setTimeout(() => {
-    current = current.filter((t) => t.id !== id);
-    notify();
-  }, ttlMs);
+}
+
+// Returns the toast id (or -1 if dropped as a dedupe). Sticky toasts never
+// schedule an auto-dismiss; the caller dismisses via an action/close.
+function show(msg: string, opts: ToastOptions = {}): number {
+  const { kind = 'info', actions, sticky = false, dedupeKey } = opts;
+  if (dedupeKey && current.some((t) => t.dedupeKey === dedupeKey)) return -1;
+  const id = nextId++;
+  current = [...current, { id, kind, msg, actions, sticky, dedupeKey }];
+  notify();
+  if (!sticky) {
+    setTimeout(() => dismiss(id), opts.ttlMs ?? 5000);
+  }
+  return id;
 }
 
 export const toast = {
-  error:   (msg: string) => push('error',   msg, 7000),
-  info:    (msg: string) => push('info',    msg, 4000),
-  success: (msg: string) => push('success', msg, 3000),
+  error:   (msg: string) => show(msg, { kind: 'error',   ttlMs: 7000 }),
+  info:    (msg: string) => show(msg, { kind: 'info',    ttlMs: 4000 }),
+  success: (msg: string) => show(msg, { kind: 'success', ttlMs: 3000 }),
+  // Rich entry point: actions + sticky + dedupe. Built on the same emitter.
+  show,
+  dismiss,
 };
 
 export function Toaster() {
@@ -52,16 +88,50 @@ export function Toaster() {
 
   return (
     <div className="toaster">
-      {toasts.map((t) => (
-        <div
-          key={t.id}
-          className={`toast toast--${t.kind}`}
-          role={t.kind === 'error' ? 'alert' : 'status'}
-          onClick={() => { current = current.filter((c) => c.id !== t.id); notify(); }}
-        >
-          {t.msg}
-        </div>
-      ))}
+      {toasts.map((t) => {
+        const hasActions = !!t.actions?.length;
+        // Plain toasts keep click-to-dismiss. Actionable/sticky toasts must not
+        // dismiss on body click (you'd lose the buttons) — they get an explicit
+        // close control instead.
+        const dismissOnBodyClick = !hasActions && !t.sticky;
+        return (
+          <div
+            key={t.id}
+            className={`toast toast--${t.kind}${hasActions ? ' toast--actionable' : ''}`}
+            role={t.kind === 'error' ? 'alert' : 'status'}
+            onClick={dismissOnBodyClick ? () => dismiss(t.id) : undefined}
+            style={dismissOnBodyClick ? undefined : { cursor: 'default' }}
+          >
+            <div className="toast__body">
+              <span className="toast__msg">{t.msg}</span>
+              {(hasActions || t.sticky) && (
+                <button
+                  type="button"
+                  className="toast__close"
+                  aria-label="Dismiss"
+                  onClick={() => dismiss(t.id)}
+                >
+                  ×
+                </button>
+              )}
+            </div>
+            {hasActions && (
+              <div className="toast__actions">
+                {t.actions!.map((a, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    className={`toast__action${a.primary ? ' toast__action--primary' : ''}`}
+                    onClick={() => { a.onClick(); dismiss(t.id); }}
+                  >
+                    {a.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -4,6 +4,7 @@ import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
 import { readUserSetting } from './useUserSetting';
 import { pickHandles } from '../components/map/edgeUtils';
+import { maybeConfirmWhJump } from './whJumpConfirm';
 import type { SystemClass, WormholeEffect } from '../types';
 
 interface Box { position: { x: number; y: number } }
@@ -175,6 +176,23 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
         : { sourceHandle: 'right' as const, targetHandle: 'left' as const };
       addConnection(prevMapSystemId, mapSystemId, sourceHandle, targetHandle);
     }
+  }
+
+  // A jump resolved — real tracking and the jump simulator both funnel through
+  // here. If it's a wormhole jump, offer to pin the source system's hole to
+  // where it led. Fires regardless of whether the connection was new (so a
+  // class-only hole still gets upgraded to the specific system); holes already
+  // pinned to a system are filtered out inside whJumpConfirm. Fire-and-forget.
+  if (canAdd && prevMapSystemId && prevMapSystemId !== mapSystemId) {
+    const fromSys = map.systems.find((s) => s.id === prevMapSystemId);
+    void maybeConfirmWhJump({
+      mapId:           map.id,
+      fromMapSystemId: prevMapSystemId,
+      fromEveSystemId: fromSys?.eveSystemId ?? null,
+      toEveSystemId:   system.eveSystemId,
+      toClass:         system.systemClass,
+      toName:          system.name,
+    });
   }
 
   return mapSystemId;

--- a/web/src/hooks/whJumpConfirm.ts
+++ b/web/src/hooks/whJumpConfirm.ts
@@ -1,0 +1,109 @@
+import { api } from '../api/client';
+import { toast } from '../components/ui/Toaster';
+import { reevaluateConnectionsForSystem } from '../utils/whAutoDetect';
+import i18n from '../i18n';
+import type { Signature } from '../types';
+
+// After a tracked wormhole jump, offer to record which wormhole signature in
+// the source system was the one jumped — upgrading its leads-to from a class /
+// "unknown" to the SPECIFIC system we arrived in. Confirm-on-commit: nothing is
+// written until the user picks, so no premature live-sync / Discord broadcast.
+// See wh_jump_confirm_feature.md.
+
+// W-space ids start here; w-space has no stargates, so a jump touching it is a
+// wormhole jump. (k<->k wormhole jumps need server gate data — out of v1.)
+const WSPACE_MIN_ID = 31_000_000;
+const isWspace = (eveId: number | null): boolean => eveId !== null && eveId >= WSPACE_MIN_ID;
+
+// The leads-to values that are class/band/unknown rather than a pinned system
+// (see LeadsToDropdown). Anything NOT in here is a specific connected-system
+// name — i.e. the hole is already solved, so we leave it alone.
+const CLASS_OR_UNKNOWN = new Set([
+  '', 'unknown',
+  'C1-C3', 'C4-C5', 'C6', 'C13', 'Thera', 'Pochven', 'Drifter',
+  'HS', 'LS', 'NS',
+  'C1', 'C2', 'C3', 'C4', 'C5', // legacy exact-class values
+]);
+
+// The band value the dropdown uses for an exact C-space class.
+function bandFor(cls: string): string {
+  if (cls === 'C1' || cls === 'C2' || cls === 'C3') return 'C1-C3';
+  if (cls === 'C4' || cls === 'C5') return 'C4-C5';
+  return cls; // C6 / C13 / Thera / Pochven / Drifter / HS / LS / NS
+}
+
+// A hole is a plausible candidate when it isn't already pinned to a system, and
+// its class/band is compatible with where we arrived ("unknown" always is; a
+// hole that leads to a different class can't be the one we jumped).
+function isCandidate(whLeadsTo: string, arrivalClass: string): boolean {
+  const v = (whLeadsTo || '').trim();
+  if (!CLASS_OR_UNKNOWN.has(v)) return false;          // already a specific system
+  if (v === '' || v === 'unknown') return true;        // unknown → plausible
+  return v === bandFor(arrivalClass) || v === arrivalClass;
+}
+
+export interface WhJumpContext {
+  mapId:           string;
+  fromMapSystemId: string;       // source system's map-node id (where the hole sig lives)
+  fromEveSystemId: number | null;
+  toEveSystemId:   number | null;
+  toClass:         string;        // arrival system's class, e.g. 'C3'
+  toName:          string;        // arrival system's name, e.g. 'J203753' — what we pin the hole to
+}
+
+export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
+  const { mapId, fromMapSystemId, fromEveSystemId, toEveSystemId, toClass, toName } = ctx;
+
+  // Only when the jump involves w-space (guaranteed-wormhole).
+  if (!isWspace(fromEveSystemId) && !isWspace(toEveSystemId)) return;
+
+  let sigs: Signature[];
+  try {
+    sigs = await api<Signature[]>(`/api/maps/${mapId}/systems/${fromMapSystemId}/signatures`);
+  } catch {
+    return;
+  }
+
+  // Eligible = known wormhole sigs not yet pinned to a system, whose class is
+  // compatible with where we arrived. Unknowns (non-wormhole) are never touched.
+  const candidates = sigs.filter((s) => s.sigType === 'wormhole' && isCandidate(s.whLeadsTo, toClass));
+  if (candidates.length === 0) return;
+
+  const t = i18n.t.bind(i18n);
+  const label = (s: Signature): string => s.sigId || s.whType || s.name || '???';
+  const dedupeKey = `whjump:${fromMapSystemId}->${toEveSystemId ?? '?'}`;
+
+  // Pin the hole to the specific arrival system (the dropdown stores the
+  // connected-system name as the leads-to value), then re-run the same
+  // connection auto-detect the sig pane uses on edit — so the map edge picks up
+  // this sig's WH type now that the hole resolves to the destination system.
+  const setLeadsTo = (s: Signature): void => {
+    api(`/api/maps/${mapId}/systems/${fromMapSystemId}/signatures/${s.id}`, {
+      method: 'PATCH',
+      body:   JSON.stringify({ whLeadsTo: toName }),
+    }).catch(() => { /* best-effort; the user can still set it by hand */ });
+    const updated = sigs.map((x) => (x.id === s.id ? { ...x, whLeadsTo: toName } : x));
+    reevaluateConnectionsForSystem(fromMapSystemId, updated, s);
+  };
+
+  // One plausible hole → one-tap confirm; several → one button per candidate.
+  if (candidates.length === 1) {
+    const sole = candidates[0];
+    toast.show(t('whJump.confirmOne', { sig: label(sole), system: toName }), {
+      kind: 'info', sticky: true, dedupeKey,
+      actions: [
+        { label: t('whJump.confirm'),       primary: true, onClick: () => setLeadsTo(sole) },
+        { label: t('whJump.differentHole'),                onClick: () => { /* skip */ } },
+      ],
+    });
+    return;
+  }
+
+  toast.show(t('whJump.confirmMany', { system: toName }), {
+    kind: 'info', sticky: true, dedupeKey,
+    actions: [
+      ...candidates.map((s) => ({ label: label(s), onClick: () => setLeadsTo(s) })),
+      { label: t('whJump.unmapped'), onClick: () => { /* skip */ } },
+    ],
+  });
+}

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "Schiff-Sprunggröße",
     "colTotalMass": "Gesamtmasse",
     "colLifetime": "Lebensdauer"
+  },
+  "whJump": {
+    "confirmOne": "Sprung nach {{system}}. {{sig}} als Verbindung dorthin markieren?",
+    "confirmMany": "Sprung nach {{system}}. Welche Signatur warst du?",
+    "confirm": "Bestätigen",
+    "differentHole": "Anderes Loch",
+    "unmapped": "Unbekanntes Loch"
   }
 }

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1480,5 +1480,12 @@
     "lessThan4h": "< 4 hrs",
     "lessThan1h": "< 1 hr",
     "broken": "Connection broken — the wormhole sig was deleted (hole collapsed)"
+  },
+  "whJump": {
+    "confirmOne": "Jumped to {{system}}. Mark {{sig}} as leading there?",
+    "confirmMany": "Jumped to {{system}}. Which signature did you jump?",
+    "confirm": "Confirm",
+    "differentHole": "Different hole",
+    "unmapped": "Unmapped hole"
   }
 }

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "Tamaño de salto de nave",
     "colTotalMass": "Masa total",
     "colLifetime": "Vida útil"
+  },
+  "whJump": {
+    "confirmOne": "Saltaste a {{system}}. ¿Marcar {{sig}} como que lleva allí?",
+    "confirmMany": "Saltaste a {{system}}. ¿Qué firma usaste?",
+    "confirm": "Confirmar",
+    "differentHole": "Otro agujero",
+    "unmapped": "Agujero desconocido"
   }
 }

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "Taille de saut de vaisseau",
     "colTotalMass": "Masse totale",
     "colLifetime": "Durée de vie"
+  },
+  "whJump": {
+    "confirmOne": "Saut vers {{system}}. Marquer {{sig}} comme y menant ?",
+    "confirmMany": "Saut vers {{system}}. Quelle signature avez-vous empruntée ?",
+    "confirm": "Confirmer",
+    "differentHole": "Autre trou",
+    "unmapped": "Trou inconnu"
   }
 }

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "艦船ジャンプサイズ",
     "colTotalMass": "総質量",
     "colLifetime": "寿命"
+  },
+  "whJump": {
+    "confirmOne": "{{system}} へジャンプ。{{sig}} をそこへの接続として記録しますか？",
+    "confirmMany": "{{system}} へジャンプ。どのシグネチャを通りましたか？",
+    "confirm": "確認",
+    "differentHole": "別のホール",
+    "unmapped": "未確認のホール"
   }
 }

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "함선 점프 크기",
     "colTotalMass": "총 질량",
     "colLifetime": "수명"
+  },
+  "whJump": {
+    "confirmOne": "{{system}}(으)로 점프했습니다. {{sig}}을(를) 그곳으로 연결되는 것으로 표시할까요?",
+    "confirmMany": "{{system}}(으)로 점프했습니다. 어떤 시그니처로 점프했나요?",
+    "confirm": "확인",
+    "differentHole": "다른 웜홀",
+    "unmapped": "미확인 웜홀"
   }
 }

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "Tamanho de salto de nave",
     "colTotalMass": "Massa total",
     "colLifetime": "Vida útil"
+  },
+  "whJump": {
+    "confirmOne": "Saltou para {{system}}. Marcar {{sig}} como levando até lá?",
+    "confirmMany": "Saltou para {{system}}. Qual assinatura você usou?",
+    "confirm": "Confirmar",
+    "differentHole": "Outro buraco",
+    "unmapped": "Buraco desconhecido"
   }
 }

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1531,5 +1531,12 @@
     "colShipSize": "Размер прыжка корабля",
     "colTotalMass": "Общая масса",
     "colLifetime": "Время жизни"
+  },
+  "whJump": {
+    "confirmOne": "Прыжок в {{system}}. Отметить {{sig}} как ведущую туда?",
+    "confirmMany": "Прыжок в {{system}}. Через какую сигнатуру вы прыгнули?",
+    "confirm": "Подтвердить",
+    "differentHole": "Другая дыра",
+    "unmapped": "Неизвестная дыра"
   }
 }

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1493,5 +1493,12 @@
     "colShipSize": "舰船跳跃尺寸",
     "colTotalMass": "总质量",
     "colLifetime": "寿命"
+  },
+  "whJump": {
+    "confirmOne": "跳到 {{system}}。将 {{sig}} 标记为通往该系统？",
+    "confirmMany": "跳到 {{system}}。你跳的是哪个信号？",
+    "confirm": "确认",
+    "differentHole": "其他虫洞",
+    "unmapped": "未知虫洞"
   }
 }

--- a/wh_jump_confirm_feature.md
+++ b/wh_jump_confirm_feature.md
@@ -1,0 +1,125 @@
+# Wormhole jump-confirm: auto-populate leads-to
+
+## Goal
+
+When a tracked character jumps through a wormhole, let the user confirm which
+signature they jumped, and populate that sig's `wh_leads_to` from the class of
+the system they arrived in. Non-blocking, confirm-on-commit (never optimistic).
+
+## Why confirm, not auto + undo
+
+- "One *known* wormhole sig" != "one wormhole" — the real hole may be unmapped,
+  so silently stapling leads-to onto the known sig can mis-attribute.
+- Sig writes are not silent: `createSignature` / `updateSignature` always
+  `publishToMap('sig.changed')` + `syncSignature` (live-sync to every client +
+  cross-map), and setting a non-empty `whLeadsTo` fires `flushK162` → the held
+  Discord notice goes out (`mapWrite.ts:47,81,85`; `maps.ts:1833`).
+- So an optimistic write broadcasts (and may Discord-ping) wrong intel before
+  anyone confirms. nexum already *holds* the K162 notice until leads-to is
+  known — confirm-on-commit matches that existing philosophy.
+
+## Trigger (all must hold)
+
+1. A **tracked jump** A→B fired in `applyJump` (location tracking, jumper's
+   client only — inherently per-client).
+2. The jump is a **wormhole jump**. v1 detects this client-side as "the jump
+   touches w-space" (`eveSystemId >= 31_000_000` on either end) — w-space has no
+   stargates, so such a jump is necessarily through a hole. (k<->k wormhole
+   jumps need the server's gate classification to separate from gate jumps —
+   out of scope for v1.)
+3. The same gate `applyJump` uses for auto-add: `canAdd = trackJumps &&
+   !map.locked && canEdit`. Turning off jump tracking opts out of prompts too.
+4. A has **>= 1 known wormhole signature** (`sig_type = 'wormhole'`) that could
+   plausibly lead to the arrival (see candidate rule). Unknowns are never
+   touched — per design. Fires on any qualifying jump, not just a new
+   connection — a class-only hole still needs upgrading even on a known route.
+
+If any fail: do nothing (silent). Never prompt on a gate jump or when there is
+nothing fillable.
+
+## Candidate selection
+
+`wh_leads_to` (see `LeadsToDropdown`) can hold: blank/`unknown`, a class/band
+(`C1-C3`, `C4-C5`, `C6`, `HS`, `Thera`, …), a legacy exact class (`C3`), or a
+**specific connected-system name** (`J203753`).
+
+- **Candidates = A's wormhole sigs (`sig_type = 'wormhole'`) that are NOT yet
+  pinned to a system AND are class-compatible with the arrival.**
+  - Pinned-to-a-system (value not in the class/band/unknown set) → excluded; we
+    already know where it leads. This is the "solved" signal.
+  - `isCandidate` = value in `CLASS_OR_UNKNOWN`, and (blank/`unknown`, or equals
+    the arrival's band / legacy exact class). A hole pinned to a *different*
+    class can't be the one jumped → excluded.
+- Exactly one candidate → **pre-select it**; confirm is a single tap.
+  Several → one button per candidate + an **"unmapped hole"** skip.
+
+## What confirm writes
+
+- Sets `wh_leads_to` to the **arrival system name** (`toName`, e.g. `J203753`) —
+  the genuine upgrade from class → specific system, via the existing sig PATCH.
+- Then calls `reevaluateConnectionsForSystem` (the same auto-detect the sig pane
+  runs on edit), so the **map connection edge picks up this sig's WH type** now
+  that the hole resolves to the destination system. Without this the leads-to is
+  set but the edge stays unlabelled.
+
+## UI: sticky actionable toast (not a modal, not the current toast)
+
+The current toaster is text-only, auto-dismiss 3-7s, click-to-close
+(`Toaster.tsx`). Extend it minimally:
+
+- `toast.confirm({ msg, actions: {label, kind?, onClick}[], sticky: true })`
+  - `actions`: renders a button row inside the toast.
+  - `sticky`: no auto-dismiss; stays until an action is taken or it is
+    explicitly closed. (Keep existing `error/info/success` unchanged.)
+- Single (pre-selected) case:
+  `Jumped to C4. Set ABC-123 -> C4?  [Confirm] [Different hole] [x]`
+- Multiple case — **one button per eligible candidate, no cap**. Eligible =
+  known wormhole sigs with unknown leads-to (solved holes are excluded), so if
+  A has 8 unknown holes, show 8:
+  `Which hole did you take into C4?  [ABC-123] [DEF-456] ... [Unmapped] [x]`
+  Buttons wrap to multiple rows; in practice the eligible count is small
+  because solved holes drop out.
+- Guardrails: never auto-dismiss a pending decision; one prompt per jump;
+  jumper-only; anchored to "the jump from A" so it stays valid if the user
+  jumps onward before answering.
+
+## Write-on-commit
+
+On the user's pick, write through the **existing** endpoint so sync + Discord
+behave normally — just with confirmed data:
+
+`PATCH /api/maps/:mapId/systems/:systemId/signatures/:sigId` with
+`{ whLeadsTo: B.systemClass }` (same call as `SignaturePane.tsx:377`).
+
+Nothing is written (no live-sync, no Discord) until they confirm. "Unmapped" /
+dismiss writes nothing. Manual entry via SignaturePane remains the fallback.
+
+## Edge cases
+
+- Poll latency (~10s): the prompt references A + the sig, so it survives the
+  user moving on; the write targets A's sig regardless of current location.
+- Re-render safety: dedupe by (jumpFromSystemId, arrivalEveSystemId) so React
+  re-renders don't re-toast the same jump.
+- leads-to already set on the sole candidate → no prompt.
+- Readonly / locked map / no-track → no prompt (same gate as auto-add).
+- Reverse side (optional, later): also offer to drop the K162 on B leading to
+  A's class. Out of scope for v1.
+
+## Files
+
+- `web/src/components/ui/Toaster.tsx` — actions + sticky support.
+- `web/src/App.css` — toast action-button styling.
+- `web/src/hooks/useLocationTracking.ts` (`applyJump`) — detect non-gate jump,
+  fetch A's sigs (`GET /api/maps/:mapId/systems/:systemId/signatures`), narrow,
+  raise the confirm toast.
+- (maybe) `web/src/hooks/useWhJumpConfirm.ts` — extract the candidate/narrow
+  logic so `applyJump` stays lean and it's unit-testable.
+- `web/src/i18n/locales/*/common.json` — new strings in all 9 locales
+  (parity-checked).
+
+## Out of scope (v1)
+
+- Touching unknown/unscanned sigs.
+- Writing `wh_type` (the code still needs scanning — only leads-to is inferable).
+- Reverse-side K162 auto-drop.
+- Capital-jump / filament inference.


### PR DESCRIPTION
## What

When a tracked character jumps through a wormhole, a sticky, non-blocking toast asks which signature in the source system they jumped. Confirming pins that sig's leads-to to the **specific arrival system** and stamps the map connection edge with the sig's WH type.

Confirm-on-commit (never optimistic): nothing live-syncs or pings Discord until the user picks — the app already holds the K162 notice until leads-to is known, and this matches that.

## Behaviour

- Fires on any wormhole jump (jump touches w-space → guaranteed-hole; `applyJump` is the chokepoint, so real ESI tracking and `nexumDebug.simulateJumps` both hit it).
- **Candidates** = source-system wormhole sigs not yet pinned to a system, whose class/band is compatible with where you arrived. Holes already pinned to a system are excluded ("solved"); unknown/`C1-C3`/`C3` etc. are offered.
- One candidate → one-tap confirm; several → one button per hole + an "unmapped hole" escape.
- On confirm: PATCH `wh_leads_to` = arrival system name, then `reevaluateConnectionsForSystem` so the edge shows the WH type.

## Toaster

Extended `Toaster` with optional `actions` (buttons) + a `sticky` flag + `dedupeKey`. Existing `error/info/success` unchanged.

## i18n

`whJump.*` added to all 9 locales (parity-checked).

## Scope / notes

- v1 detects "wormhole jump" as "touches w-space"; k<->k wormhole jumps (need server gate data) are out of scope.
- Verified via the jump simulator: toast → confirm → leads-to pinned → edge labelled. The real ESI-tracking path runs through the same `applyJump` but wasn't exercised live.
- Spec: `wh_jump_confirm_feature.md`.

Web `tsc -b` passes; lint clean (pre-existing Toaster warnings only).