### PR TITLE
Bump undici to 7.28.0 (Dependabot)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,8 @@
   },
   "resolutions": {
     "qs": "^6.15.2",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "undici": "^7.28.0"
   },
   "dependencies": {
     "cheerio": "^1.2.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1192,10 +1192,10 @@ undici-types@~7.19.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz"
   integrity sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==
 
-undici@^7.19.0:
-  version "7.25.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz"
-  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
+undici@^7.19.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
All 7 open Dependabot alerts are the same package: **undici** in `server/yarn.lock`, each fixed by **7.28.0** (severities low/medium/high).

undici is transitive via `cheerio` (`undici@^7.19.0` -> resolved 7.25.0). Pinned to `^7.28.0` via the existing `resolutions` block in `server/package.json`, then `yarn install` -> now resolves 7.28.0.

- Server `yarn build` passes.
- Only `server/package.json` + `server/yarn.lock` changed.