### PR TITLE
Fix Docker bootstrap: importer must not create app-table indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-comp
 
 App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automatically the first time the server boots — no manual step.
 
+> **Schema ownership.** The one-shot importer (`server/scripts/setup-db.ts`) creates only the **static/SDE** schema and its indexes (`solar_systems`, `map_stargates`, `item_types`, …) — it must not depend on app columns the server migration adds later, since the importer runs *before* the server boots. **App-table indexes are owned by `server/src/migrate.ts`**, which creates them after the app columns are guaranteed to exist. (Keeping an app-table index in the importer would crash a fresh bootstrap on a missing column.)
+
 #### Updating the SDE
 
 The static data (systems, stargates, item types, dogma — everything CCP ships in the Static Data Export) is imported into Postgres at first boot and kept current from there. Here's how it stays up to date, how to force it, and how to check which build you're on.

--- a/server/scripts/setup-db.ts
+++ b/server/scripts/setup-db.ts
@@ -431,7 +431,19 @@ async function createTables() {
     ALTER TABLE users ALTER COLUMN panel_order SET DEFAULT '{notes,signatures,anomalies,structures,npcStations}';
   `);
 
-  // Step 2: indexes (columns guaranteed to exist after step 1)
+  // Step 1.5: fix missing columns. `CREATE TABLE IF NOT EXISTS` above is a no-op
+  // when a table already exists from an older deploy, so it won't add columns
+  // introduced later by src/migrate.ts. Add the ones the importer would
+  // otherwise reference before the server migration runs. Idempotent; migrate.ts
+  // re-adds these where the app schema is fully owned.
+  await db.query(`
+    ALTER TABLE map_signatures ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+    ALTER TABLE map_structures ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+    ALTER TABLE map_anomalies  ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+  `);
+
+  // Step 2: static/SDE indexes. App-table indexes live in src/migrate.ts,
+  // where the full app schema columns are guaranteed to exist.
   await db.query(`
     CREATE INDEX IF NOT EXISTS idx_solar_systems_name          ON solar_systems (name text_pattern_ops);
     CREATE INDEX IF NOT EXISTS idx_solar_systems_constellation ON solar_systems (constellation_id);
@@ -440,17 +452,6 @@ async function createTables() {
     CREATE INDEX IF NOT EXISTS idx_item_groups_category        ON item_groups (category_id);
     CREATE INDEX IF NOT EXISTS idx_item_types_group            ON item_types (group_id);
     CREATE INDEX IF NOT EXISTS idx_item_types_name             ON item_types (name text_pattern_ops);
-    CREATE INDEX IF NOT EXISTS idx_maps_user                   ON maps (user_id);
-    CREATE INDEX IF NOT EXISTS idx_map_systems_map             ON map_systems (map_id);
-    CREATE INDEX IF NOT EXISTS idx_map_connections_map         ON map_connections (map_id);
-    CREATE INDEX IF NOT EXISTS idx_map_signatures_system       ON map_signatures (system_id);
-    CREATE INDEX IF NOT EXISTS idx_map_structures_system       ON map_structures (system_id);
-    CREATE INDEX IF NOT EXISTS idx_map_signatures_creator      ON map_signatures (created_by_user_id);
-    CREATE INDEX IF NOT EXISTS idx_map_structures_creator      ON map_structures (created_by_user_id);
-    CREATE INDEX IF NOT EXISTS idx_map_anomalies_system        ON map_anomalies (system_id);
-    CREATE INDEX IF NOT EXISTS idx_map_anomalies_creator       ON map_anomalies (created_by_user_id);
-    CREATE INDEX IF NOT EXISTS idx_user_events_map             ON user_events (map_id);
-    CREATE INDEX IF NOT EXISTS idx_maps_corp                   ON maps (corp_id);
   `);
 
   console.log('done');


### PR DESCRIPTION
## Problem
The one-shot DB importer (`server/scripts/setup-db.ts`) runs **before** the server migration. Its Step 2 created indexes on app tables/columns that `src/migrate.ts` only guarantees later — e.g. `idx_map_signatures_creator` on `map_signatures(created_by_user_id)`, a column the importer's `CREATE TABLE` doesn't include. So a fresh `docker compose up -d` could crash the importer before `migrate()` ever ran.

## Fix (setup-db.ts only — migrate.ts untouched)
- **Step 2 now creates only static/SDE indexes** (`solar_systems`, `map_stargates`, `item_*`). The 11 app-table indexes (`idx_maps_user`, `idx_map_*`, `idx_user_events_map`, `idx_maps_corp`) are removed here — they're already owned by `src/migrate.ts`, which runs after the app schema exists. Verified migrate.ts has all 11 + the `created_by_user_id` ALTERs.
- **Step 1.5** added: `ALTER TABLE … ADD COLUMN IF NOT EXISTS created_by_user_id` on `map_signatures` / `map_structures` / `map_anomalies`, since `CREATE TABLE IF NOT EXISTS` won't add the column to a pre-existing table. Idempotent.
- Step 2 comment updated to state the ownership split.
- **README**: documents the importer (static/SDE schema) vs `migrate.ts` (app schema + its indexes) split.

## Validation
- `git diff --check` clean.
- `cd server && yarn build` passes.
- No app-table indexes remain in setup-db Step 2.
- No compose overlay / deployment files touched.

(Reported + tested by the user in WSL and remote deploy.)