### PR TITLE
Jump-confirm: handle k-space (HS↔HS) wormhole jumps + auto-fill single hole

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -157,6 +157,7 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
     }
   }
 
+  let jumpConnId: string | null = null;
   if (canAdd && prevMapSystemId && prevMapSystemId !== mapSystemId && map.systems.some((s) => s.id === prevMapSystemId)) {
     const freshConnections = useMapStore.getState().map.connections;
     const existingConn = freshConnections.find(
@@ -167,6 +168,7 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
     if (existingConn) {
       // Physically jumping the link is proof it's live — un-quarantine if broken.
       if (existingConn.broken) updateConnection(existingConn.id, { broken: false });
+      jumpConnId = existingConn.id;
     } else {
       const placed = useMapStore.getState().map.systems;
       const srcPos = placed.find((s) => s.id === prevMapSystemId)?.position;
@@ -174,16 +176,15 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
       const { sourceHandle, targetHandle } = srcPos && tgtPos
         ? pickHandles(srcPos, tgtPos)
         : { sourceHandle: 'right' as const, targetHandle: 'left' as const };
-      addConnection(prevMapSystemId, mapSystemId, sourceHandle, targetHandle);
+      jumpConnId = addConnection(prevMapSystemId, mapSystemId, sourceHandle, targetHandle);
     }
   }
 
   // A jump resolved — real tracking and the jump simulator both funnel through
-  // here. If it's a wormhole jump, offer to pin the source system's hole to
-  // where it led. Fires regardless of whether the connection was new (so a
-  // class-only hole still gets upgraded to the specific system); holes already
-  // pinned to a system are filtered out inside whJumpConfirm. Fire-and-forget.
-  if (canAdd && prevMapSystemId && prevMapSystemId !== mapSystemId) {
+  // here. If it crossed a wormhole (not a stargate — whJumpConfirm checks the
+  // stargate route between the two systems), record where the source's hole
+  // leads. Holes already pinned to a system are filtered out inside whJumpConfirm.
+  if (jumpConnId && prevMapSystemId) {
     const fromSys = map.systems.find((s) => s.id === prevMapSystemId);
     void maybeConfirmWhJump({
       mapId:           map.id,

--- a/web/src/hooks/whJumpConfirm.ts
+++ b/web/src/hooks/whJumpConfirm.ts
@@ -4,16 +4,10 @@ import { reevaluateConnectionsForSystem } from '../utils/whAutoDetect';
 import i18n from '../i18n';
 import type { Signature } from '../types';
 
-// After a tracked wormhole jump, offer to record which wormhole signature in
-// the source system was the one jumped — upgrading its leads-to from a class /
-// "unknown" to the SPECIFIC system we arrived in. Confirm-on-commit: nothing is
-// written until the user picks, so no premature live-sync / Discord broadcast.
+// After a tracked wormhole jump, record which wormhole signature in the source
+// system was jumped — pinning its leads-to to the SPECIFIC arrival system. A
+// single plausible hole is filled directly (with an undo); ambiguous cases ask.
 // See wh_jump_confirm_feature.md.
-
-// W-space ids start here; w-space has no stargates, so a jump touching it is a
-// wormhole jump. (k<->k wormhole jumps need server gate data — out of v1.)
-const WSPACE_MIN_ID = 31_000_000;
-const isWspace = (eveId: number | null): boolean => eveId !== null && eveId >= WSPACE_MIN_ID;
 
 // The leads-to values that are class/band/unknown rather than a pinned system
 // (see LeadsToDropdown). Anything NOT in here is a specific connected-system
@@ -54,8 +48,19 @@ export interface WhJumpContext {
 export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
   const { mapId, fromMapSystemId, fromEveSystemId, toEveSystemId, toClass, toName } = ctx;
 
-  // Only when the jump involves w-space (guaranteed-wormhole).
-  if (!isWspace(fromEveSystemId) && !isWspace(toEveSystemId)) return;
+  // Wormhole jump only. Use the stargate route: directly gate-adjacent systems
+  // are exactly 1 jump apart, so a shortest route of 1 means it was a gate, not
+  // a hole. Anything > 1 jump — or no gate path at all, which includes ALL
+  // w-space (no stargates) — means a wormhole. Race-free vs reading the
+  // connection's async gate classification.
+  if (fromEveSystemId && toEveSystemId) {
+    try {
+      const r = await api<Record<string, { jumps: number }>>(
+        `/api/route?from=${fromEveSystemId}&to=${toEveSystemId}&mode=shortest`,
+      );
+      if (r[String(toEveSystemId)]?.jumps === 1) return; // adjacent → gate jump
+    } catch { /* route unavailable — fall through and treat as a wormhole */ }
+  }
 
   let sigs: Signature[];
   try {
@@ -73,27 +78,28 @@ export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
   const label = (s: Signature): string => s.sigId || s.whType || s.name || '???';
   const dedupeKey = `whjump:${fromMapSystemId}->${toEveSystemId ?? '?'}`;
 
-  // Pin the hole to the specific arrival system (the dropdown stores the
-  // connected-system name as the leads-to value), then re-run the same
-  // connection auto-detect the sig pane uses on edit — so the map edge picks up
-  // this sig's WH type now that the hole resolves to the destination system.
-  const setLeadsTo = (s: Signature): void => {
+  // Write a hole's leads-to and re-run the same connection auto-detect the sig
+  // pane uses on edit, so the map edge picks up the WH type. `oldSig` is the
+  // pre-write state — it lets the auto-detect follow/clear the right link.
+  const writeLeadsTo = (s: Signature, value: string, oldSig: Signature): void => {
     api(`/api/maps/${mapId}/systems/${fromMapSystemId}/signatures/${s.id}`, {
       method: 'PATCH',
-      body:   JSON.stringify({ whLeadsTo: toName }),
+      body:   JSON.stringify({ whLeadsTo: value }),
     }).catch(() => { /* best-effort; the user can still set it by hand */ });
-    const updated = sigs.map((x) => (x.id === s.id ? { ...x, whLeadsTo: toName } : x));
-    reevaluateConnectionsForSystem(fromMapSystemId, updated, s);
+    const updated = sigs.map((x) => (x.id === s.id ? { ...x, whLeadsTo: value } : x));
+    reevaluateConnectionsForSystem(fromMapSystemId, updated, oldSig);
   };
 
-  // One plausible hole → one-tap confirm; several → one button per candidate.
+  // One plausible hole → fill it directly (no prompt), with an undo. Several →
+  // ask which one (no safe way to guess).
   if (candidates.length === 1) {
     const sole = candidates[0];
-    toast.show(t('whJump.confirmOne', { sig: label(sole), system: toName }), {
-      kind: 'info', sticky: true, dedupeKey,
+    const prev = sole.whLeadsTo;
+    writeLeadsTo(sole, toName, sole);
+    toast.show(t('whJump.filled', { sig: label(sole), system: toName }), {
+      kind: 'success', dedupeKey, ttlMs: 8000,
       actions: [
-        { label: t('whJump.confirm'),       primary: true, onClick: () => setLeadsTo(sole) },
-        { label: t('whJump.differentHole'),                onClick: () => { /* skip */ } },
+        { label: t('whJump.undo'), onClick: () => writeLeadsTo(sole, prev, { ...sole, whLeadsTo: toName }) },
       ],
     });
     return;
@@ -102,7 +108,7 @@ export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
   toast.show(t('whJump.confirmMany', { system: toName }), {
     kind: 'info', sticky: true, dedupeKey,
     actions: [
-      ...candidates.map((s) => ({ label: label(s), onClick: () => setLeadsTo(s) })),
+      ...candidates.map((s) => ({ label: label(s), onClick: () => writeLeadsTo(s, toName, s) })),
       { label: t('whJump.unmapped'), onClick: () => { /* skip */ } },
     ],
   });

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "Sprung nach {{system}}. Welche Signatur warst du?",
     "confirm": "Bestätigen",
     "differentHole": "Anderes Loch",
-    "unmapped": "Unbekanntes Loch"
+    "unmapped": "Unbekanntes Loch",
+    "filled": "{{sig}} führt jetzt nach {{system}}",
+    "undo": "Rückgängig"
   },
   "labelsDialog": {
     "title": "Eigene Labels",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1513,6 +1513,8 @@
     "confirmMany": "Jumped to {{system}}. Which signature did you jump?",
     "confirm": "Confirm",
     "differentHole": "Different hole",
-    "unmapped": "Unmapped hole"
+    "unmapped": "Unmapped hole",
+    "filled": "{{sig}} now leads to {{system}}",
+    "undo": "Undo"
   }
 }

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "Saltaste a {{system}}. ¿Qué firma usaste?",
     "confirm": "Confirmar",
     "differentHole": "Otro agujero",
-    "unmapped": "Agujero desconocido"
+    "unmapped": "Agujero desconocido",
+    "filled": "{{sig}} ahora lleva a {{system}}",
+    "undo": "Deshacer"
   },
   "labelsDialog": {
     "title": "Etiquetas personalizadas",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "Saut vers {{system}}. Quelle signature avez-vous empruntée ?",
     "confirm": "Confirmer",
     "differentHole": "Autre trou",
-    "unmapped": "Trou inconnu"
+    "unmapped": "Trou inconnu",
+    "filled": "{{sig}} mène maintenant vers {{system}}",
+    "undo": "Annuler"
   },
   "labelsDialog": {
     "title": "Labels personnalisés",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "{{system}} へジャンプ。どのシグネチャを通りましたか？",
     "confirm": "確認",
     "differentHole": "別のホール",
-    "unmapped": "未確認のホール"
+    "unmapped": "未確認のホール",
+    "filled": "{{sig}} は {{system}} へ通じます",
+    "undo": "元に戻す"
   },
   "labelsDialog": {
     "title": "カスタムラベル",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "{{system}}(으)로 점프했습니다. 어떤 시그니처로 점프했나요?",
     "confirm": "확인",
     "differentHole": "다른 웜홀",
-    "unmapped": "미확인 웜홀"
+    "unmapped": "미확인 웜홀",
+    "filled": "{{sig}}이(가) 이제 {{system}}(으)로 연결됩니다",
+    "undo": "실행 취소"
   },
   "labelsDialog": {
     "title": "사용자 라벨",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "Saltou para {{system}}. Qual assinatura você usou?",
     "confirm": "Confirmar",
     "differentHole": "Outro buraco",
-    "unmapped": "Buraco desconhecido"
+    "unmapped": "Buraco desconhecido",
+    "filled": "{{sig}} agora leva a {{system}}",
+    "undo": "Desfazer"
   },
   "labelsDialog": {
     "title": "Etiquetas personalizadas",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1553,7 +1553,9 @@
     "confirmMany": "Прыжок в {{system}}. Через какую сигнатуру вы прыгнули?",
     "confirm": "Подтвердить",
     "differentHole": "Другая дыра",
-    "unmapped": "Неизвестная дыра"
+    "unmapped": "Неизвестная дыра",
+    "filled": "{{sig}} теперь ведёт в {{system}}",
+    "undo": "Отменить"
   },
   "labelsDialog": {
     "title": "Свои метки",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1515,7 +1515,9 @@
     "confirmMany": "跳到 {{system}}。你跳的是哪个信号？",
     "confirm": "确认",
     "differentHole": "其他虫洞",
-    "unmapped": "未知虫洞"
+    "unmapped": "未知虫洞",
+    "filled": "{{sig}} 现在通往 {{system}}",
+    "undo": "撤销"
   },
   "labelsDialog": {
     "title": "自定义标签",


### PR DESCRIPTION
## Bugs
1. **HS→HS (and any k-space↔k-space) wormhole jump did nothing.** The jump-confirm only fired when the jump *touched w-space* (a v1 shortcut), so jumping Jita→Amarr through an A641 never prompted or filled. Reported + reproduced by the user.
2. Even when it recognised the only possible hole, it didn't fill the connected system in the sig panel.

## Fix
- **Wormhole detection via the stargate router** (per the user's suggestion — simpler and race-free vs reading the connection's async gate classification): query `/api/route?...&mode=shortest`. A shortest route of **1 jump** = gate-adjacent → it was a gate, skip. **>1 jump, or no gate path** (which includes *all* w-space, since it has no stargates) → wormhole → proceed.
- **Single plausible hole → fill directly** (with an **Undo** toast), instead of a confirm prompt. Ambiguous (multiple candidate) cases still ask which hole was jumped.

New strings `whJump.filled` / `whJump.undo` in all 9 locales (parity-checked). Web `tsc -b` + lint pass.

## Note / edge
A wormhole that happens to connect two *gate-adjacent* systems would read as 1 jump and be treated as a gate (skipped) — an accepted trade-off of the "route > 1 = wormhole" heuristic.