### PR TITLE
Bump version to 1.20.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.19.0",
+  "version": "1.20.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.20.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
Version bump for the 1.19.0->1.20.0 release (copy/duplicate map). GitHub release v1.20.0 to follow once merged to main.