### PR TITLE
Hide region for wormhole systems (map nodes + scout connections)

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -45,6 +45,9 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();
   const sys = data as unknown as SystemNodeData;
   const color = CLASS_COLORS[sys.systemClass];
+  // Region is only worth showing for k-space; a wormhole's J-space region code
+  // ("B-R00007") carries no useful intel.
+  const isKspace = sys.systemClass === 'HS' || sys.systemClass === 'LS' || sys.systemClass === 'NS';
   const selectSystem    = useMapStore((s) => s.selectSystem);
   const compactMode     = useMapStore((s) => s.compactMode);
   const uniformSize     = useMapStore((s) => s.uniformSize);
@@ -450,7 +453,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
         </div>
       </div>
 
-      {!compactMode && sys.regionName && (
+      {!compactMode && isKspace && sys.regionName && (
         <div className="system-node__npc-type">
           {sys.regionName}{sys.npcType ? ` - ${sys.npcType}` : ''}
         </div>

--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -171,7 +171,11 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
               )}
               <span className="scout-row__time">{formatRemaining(t, c.remainingHours)}</span>
             </div>
-            <div className="scout-row__region">{c.inRegionName}</div>
+            {/* A wormhole target's J-space region code carries no useful intel;
+                only show the region for k-space exits. */}
+            {isKspaceTarget && c.inRegionName && (
+              <div className="scout-row__region">{c.inRegionName}</div>
+            )}
             <div className="scout-row__meta">
               <span className="scout-row__wh">{c.whType}</span>
               <span className="scout-row__size">


### PR DESCRIPTION
A wormhole's J-space region code (e.g. B-R00007) carries no useful intel, so drop it in two places — k-space systems still show their region.

- **System nodes**: the region line only renders for k-space (HS/LS/NS); wormhole/J-space nodes drop it.
- **Thera/Turnur scout-connections pane**: a wormhole target's region is hidden; k-space exits keep theirs.

Complements the related search-dropdown change (show class, not region, for wormhole systems) in #351.