### PR TITLE
Release 1.16.1: gate/jump-confirm fixes, centre-map, copy-bookmark, dropdown UX

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5440,6 +5440,12 @@ select.sig-toolbar-btn option {
   border-radius: 5px;
   box-shadow: 0 12px 32px rgba(0,0,0,0.8);
   z-index: 9999;
+  /* Flex column so the search stays pinned and the list fills the height the
+     hook capped to the viewport, scrolling within — so the last options are
+     always reachable instead of running off-screen. */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .wh-picker__search {
@@ -5458,7 +5464,8 @@ select.sig-toolbar-btn option {
 .wh-picker__search::placeholder { color: #7a90a8; }
 
 .wh-picker__list {
-  max-height: 300px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: #2e4a6a transparent;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5369,6 +5369,14 @@ select.sig-toolbar-btn option {
   position: relative;
 }
 
+/* Leads-to cell: the destination picker plus the copy-bookmark button. */
+.sig-leads-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sig-leads-cell > :first-child { flex: 1; min-width: 0; }
+
 .sig-th--time {
   text-align: right;
 }

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -269,16 +269,19 @@ export function MapCanvas() {
     const flowX  = node.position.x + (node.measured?.width  ?? 150) / 2;
     const flowY  = node.position.y + (node.measured?.height ?? 80)  / 2;
 
-    const rfEl   = document.querySelector<HTMLElement>('.react-flow');
-    const panel  = document.querySelector<HTMLElement>('.system-panel');
-    const cW     = rfEl?.offsetWidth  ?? window.innerWidth;
-    const cH     = rfEl?.offsetHeight ?? window.innerHeight;
-    const panelH = panel?.offsetHeight ?? 0;
+    // The canvas (.react-flow, inside the flex:1 .map-canvas) already shrinks to
+    // the space ABOVE the bottom dock (.system-panel is a flex-shrink:0 sibling)
+    // and right of the left sidebar — so its own box IS the available canvas.
+    // Centre within it directly; subtracting the dock height again (as before)
+    // double-counted and pushed the node off the top when the dock was tall.
+    const rfEl = document.querySelector<HTMLElement>('.react-flow');
+    const cW   = rfEl?.offsetWidth  ?? window.innerWidth;
+    const cH   = rfEl?.offsetHeight ?? window.innerHeight;
 
     setViewport(
       {
         x:    cW / 2 - flowX * zoom,
-        y:    (cH - panelH) / 2 - flowY * zoom,
+        y:    cH / 2 - flowY * zoom,
         zoom,
       },
       { duration: 300 },

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -95,7 +95,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -95,7 +95,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', top: pos.top, left: pos.left }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -898,11 +898,20 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                   {sig.sigType === 'wormhole' && (
                     isShareMode
                       ? <span className="sig-text">{sig.whLeadsTo || ''}</span>
-                      : <LeadsToDropdown
-                          value={sig.whLeadsTo}
-                          connectedSystems={connectedSystems}
-                          onChange={(leadsTo) => updateSig(sig.id, { whLeadsTo: leadsTo })}
-                        />
+                      : (
+                        <div className="sig-leads-cell">
+                          <LeadsToDropdown
+                            value={sig.whLeadsTo}
+                            connectedSystems={connectedSystems}
+                            onChange={(leadsTo) => updateSig(sig.id, { whLeadsTo: leadsTo })}
+                          />
+                          <button
+                            className="icon-btn"
+                            onClick={() => copyBookmark(sig)}
+                            title={t('signatures.copyBookmark')}
+                          ><CopyIcon size={12} weight="bold" /></button>
+                        </div>
+                      )
                   )}
                 </td>
                 <td>
@@ -936,13 +945,6 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 <ElapsedCell iso={sig.updatedAt} className="sig-td--time sig-td--updated" />
                 {!isShareMode && (
                   <td className="sig-cell--actions">
-                    {sig.sigType === 'wormhole' && (
-                      <button
-                        className="icon-btn"
-                        onClick={() => copyBookmark(sig)}
-                        title={t('signatures.copyBookmark')}
-                      ><CopyIcon size={12} weight="bold" /></button>
-                    )}
                     {canEdit && (
                       <button
                         className="icon-btn icon-btn--danger"

--- a/web/src/components/ui/WormholeTypePicker.tsx
+++ b/web/src/components/ui/WormholeTypePicker.tsx
@@ -155,7 +155,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/components/ui/WormholeTypePicker.tsx
+++ b/web/src/components/ui/WormholeTypePicker.tsx
@@ -155,7 +155,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
         <div
           ref={dropdownRef}
           className="wh-picker__dropdown"
-          style={{ position: 'fixed', top: pos.top, left: pos.left }}
+          style={{ position: 'fixed', left: pos.left, top: pos.top, bottom: pos.bottom, maxHeight: pos.maxHeight }}
         >
           <input
             ref={searchRef}

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -6,6 +6,19 @@ export interface PopoverPos {
   maxHeight:  number;  // available height below so the list stays on-screen + scrollable
 }
 
+// Nearest scrollable ancestor — the panel/pane the trigger lives in. Used to
+// close the dropdown once the trigger scrolls out of that container, so a fixed-
+// position dropdown never trails the (now-clipped) trigger out over the map.
+function scrollParentOf(el: HTMLElement | null): HTMLElement | null {
+  let p = el?.parentElement ?? null;
+  while (p) {
+    const oy = getComputedStyle(p).overflowY;
+    if ((oy === 'auto' || oy === 'scroll' || oy === 'overlay') && p.scrollHeight > p.clientHeight) return p;
+    p = p.parentElement;
+  }
+  return null;
+}
+
 // Shared popover plumbing for the wormhole / leads-to dropdowns. Owns the
 // open/close state, a viewport-aware position (always opens downward, follows
 // page scroll, and caps its height to the room below so the last options stay
@@ -16,6 +29,7 @@ export function usePopover() {
   const [pos, setPos]   = useState<PopoverPos>({ left: 0, top: 0, maxHeight: 300 });
   const btnRef      = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const scrollParentRef = useRef<HTMLElement | null>(null);
 
   // Recompute from the trigger's current viewport rect. Always open downward
   // (flipping up read as odd); cap the height to the room below so the dropdown
@@ -23,12 +37,24 @@ export function usePopover() {
   const reposition = useCallback(() => {
     const rect = btnRef.current?.getBoundingClientRect();
     if (!rect) return;
+    // If the trigger has scrolled out of its panel/pane (clipped invisible),
+    // close rather than trail the fixed-position dropdown out over the map.
+    const sp = scrollParentRef.current;
+    if (sp) {
+      const b = sp.getBoundingClientRect();
+      if (rect.bottom <= b.top || rect.top >= b.bottom) { setOpen(false); return; }
+    }
     const margin = 8;
-    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - margin);
-    setPos({ left: rect.left, top: rect.bottom + 2, maxHeight: spaceBelow });
+    const top = rect.bottom + 2;
+    const spaceBelow = Math.max(0, window.innerHeight - top - margin);
+    setPos({ left: rect.left, top, maxHeight: spaceBelow });
   }, []);
 
-  const openAt = useCallback(() => { reposition(); setOpen(true); }, [reposition]);
+  const openAt = useCallback(() => {
+    scrollParentRef.current = scrollParentOf(btnRef.current);
+    reposition();
+    setOpen(true);
+  }, [reposition]);
 
   // While open, keep the dropdown glued to the trigger as the page (or any
   // scroll container) scrolls or the window resizes. Capture phase so scrolls

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -1,19 +1,54 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PopoverPos {
+  left:       number;
+  top?:       number;  // set when placed below the trigger
+  bottom?:    number;  // set when flipped above the trigger (anchors its bottom)
+  maxHeight:  number;  // available height so the list stays on-screen + scrollable
+}
 
 // Shared popover plumbing for the wormhole / leads-to dropdowns. Owns the
-// open/close state, the screen-anchored position calculation, and the outside-
-// click handler — leaves the button look and dropdown contents to the caller.
+// open/close state, a viewport-aware position (follows page scroll, flips above
+// the trigger and caps its height so the last options stay reachable), and the
+// outside-click handler — leaves the button look and dropdown contents to the
+// caller.
 export function usePopover() {
   const [open, setOpen] = useState(false);
-  const [pos, setPos]   = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [pos, setPos]   = useState<PopoverPos>({ left: 0, top: 0, maxHeight: 300 });
   const btnRef      = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const openAt = () => {
+  // Recompute from the trigger's current viewport rect: place below by default,
+  // flip above when there's little room below and more above, and cap the height
+  // to the available space so the dropdown never runs off-screen.
+  const reposition = useCallback(() => {
     const rect = btnRef.current?.getBoundingClientRect();
-    if (rect) setPos({ top: rect.bottom + 2, left: rect.left });
-    setOpen(true);
-  };
+    if (!rect) return;
+    const margin = 8;
+    const spaceBelow = window.innerHeight - rect.bottom - margin;
+    const spaceAbove = rect.top - margin;
+    const flipUp = spaceBelow < 220 && spaceAbove > spaceBelow;
+    setPos(flipUp
+      ? { left: rect.left, bottom: window.innerHeight - rect.top + 2, maxHeight: Math.max(140, spaceAbove) }
+      : { left: rect.left, top: rect.bottom + 2,                      maxHeight: Math.max(140, spaceBelow) });
+  }, []);
+
+  const openAt = useCallback(() => { reposition(); setOpen(true); }, [reposition]);
+
+  // While open, keep the dropdown glued to the trigger as the page (or any
+  // scroll container) scrolls or the window resizes. Capture phase so scrolls
+  // inside nested containers are caught too.
+  useEffect(() => {
+    if (!open) return;
+    reposition();
+    const onMove = () => reposition();
+    window.addEventListener('scroll', onMove, true);
+    window.addEventListener('resize', onMove);
+    return () => {
+      window.removeEventListener('scroll', onMove, true);
+      window.removeEventListener('resize', onMove);
+    };
+  }, [open, reposition]);
 
   useEffect(() => {
     if (!open) return;

--- a/web/src/hooks/usePopover.ts
+++ b/web/src/hooks/usePopover.ts
@@ -2,35 +2,30 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface PopoverPos {
   left:       number;
-  top?:       number;  // set when placed below the trigger
-  bottom?:    number;  // set when flipped above the trigger (anchors its bottom)
-  maxHeight:  number;  // available height so the list stays on-screen + scrollable
+  top:        number;  // always placed below the trigger
+  maxHeight:  number;  // available height below so the list stays on-screen + scrollable
 }
 
 // Shared popover plumbing for the wormhole / leads-to dropdowns. Owns the
-// open/close state, a viewport-aware position (follows page scroll, flips above
-// the trigger and caps its height so the last options stay reachable), and the
-// outside-click handler — leaves the button look and dropdown contents to the
-// caller.
+// open/close state, a viewport-aware position (always opens downward, follows
+// page scroll, and caps its height to the room below so the last options stay
+// reachable), and the outside-click handler — leaves the button look and
+// dropdown contents to the caller.
 export function usePopover() {
   const [open, setOpen] = useState(false);
   const [pos, setPos]   = useState<PopoverPos>({ left: 0, top: 0, maxHeight: 300 });
   const btnRef      = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Recompute from the trigger's current viewport rect: place below by default,
-  // flip above when there's little room below and more above, and cap the height
-  // to the available space so the dropdown never runs off-screen.
+  // Recompute from the trigger's current viewport rect. Always open downward
+  // (flipping up read as odd); cap the height to the room below so the dropdown
+  // never runs off-screen — the list scrolls within whatever height is left.
   const reposition = useCallback(() => {
     const rect = btnRef.current?.getBoundingClientRect();
     if (!rect) return;
     const margin = 8;
-    const spaceBelow = window.innerHeight - rect.bottom - margin;
-    const spaceAbove = rect.top - margin;
-    const flipUp = spaceBelow < 220 && spaceAbove > spaceBelow;
-    setPos(flipUp
-      ? { left: rect.left, bottom: window.innerHeight - rect.top + 2, maxHeight: Math.max(140, spaceAbove) }
-      : { left: rect.left, top: rect.bottom + 2,                      maxHeight: Math.max(140, spaceBelow) });
+    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - margin);
+    setPos({ left: rect.left, top: rect.bottom + 2, maxHeight: spaceBelow });
   }, []);
 
   const openAt = useCallback(() => { reposition(); setOpen(true); }, [reposition]);


### PR DESCRIPTION
Batch of fixes and small UX improvements since 1.16.0.

## Fixes
- **Gate classification race** (#342): jump-created connections no longer briefly misclassify; eve-ids passed in the POST so the stargate lookup doesn't depend on committed rows.
- **Gate connection panel** (#343): wormhole-only fields (mass calc etc.) hidden for gate / jump-gate connections.
- **Jump-confirm** (#344): gate-detect now uses the reliable connection classification instead of /api/route.
- **Centre map** (#346): centres on the available canvas instead of a double-counted dock height.

## UX
- **Copy bookmark** (#347): moved next to the Leads To field, in-row.
- **Dropdowns** (#348): follow page/panel scroll, cap height so the last options stay reachable, always open downward (no flip-up), and close when the trigger scrolls out of its panel so they never overflow the map.

Version bump to follow once merged.