### PR TITLE
Fix gate misclassification race on jump-created connections

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -299,12 +299,16 @@ export async function migrate() {
     -- stargate-adjacent in the SDE and which carries no wormhole type is a
     -- gate. Only 'standard' rows are touched — connections the user marked
     -- 'jumpgate' stay Ansiblex, and an explicit wormhole type is preserved.
-    -- Guarded by applied_migrations so it runs once and never re-flips a manual
-    -- correction. New connections are classified the same way at creation time.
+    -- Guarded by applied_migrations so it runs once per version and never
+    -- re-flips a manual correction. New connections are classified the same way
+    -- at creation time. Bumped to v3 to re-sweep gates that a create-time race
+    -- (connection classified before the just-jumped-to system row committed)
+    -- left mis-tagged as 'standard'; the race itself is fixed by passing the
+    -- endpoints' eve ids on the connection POST.
     DO $gateclassify$
     BEGIN
       IF to_regclass('public.map_stargates') IS NOT NULL
-         AND NOT EXISTS (SELECT 1 FROM applied_migrations WHERE name = 'gate_classify_v2') THEN
+         AND NOT EXISTS (SELECT 1 FROM applied_migrations WHERE name = 'gate_classify_v3') THEN
         UPDATE map_connections c
            SET connection_type = 'gate'
           FROM map_systems s, map_systems t
@@ -317,7 +321,7 @@ export async function migrate() {
               WHERE (g.system_id = s.eve_system_id AND g.destination_system_id = t.eve_system_id)
                  OR (g.system_id = t.eve_system_id AND g.destination_system_id = s.eve_system_id)
            );
-        INSERT INTO applied_migrations(name) VALUES ('gate_classify_v2');
+        INSERT INTO applied_migrations(name) VALUES ('gate_classify_v3');
       END IF;
     END
     $gateclassify$;

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1604,7 +1604,7 @@ mapsRouter.delete('/:mapId/systems/:systemId', async (req, res) => {
 
 mapsRouter.post('/:mapId/connections', async (req, res) => {
   const { mapId } = req.params;
-  const { id, sourceId, targetId, sourceHandle, targetHandle, connectionType, massStatus, timeStatus, size } = req.body;
+  const { id, sourceId, targetId, sourceHandle, targetHandle, connectionType, massStatus, timeStatus, size, sourceEveId, targetEveId } = req.body;
 
   const access = await requireMapWrite(res, mapId, req);
   if (!access) return;
@@ -1617,19 +1617,36 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
   let effectiveType: string = connectionType ?? 'standard';
   if (effectiveType === 'standard') {
     try {
-      const adj = await db.query(
-        `SELECT 1 FROM map_systems s, map_systems t
-          WHERE s.id = $1 AND t.id = $2
-            AND s.eve_system_id IS NOT NULL AND t.eve_system_id IS NOT NULL
-            AND EXISTS (
-              SELECT 1 FROM map_stargates g
-               WHERE (g.system_id = s.eve_system_id AND g.destination_system_id = t.eve_system_id)
-                  OR (g.system_id = t.eve_system_id AND g.destination_system_id = s.eve_system_id)
-            )
-          LIMIT 1`,
-        [sourceId, targetId],
-      );
-      if ((adj.rowCount ?? 0) > 0) effectiveType = 'gate';
+      let adjacent = false;
+      if (typeof sourceEveId === 'number' && typeof targetEveId === 'number') {
+        // Classify straight from the eve ids the client supplied — robust to the
+        // freshly-jumped-to system's row not being committed yet (a jump POSTs
+        // the new system and this connection near-simultaneously, and the old
+        // map_systems join could race the insert and mis-tag the gate as a hole).
+        const adj = await db.query(
+          `SELECT 1 FROM map_stargates g
+            WHERE (g.system_id = $1 AND g.destination_system_id = $2)
+               OR (g.system_id = $2 AND g.destination_system_id = $1)
+            LIMIT 1`,
+          [sourceEveId, targetEveId],
+        );
+        adjacent = (adj.rowCount ?? 0) > 0;
+      } else {
+        const adj = await db.query(
+          `SELECT 1 FROM map_systems s, map_systems t
+            WHERE s.id = $1 AND t.id = $2
+              AND s.eve_system_id IS NOT NULL AND t.eve_system_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1 FROM map_stargates g
+                 WHERE (g.system_id = s.eve_system_id AND g.destination_system_id = t.eve_system_id)
+                    OR (g.system_id = t.eve_system_id AND g.destination_system_id = s.eve_system_id)
+              )
+            LIMIT 1`,
+          [sourceId, targetId],
+        );
+        adjacent = (adj.rowCount ?? 0) > 0;
+      }
+      if (adjacent) effectiveType = 'gate';
     } catch { /* stargate table absent / query failed — keep client's type */ }
   }
 

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -1007,7 +1007,13 @@ export const useMapStore = create<MapStore>()((set, get) => {
         get().pushUndo({ type: 'add_connection', connectionId: id });
         if (activeMapId) {
           const url  = `/api/maps/${activeMapId}/connections`;
-          const body = JSON.stringify({ ...conn });
+          // Pass the endpoints' eve ids so the server can gate-classify directly
+          // from map_stargates without waiting for both system rows to commit —
+          // a jump POSTs the new system and this connection near-simultaneously.
+          const systemsNow  = get().map.systems;
+          const sourceEveId = systemsNow.find((s) => s.id === conn.sourceId)?.eveSystemId ?? null;
+          const targetEveId = systemsNow.find((s) => s.id === conn.targetId)?.eveSystemId ?? null;
+          const body = JSON.stringify({ ...conn, sourceEveId, targetEveId });
           api<{ ok: boolean; connectionType?: string }>(url, { method: 'POST', body })
             .then((r) => {
               // Server may auto-classify an in-game gate (stargate-adjacent


### PR DESCRIPTION
## Bug
Gate-connected systems were sometimes drawn as wormholes (no `G` badge) — inconsistently along a single gate chain. All endpoints are genuinely stargate-adjacent in the SDE.

## Cause
A jump POSTs the new system and its connection near-simultaneously. The gate-classify query joined `map_systems` and required **both** rows committed with `eve_system_id`. When the connection's classify raced ahead of the just-jumped-to system's insert, it found no adjacency → left the gate as `standard`. There was no later recovery, so it stuck.

## Fix
- **Prevent:** the client now sends the endpoints' eve ids on the connection POST; the server classifies **directly from `map_stargates`** with those ids, so it no longer depends on the system rows being committed. Falls back to the old join when eve ids aren't supplied (manual draws between resolved systems).
- **Recover:** bump the one-time `standard → gate` backfill (`gate_classify_v2` → `v3`) so it re-runs once on next boot and fixes connections the race already mis-tagged.

Server `tsc` + web `tsc -b` pass.

> After deploy, the v3 backfill fixes existing mis-tagged gates on server boot; the eve-id change prevents new ones.