### PR TITLE
Jump-confirm: detect gates via the connection classification (redo of #341)

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -182,17 +182,16 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
 
   // A jump resolved — real tracking and the jump simulator both funnel through
   // here. If it crossed a wormhole (not a stargate — whJumpConfirm checks the
-  // stargate route between the two systems), record where the source's hole
-  // leads. Holes already pinned to a system are filtered out inside whJumpConfirm.
+  // connection's gate classification), record where the source's hole leads.
+  // Holes already pinned to a system are filtered out inside whJumpConfirm.
   if (jumpConnId && prevMapSystemId) {
-    const fromSys = map.systems.find((s) => s.id === prevMapSystemId);
     void maybeConfirmWhJump({
       mapId:           map.id,
       fromMapSystemId: prevMapSystemId,
-      fromEveSystemId: fromSys?.eveSystemId ?? null,
       toEveSystemId:   system.eveSystemId,
       toClass:         system.systemClass,
       toName:          system.name,
+      connId:          jumpConnId,
     });
   }
 

--- a/web/src/hooks/whJumpConfirm.ts
+++ b/web/src/hooks/whJumpConfirm.ts
@@ -1,6 +1,7 @@
 import { api } from '../api/client';
 import { toast } from '../components/ui/Toaster';
 import { reevaluateConnectionsForSystem } from '../utils/whAutoDetect';
+import { useMapStore, awaitConnectionType } from '../store/mapStore';
 import i18n from '../i18n';
 import type { Signature } from '../types';
 
@@ -39,28 +40,14 @@ function isCandidate(whLeadsTo: string, arrivalClass: string): boolean {
 export interface WhJumpContext {
   mapId:           string;
   fromMapSystemId: string;       // source system's map-node id (where the hole sig lives)
-  fromEveSystemId: number | null;
   toEveSystemId:   number | null;
   toClass:         string;        // arrival system's class, e.g. 'C3'
   toName:          string;        // arrival system's name, e.g. 'J203753' — what we pin the hole to
+  connId:          string | null; // the connection the jump traversed
 }
 
 export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
-  const { mapId, fromMapSystemId, fromEveSystemId, toEveSystemId, toClass, toName } = ctx;
-
-  // Wormhole jump only. Use the stargate route: directly gate-adjacent systems
-  // are exactly 1 jump apart, so a shortest route of 1 means it was a gate, not
-  // a hole. Anything > 1 jump — or no gate path at all, which includes ALL
-  // w-space (no stargates) — means a wormhole. Race-free vs reading the
-  // connection's async gate classification.
-  if (fromEveSystemId && toEveSystemId) {
-    try {
-      const r = await api<Record<string, { jumps: number }>>(
-        `/api/route?from=${fromEveSystemId}&to=${toEveSystemId}&mode=shortest`,
-      );
-      if (r[String(toEveSystemId)]?.jumps === 1) return; // adjacent → gate jump
-    } catch { /* route unavailable — fall through and treat as a wormhole */ }
-  }
+  const { mapId, fromMapSystemId, toEveSystemId, toClass, toName, connId } = ctx;
 
   let sigs: Signature[];
   try {
@@ -71,8 +58,23 @@ export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
 
   // Eligible = known wormhole sigs not yet pinned to a system, whose class is
   // compatible with where we arrived. Unknowns (non-wormhole) are never touched.
+  // Bail before the gate check when there's nothing to fill.
   const candidates = sigs.filter((s) => s.sigType === 'wormhole' && isCandidate(s.whLeadsTo, toClass));
   if (candidates.length === 0) return;
+
+  // Wormhole jump only. Use the connection's server gate classification — the
+  // same map_stargates check that draws the 'G' badge, reliable now that gates
+  // are classified from the endpoints' eve ids at create time. For a fresh
+  // connection, await the create POST's result; an existing one is already
+  // classified in the store. Proceed ONLY for a confirmed 'standard' (wormhole)
+  // — a gate / jump-bridge / unknown is left alone, so no false fills on a gate.
+  if (connId) {
+    const pending = awaitConnectionType(connId);
+    const ct = pending
+      ? await pending
+      : useMapStore.getState().map.connections.find((c) => c.id === connId)?.connectionType ?? 'standard';
+    if (ct !== 'standard') return;
+  }
 
   const t = i18n.t.bind(i18n);
   const label = (s: Signature): string => s.sigId || s.whType || s.name || '???';

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -18,6 +18,16 @@ export interface RouteOriginOverride {
 
 // Debounce position saves — fires max once per 500 ms per system
 const moveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+// Per-connection promises that resolve with the server's authoritative
+// gate/standard classification once the create POST returns. Lets the jump
+// confirm await the real type instead of racing the optimistic 'standard'
+// default. Resolves 'unknown' if the POST failed (offline) so callers can be
+// conservative. Self-cleans after settling.
+const connClassPromises = new Map<string, Promise<string>>();
+export function awaitConnectionType(id: string): Promise<string> | null {
+  return connClassPromises.get(id) ?? null;
+}
 // Per-node measured dimensions, kept out of reactive state so individual
 // ResizeObserver fires don't trigger re-renders across the whole map.
 // `countHeight` is false for systems with statics — those WH systems can
@@ -1014,19 +1024,23 @@ export const useMapStore = create<MapStore>()((set, get) => {
           const sourceEveId = systemsNow.find((s) => s.id === conn.sourceId)?.eveSystemId ?? null;
           const targetEveId = systemsNow.find((s) => s.id === conn.targetId)?.eveSystemId ?? null;
           const body = JSON.stringify({ ...conn, sourceEveId, targetEveId });
-          api<{ ok: boolean; connectionType?: string }>(url, { method: 'POST', body })
+          const classifyP = api<{ ok: boolean; connectionType?: string }>(url, { method: 'POST', body })
             .then((r) => {
               // Server may auto-classify an in-game gate (stargate-adjacent
               // systems). Reflect it locally so the chain/edge updates without
               // a reload.
-              if (r?.connectionType && r.connectionType !== 'standard') {
+              const ct = r?.connectionType ?? 'standard';
+              if (ct !== 'standard') {
                 set((s) => ({
                   map: { ...s.map, connections: s.map.connections.map((c) =>
-                    c.id === id ? { ...c, connectionType: r.connectionType as MapConnection['connectionType'] } : c) },
+                    c.id === id ? { ...c, connectionType: ct as MapConnection['connectionType'] } : c) },
                 }));
               }
+              return ct;
             })
-            .catch(() => enqueue(`addConnection:${id}`, url, 'POST', body));
+            .catch(() => { enqueue(`addConnection:${id}`, url, 'POST', body); return 'unknown'; });
+          connClassPromises.set(id, classifyP);
+          void classifyP.finally(() => connClassPromises.delete(id));
         }
       }
 


### PR DESCRIPTION
Redo of the closed #341 (jump-confirm false-filling holes on gate jumps), using the now-reliable connection gate classification instead of the rate-limited `/api/route` hack.

## Approach
- Gate vs wormhole is decided from the **connection's server classification** — the same `map_stargates` check that draws the `G` badge, reliable since #342 made gates classify from the endpoints' eve ids at create time.
- `addConnection` now exposes the create POST's classification as a promise (`awaitConnectionType(id)`), so the confirm **awaits the authoritative type** rather than racing the optimistic `standard` default. An existing connection is read straight from the store (already classified).
- Proceeds **only** for a confirmed `standard` (wormhole). Gate / jump-bridge / unknown (offline) → left alone. **No false fills on gate jumps.**
- Bails before the gate check when there are no holes to fill (so it does no extra work on plain travel), and makes no `/api/route` calls at all.

Web `tsc -b` + lint pass.