### PR TITLE
Move copy-bookmark button next to the Leads To field

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5369,6 +5369,14 @@ select.sig-toolbar-btn option {
   position: relative;
 }
 
+/* Leads-to cell: the destination picker plus the copy-bookmark button. */
+.sig-leads-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sig-leads-cell > :first-child { flex: 1; min-width: 0; }
+
 .sig-th--time {
   text-align: right;
 }

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -898,11 +898,20 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                   {sig.sigType === 'wormhole' && (
                     isShareMode
                       ? <span className="sig-text">{sig.whLeadsTo || ''}</span>
-                      : <LeadsToDropdown
-                          value={sig.whLeadsTo}
-                          connectedSystems={connectedSystems}
-                          onChange={(leadsTo) => updateSig(sig.id, { whLeadsTo: leadsTo })}
-                        />
+                      : (
+                        <div className="sig-leads-cell">
+                          <LeadsToDropdown
+                            value={sig.whLeadsTo}
+                            connectedSystems={connectedSystems}
+                            onChange={(leadsTo) => updateSig(sig.id, { whLeadsTo: leadsTo })}
+                          />
+                          <button
+                            className="icon-btn"
+                            onClick={() => copyBookmark(sig)}
+                            title={t('signatures.copyBookmark')}
+                          ><CopyIcon size={12} weight="bold" /></button>
+                        </div>
+                      )
                   )}
                 </td>
                 <td>
@@ -936,13 +945,6 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 <ElapsedCell iso={sig.updatedAt} className="sig-td--time sig-td--updated" />
                 {!isShareMode && (
                   <td className="sig-cell--actions">
-                    {sig.sigType === 'wormhole' && (
-                      <button
-                        className="icon-btn"
-                        onClick={() => copyBookmark(sig)}
-                        title={t('signatures.copyBookmark')}
-                      ><CopyIcon size={12} weight="bold" /></button>
-                    )}
                     {canEdit && (
                       <button
                         className="icon-btn icon-btn--danger"


### PR DESCRIPTION
Moves the per-row **copy bookmark name** button from the far-right actions cell to **inline beside the Leads To** picker, where it relates to the wormhole fields. The actions cell keeps only delete.

Behaviour unchanged (wormhole rows only, non-share mode); just relocated. Web `tsc -b` passes (pre-existing lint warnings only).