### PR TITLE
Fix CodeQL security alerts (SSRF, ReDoS, CSP)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,11 +54,16 @@ app.set('trust proxy', 1);
 app.disable('x-powered-by');
 
 // Default Helmet is safe for a JSON API: HSTS (HTTPS only), nosniff,
-// frameguard=deny, referrer-policy=no-referrer, etc. CSP is disabled
-// because we serve JSON not HTML — the frontend is delivered by nginx,
-// which is where any meaningful CSP belongs.
+// frameguard=deny, referrer-policy=no-referrer, etc. This server only ever
+// returns JSON (the SPA is served by nginx/traefik, which owns the frontend
+// CSP), so we lock the API's own CSP all the way down: default-src 'none'
+// forbids loading/executing anything should a response ever be interpreted as
+// a document. Costs nothing on JSON responses.
 app.use(helmet({
-  contentSecurityPolicy: false,
+  contentSecurityPolicy: {
+    useDefaults: false,
+    directives: { defaultSrc: ["'none'"], frameAncestors: ["'none'"] },
+  },
   crossOriginEmbedderPolicy: false,
   crossOriginResourcePolicy: { policy: 'cross-origin' },
 }));

--- a/server/src/middleware/originGuard.ts
+++ b/server/src/middleware/originGuard.ts
@@ -7,6 +7,15 @@ const log = createLogger('origin-guard');
 // preflight; CSRF on those isn't a thing.
 const STATE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+// Strip trailing slashes with a linear scan rather than `/\/+$/`, which is
+// O(n^2) on a long run of slashes (polynomial ReDoS) — and the Origin/Referer
+// headers this runs on are attacker-influenced.
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return s.slice(0, end);
+}
+
 /**
  * Defense-in-depth CSRF guard. Rejects state-changing requests whose
  * Origin (or Referer as a fallback) doesn't match FRONTEND_URL.
@@ -29,7 +38,7 @@ const STATE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 export function originGuard(allowedOrigin: string) {
   // Normalise once: strip trailing slash so '.../app' and '.../app/'
   // both match without per-request string juggling.
-  const allowed = allowedOrigin.replace(/\/+$/, '');
+  const allowed = stripTrailingSlashes(allowedOrigin);
 
   return function originGuardMiddleware(req: Request, res: Response, next: NextFunction) {
     if (!STATE_METHODS.has(req.method)) {
@@ -49,7 +58,7 @@ export function originGuard(allowedOrigin: string) {
       return;
     }
 
-    const origin  = (req.headers.origin  ?? '').replace(/\/+$/, '');
+    const origin  = stripTrailingSlashes(req.headers.origin ?? '');
     const referer = req.headers.referer ?? '';
 
     // Origin is the strong signal — when present, it's authoritative.

--- a/server/src/routes/killboard.ts
+++ b/server/src/routes/killboard.ts
@@ -120,7 +120,14 @@ async function fetchEsi(killmailId: number, hash: string): Promise<EsiKillmail |
 }
 
 router.get('/:systemId(\\d+)', async (req, res) => {
-  const { systemId } = req.params;
+  // The route pattern already constrains this to digits, but parse to a bounded
+  // integer and build the upstream URL from the NUMBER (not the raw string) so
+  // no attacker-controlled text can ever reach the outbound request (SSRF).
+  const idNum = Number(req.params.systemId);
+  if (!Number.isInteger(idNum) || idNum <= 0 || idNum > 100_000_000) {
+    return res.status(400).json({ error: 'Invalid system id' });
+  }
+  const systemId = String(idNum);
 
   // Fresh cache hit — return immediately. peek() falls back to any stale entry
   // we can still serve from when the upstream is unhappy.
@@ -133,7 +140,7 @@ router.get('/:systemId(\\d+)', async (req, res) => {
   // made the client-side toggle ineffective — the server now hands back
   // everything and the killboard pane decides whether to render NPC kills
   // based on the user's preference.
-  const zkbUrl = `https://zkillboard.com/api/kills/solarSystemID/${systemId}/pastSeconds/86400/`;
+  const zkbUrl = `https://zkillboard.com/api/kills/solarSystemID/${idNum}/pastSeconds/86400/`;
   const zkbHeaders: Record<string, string> = {
     'User-Agent': ZKB_AGENT,
     Accept:       'application/json',


### PR DESCRIPTION
Resolves 3 of the 4 CodeQL alerts in code; the 4th is a documented false positive (dismissed separately).

- **SSRF** (`js/request-forgery`, `killboard.ts`) — the zKillboard URL is now built from a **validated integer** (`Number()` + range check), not the raw path string, so no attacker-controlled text can reach the outbound `fetch`. The route was already `(\d+)`-constrained; this makes it airtight.
- **ReDoS** (`js/polynomial-redos`, `originGuard.ts`) — trailing-slash stripping used `/\/+$/`, which is O(n²) on a long run of slashes; replaced with a linear char-scan (`stripTrailingSlashes`). Matters because it runs on the attacker-influenced Origin/Referer headers.
- **CSP disabled** (`js/insecure-helmet-configuration`, `index.ts`) — `contentSecurityPolicy: false` replaced with a locked-down `default-src 'none'` / `frame-ancestors 'none'` policy. This server only returns JSON (the SPA's CSP lives in nginx/traefik), so the tight policy costs nothing and hardens any response a browser might treat as a document.

**Not changed — CSRF** (`js/missing-token-validation`): already mitigated by the `originGuard` middleware (origin/referer validation on all state-changing methods, `index.ts:95`) + `SameSite=lax` session cookies. CodeQL only recognizes token libraries, so it's a false positive; adding csurf would contradict the deliberate origin-based design. Dismissed with that justification.

Server `yarn build` clean.