### PR TITLE
Minor UI fixes: notes Enter, selection highlight, single-click select

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2722,8 +2722,11 @@
   border-color: var(--intel-color);
   border-width: 4px;
 
-  &:hover,
-  &[data-selected='true'] {
+  /* Hover keeps the intel colour (toggling borders on hover read as jumpy).
+     Selection is intentionally NOT held here so a selected node falls through
+     to the white highlight from the base rules — otherwise a selected
+     "occupied" system stays orange and is indistinguishable from the tag. */
+  &:hover {
     border-color: var(--intel-color);
   }
 }
@@ -2825,9 +2828,13 @@
     box-shadow: 0 0 12px color-mix(in srgb, var(--class-color) 30%, transparent);
   }
 
+  /* Selected node: white border + soft white glow, matching the current-system
+     treatment so neither collides with the orange "occupied" bezel. Kept a
+     touch lighter than data-current (below) so "where you are" still reads
+     slightly stronger; data-current wins when a node is both. */
   &[data-selected='true'] {
-    border-color: var(--class-color);
-    box-shadow: 0 0 16px color-mix(in srgb, var(--class-color) 40%, transparent);
+    border-color: #ffffff;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4), 0 0 14px rgba(255, 255, 255, 0.28);
   }
 
   &[data-home='true'] {

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -227,7 +227,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
         ...(uniformSize && uniformWidth  > 0 ? { minWidth:  uniformWidth  } : null),
         ...(uniformSize && uniformHeight > 0 ? { minHeight: uniformHeight } : null),
       } as React.CSSProperties}
-      data-selected={selected}
+      data-selected={selected || sys.selected}
       data-heat={heat ? '' : undefined}
       data-status={sys.status}
       data-intel={sys.intel ?? undefined}

--- a/web/src/components/ui/NotesEditor.tsx
+++ b/web/src/components/ui/NotesEditor.tsx
@@ -118,6 +118,16 @@ export function NotesEditor({ value, onChange, compact = false, readOnly = false
       className={`notes-editor${compact ? '' : ' notes-editor--full'}`}
       data-color-mode="dark"
       onClick={enterEdit}
+      onKeyDown={(e) => {
+        // Compact row notes (signatures / structures) behave like a plain
+        // single-line text box: Enter saves and blurs instead of inserting a
+        // newline (blur triggers the flush below). Shift+Enter still adds a line
+        // for the occasional multi-line note. The full Notes pane keeps Enter.
+        if (compact && e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          (e.target as HTMLElement).blur();
+        }
+      }}
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node)) { flush(); setFocused(false); }
       }}


### PR DESCRIPTION
Three small UI fixes.

## Signature notes: Enter saves + blurs
Compact row notes (signatures / structures) now behave like a plain text box — **Enter** saves and blurs instead of inserting a newline; **Shift+Enter** still adds a line. The full Notes pane (markdown) is unchanged.

## Selected / current system highlight
`[data-selected]` and `[data-current]` now use a **white border + soft white glow** instead of class/gold colours, so they no longer read like the orange "occupied" intel bezel. Selection deliberately falls through the `[data-intel]` override (so a selected occupied system is distinguishable); `:hover` keeps the intel colour to avoid jumpy border toggling. Current keeps a slightly stronger glow, and the green you-are-here dot still distinguishes it from merely-selected.

## Single click selects a node
`data-selected` now reflects the store selection as well as ReactFlow's: `selected || sys.selected`. Previously a single click set `selectedSystemId`, which triggered the systems→nodes rebuild and wiped ReactFlow's just-set `selected` flag — so it took two clicks. Multi-select (shift-click) still works via ReactFlow's flag.

Web `tsc -b` passes.