### PR TITLE
Bump version to 1.14.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
Version bump to **1.14.0** (server + web). Catches the release tag up to everything merged since v1.11.0 — 1.12.0 and 1.13.0 were bumped in `package.json` but never tagged, so v1.14.0 covers them all.

## Proposed v1.14.0 release notes

### Shattered systems
- Shattered wormhole systems (every planet is Planet (Shattered): C13 frigate holes, Drifter holes, shattered C1–C6) now carry a fragments icon on the map node. Seeded from the SDE; tooltip in all 9 locales.

### Wormhole jump-confirm
- On a tracked wormhole jump, a sticky non-blocking toast asks which signature you jumped and pins that hole's leads-to to the specific arrival system, then stamps the connection edge with the hole's WH type. Confirm-on-commit — nothing syncs/pings until you pick.

### Reordering
- Drag-and-drop to reorder saved chains.
- Drag-and-drop to reorder watchlist entries.

### Fixes
- Signature/structure row notes: Enter saves and blurs instead of inserting a newline (Shift+Enter still adds a line).
- Selected and current systems now use a white border + glow so they no longer read like the orange "occupied" intel bezel.
- Single click now selects a node (was taking two — the systems→nodes rebuild was wiping the first click's selection).

## After merge
- Land this on `main` (release → main), then cut GitHub release **v1.14.0** with the notes above.