### PR TITLE
Dropdowns: follow page scroll + cap height so the last options are reachable

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5440,6 +5440,12 @@ select.sig-toolbar-btn option {
   border-radius: 5px;
   box-shadow: 0 12px 32px rgba(0,0,0,0.8);
   z-index: 9999;
+  /* Flex column so the search stays pinned and the list fills the height the
+     hook capped to the viewport, scrolling within — so the last options are
+     always reachable instead of running off-screen. */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .wh-picker__search {
@@ -5458,7 +5464,8 @@ select.sig-toolbar-btn option {
 .wh-picker__search::placeholder { color: #7a90a8; }
 
 .wh-picker__list {
-  max-height: 300px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: #2e4a6a transparent;

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -95,7 +95,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -95,7 +95,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', top: pos.top, left: pos.left }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/components/ui/WormholeTypePicker.tsx
+++ b/web/src/components/ui/WormholeTypePicker.tsx
@@ -155,7 +155,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/components/ui/WormholeTypePicker.tsx
+++ b/web/src/components/ui/WormholeTypePicker.tsx
@@ -155,7 +155,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', top: pos.top, left: pos.left }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -6,6 +6,19 @@ export interface PopoverPos {
   maxHeight:  number;  // available height below so the list stays on-screen + scrollable
 }
 
+// Nearest scrollable ancestor — the panel/pane the trigger lives in. Used to
+// close the dropdown once the trigger scrolls out of that container, so a fixed-
+// position dropdown never trails the (now-clipped) trigger out over the map.
+function scrollParentOf(el: HTMLElement | null): HTMLElement | null {
+  let p = el?.parentElement ?? null;
+  while (p) {
+    const oy = getComputedStyle(p).overflowY;
+    if ((oy === 'auto' || oy === 'scroll' || oy === 'overlay') && p.scrollHeight > p.clientHeight) return p;
+    p = p.parentElement;
+  }
+  return null;
+}
+
 // Shared popover plumbing for the wormhole / leads-to dropdowns. Owns the
 // open/close state, a viewport-aware position (always opens downward, follows
 // page scroll, and caps its height to the room below so the last options stay
@@ -16,6 +29,7 @@ export function usePopover() {
   const [pos, setPos]   = useState<PopoverPos>({ left: 0, top: 0, maxHeight: 300 });
   const btnRef      = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const scrollParentRef = useRef<HTMLElement | null>(null);
 
   // Recompute from the trigger's current viewport rect. Always open downward
   // (flipping up read as odd); cap the height to the room below so the dropdown
@@ -23,12 +37,24 @@ export function usePopover() {
   const reposition = useCallback(() => {
     const rect = btnRef.current?.getBoundingClientRect();
     if (!rect) return;
+    // If the trigger has scrolled out of its panel/pane (clipped invisible),
+    // close rather than trail the fixed-position dropdown out over the map.
+    const sp = scrollParentRef.current;
+    if (sp) {
+      const b = sp.getBoundingClientRect();
+      if (rect.bottom <= b.top || rect.top >= b.bottom) { setOpen(false); return; }
+    }
     const margin = 8;
-    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - margin);
-    setPos({ left: rect.left, top: rect.bottom + 2, maxHeight: spaceBelow });
+    const top = rect.bottom + 2;
+    const spaceBelow = Math.max(0, window.innerHeight - top - margin);
+    setPos({ left: rect.left, top, maxHeight: spaceBelow });
   }, []);
 
-  const openAt = useCallback(() => { reposition(); setOpen(true); }, [reposition]);
+  const openAt = useCallback(() => {
+    scrollParentRef.current = scrollParentOf(btnRef.current);
+    reposition();
+    setOpen(true);
+  }, [reposition]);
 
   // While open, keep the dropdown glued to the trigger as the page (or any
   // scroll container) scrolls or the window resizes. Capture phase so scrolls

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -1,19 +1,54 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PopoverPos {
+  left:       number;
+  top?:       number;  // set when placed below the trigger
+  bottom?:    number;  // set when flipped above the trigger (anchors its bottom)
+  maxHeight:  number;  // available height so the list stays on-screen + scrollable
+}
 
 // Shared popover plumbing for the wormhole / leads-to dropdowns. Owns the
-// open/close state, the screen-anchored position calculation, and the outside-
-// click handler — leaves the button look and dropdown contents to the caller.
+// open/close state, a viewport-aware position (follows page scroll, flips above
+// the trigger and caps its height so the last options stay reachable), and the
+// outside-click handler — leaves the button look and dropdown contents to the
+// caller.
 export function usePopover() {
   const [open, setOpen] = useState(false);
-  const [pos, setPos]   = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [pos, setPos]   = useState<PopoverPos>({ left: 0, top: 0, maxHeight: 300 });
   const btnRef      = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const openAt = () => {
+  // Recompute from the trigger's current viewport rect: place below by default,
+  // flip above when there's little room below and more above, and cap the height
+  // to the available space so the dropdown never runs off-screen.
+  const reposition = useCallback(() => {
     const rect = btnRef.current?.getBoundingClientRect();
-    if (rect) setPos({ top: rect.bottom + 2, left: rect.left });
-    setOpen(true);
-  };
+    if (!rect) return;
+    const margin = 8;
+    const spaceBelow = window.innerHeight - rect.bottom - margin;
+    const spaceAbove = rect.top - margin;
+    const flipUp = spaceBelow < 220 && spaceAbove > spaceBelow;
+    setPos(flipUp
+      ? { left: rect.left, bottom: window.innerHeight - rect.top + 2, maxHeight: Math.max(140, spaceAbove) }
+      : { left: rect.left, top: rect.bottom + 2,                      maxHeight: Math.max(140, spaceBelow) });
+  }, []);
+
+  const openAt = useCallback(() => { reposition(); setOpen(true); }, [reposition]);
+
+  // While open, keep the dropdown glued to the trigger as the page (or any
+  // scroll container) scrolls or the window resizes. Capture phase so scrolls
+  // inside nested containers are caught too.
+  useEffect(() => {
+    if (!open) return;
+    reposition();
+    const onMove = () => reposition();
+    window.addEventListener('scroll', onMove, true);
+    window.addEventListener('resize', onMove);
+    return () => {
+      window.removeEventListener('scroll', onMove, true);
+      window.removeEventListener('resize', onMove);
+    };
+  }, [open, reposition]);
 
   useEffect(() => {
     if (!open) return;

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -2,35 +2,30 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface PopoverPos {
   left:       number;
-  top?:       number;  // set when placed below the trigger
-  bottom?:    number;  // set when flipped above the trigger (anchors its bottom)
-  maxHeight:  number;  // available height so the list stays on-screen + scrollable
+  top:        number;  // always placed below the trigger
+  maxHeight:  number;  // available height below so the list stays on-screen + scrollable
 }
 
 // Shared popover plumbing for the wormhole / leads-to dropdowns. Owns the
-// open/close state, a viewport-aware position (follows page scroll, flips above
-// the trigger and caps its height so the last options stay reachable), and the
-// outside-click handler — leaves the button look and dropdown contents to the
-// caller.
+// open/close state, a viewport-aware position (always opens downward, follows
+// page scroll, and caps its height to the room below so the last options stay
+// reachable), and the outside-click handler — leaves the button look and
+// dropdown contents to the caller.
 export function usePopover() {
   const [open, setOpen] = useState(false);
   const [pos, setPos]   = useState<PopoverPos>({ left: 0, top: 0, maxHeight: 300 });
   const btnRef      = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Recompute from the trigger's current viewport rect: place below by default,
-  // flip above when there's little room below and more above, and cap the height
-  // to the available space so the dropdown never runs off-screen.
+  // Recompute from the trigger's current viewport rect. Always open downward
+  // (flipping up read as odd); cap the height to the room below so the dropdown
+  // never runs off-screen — the list scrolls within whatever height is left.
   const reposition = useCallback(() => {
     const rect = btnRef.current?.getBoundingClientRect();
     if (!rect) return;
     const margin = 8;
-    const spaceBelow = window.innerHeight - rect.bottom - margin;
-    const spaceAbove = rect.top - margin;
-    const flipUp = spaceBelow < 220 && spaceAbove > spaceBelow;
-    setPos(flipUp
-      ? { left: rect.left, bottom: window.innerHeight - rect.top + 2, maxHeight: Math.max(140, spaceAbove) }
-      : { left: rect.left, top: rect.bottom + 2,                      maxHeight: Math.max(140, spaceBelow) });
+    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - margin);
+    setPos({ left: rect.left, top: rect.bottom + 2, maxHeight: spaceBelow });
   }, []);
 
   const openAt = useCallback(() => { reposition(); setOpen(true); }, [reposition]);


### PR DESCRIPTION
## Problems
The wormhole-type / leads-to dropdowns (used across the signature, anomaly, connection panels):
1. **Couldn't scroll to the final options** — anchored at the trigger's bottom with no viewport bound, so near the bottom of a panel the list ran off-screen and its last rows were unreachable.
2. **Didn't follow the page** — position was computed once at open, so scrolling the panel left the dropdown floating in place.

## Fix (shared `usePopover`)
- Recompute the position on **scroll (capture) + resize** while open, so the dropdown stays glued to its trigger.
- **Flip above** the trigger when there's little room below, and **cap the height** to the available viewport space.
- The dropdown is now a flex column (search pinned, `.wh-picker__list` `flex:1; overflow-y:auto`), so it always fits on-screen and the list scrolls within — last options reachable.

Applies to both `LeadsToDropdown` and `WormholeTypePicker`. Web `tsc -b` + lint pass.