### PR TITLE
Release 1.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-comp
 
 App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automatically the first time the server boots — no manual step.
 
+> **Schema ownership.** The one-shot importer (`server/scripts/setup-db.ts`) creates only the **static/SDE** schema and its indexes (`solar_systems`, `map_stargates`, `item_types`, …) — it must not depend on app columns the server migration adds later, since the importer runs *before* the server boots. **App-table indexes are owned by `server/src/migrate.ts`**, which creates them after the app columns are guaranteed to exist. (Keeping an app-table index in the importer would crash a fresh bootstrap on a missing column.)
+
 #### Updating the SDE
 
 The static data (systems, stargates, item types, dogma — everything CCP ships in the Static Data Export) is imported into Postgres at first boot and kept current from there. Here's how it stays up to date, how to force it, and how to check which build you're on.

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/scripts/setup-db.ts
+++ b/server/scripts/setup-db.ts
@@ -431,7 +431,19 @@ async function createTables() {
     ALTER TABLE users ALTER COLUMN panel_order SET DEFAULT '{notes,signatures,anomalies,structures,npcStations}';
   `);
 
-  // Step 2: indexes (columns guaranteed to exist after step 1)
+  // Step 1.5: fix missing columns. `CREATE TABLE IF NOT EXISTS` above is a no-op
+  // when a table already exists from an older deploy, so it won't add columns
+  // introduced later by src/migrate.ts. Add the ones the importer would
+  // otherwise reference before the server migration runs. Idempotent; migrate.ts
+  // re-adds these where the app schema is fully owned.
+  await db.query(`
+    ALTER TABLE map_signatures ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+    ALTER TABLE map_structures ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+    ALTER TABLE map_anomalies  ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+  `);
+
+  // Step 2: static/SDE indexes. App-table indexes live in src/migrate.ts,
+  // where the full app schema columns are guaranteed to exist.
   await db.query(`
     CREATE INDEX IF NOT EXISTS idx_solar_systems_name          ON solar_systems (name text_pattern_ops);
     CREATE INDEX IF NOT EXISTS idx_solar_systems_constellation ON solar_systems (constellation_id);
@@ -440,17 +452,6 @@ async function createTables() {
     CREATE INDEX IF NOT EXISTS idx_item_groups_category        ON item_groups (category_id);
     CREATE INDEX IF NOT EXISTS idx_item_types_group            ON item_types (group_id);
     CREATE INDEX IF NOT EXISTS idx_item_types_name             ON item_types (name text_pattern_ops);
-    CREATE INDEX IF NOT EXISTS idx_maps_user                   ON maps (user_id);
-    CREATE INDEX IF NOT EXISTS idx_map_systems_map             ON map_systems (map_id);
-    CREATE INDEX IF NOT EXISTS idx_map_connections_map         ON map_connections (map_id);
-    CREATE INDEX IF NOT EXISTS idx_map_signatures_system       ON map_signatures (system_id);
-    CREATE INDEX IF NOT EXISTS idx_map_structures_system       ON map_structures (system_id);
-    CREATE INDEX IF NOT EXISTS idx_map_signatures_creator      ON map_signatures (created_by_user_id);
-    CREATE INDEX IF NOT EXISTS idx_map_structures_creator      ON map_structures (created_by_user_id);
-    CREATE INDEX IF NOT EXISTS idx_map_anomalies_system        ON map_anomalies (system_id);
-    CREATE INDEX IF NOT EXISTS idx_map_anomalies_creator       ON map_anomalies (created_by_user_id);
-    CREATE INDEX IF NOT EXISTS idx_user_events_map             ON user_events (map_id);
-    CREATE INDEX IF NOT EXISTS idx_maps_corp                   ON maps (corp_id);
   `);
 
   console.log('done');

--- a/server/src/routes/wormholes.ts
+++ b/server/src/routes/wormholes.ts
@@ -33,6 +33,14 @@ const CLASS_MAP: Record<number, string> = {
   25: 'pochven',
 };
 
+// Destination override by WH code, for holes the SDE leaves with dest_class=-1
+// (no standard destination attribute). C729 is the Pochven (Triglavian) hole —
+// it leads into Pochven, but CCP never set its destination class in dogma, so
+// without this it would be skipped as "unmapped".
+const DEST_OVERRIDE: Record<string, string> = {
+  C729: 'pochven',
+};
+
 // Curated, non-derivable fields, keyed by WH code. Also the fallback source for
 // codes that aren't in dogma at all (e.g. K162, the generic "return side").
 interface CuratedSpec {
@@ -110,7 +118,7 @@ async function loadSpecs(): Promise<Record<string, WormholeSpec>> {
     for (const row of rows) {
       const code = row.name.replace(/^Wormhole\s+/, '');
       const destNum = row.dest_class != null ? Math.round(parseFloat(row.dest_class)) : null;
-      const dest = destNum != null ? CLASS_MAP[destNum] : null;
+      const dest = (destNum != null ? CLASS_MAP[destNum] : null) ?? DEST_OVERRIDE[code] ?? null;
       if (!dest) { unmapped.push(`${code} (dest_class=${row.dest_class})`); continue; }
 
       const cur = curated[code];

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.15.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
Patch release — two bug fixes, no functional changes. Version bumped 1.15.1 → **1.15.2** (server + web).

## Fixes
- **Docker bootstrap** (#333): the one-shot importer no longer creates app-table indexes (which referenced columns `src/migrate.ts` only adds later), so a fresh `docker compose up -d` no longer risks failing before the server migration runs. App-table indexes stay owned by `migrate.ts`.
- **C729 wormhole → Pochven** (#334): C729 (the Triglavian hole) ships with `dest_class=-1` in the SDE and was being skipped as unmapped; a per-code override now resolves it to Pochven, clearing the boot warning and serving the hole correctly.

## After merge
- Cut GitHub release / tag **v1.15.2**.