### PR TITLE
Stack connection label badges vertically

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3941,10 +3941,6 @@ div.system-node__easy-handle {
   align-items: center;
 }
 
-.connection-label__row--top {
-  margin-bottom: 1px;
-}
-
 .connection-label__type {
   font-size: calc(13px * var(--font-scale, 1));
   font-weight: 700;

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -227,13 +227,12 @@ export const ConnectionEdge = memo(({
               style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`, zIndex: highlighted ? 1001 : undefined }}
               onClick={() => selectConnection(id)}
             >
-              {count === 3 ? (
+              {count > 0 ? (
                 <>
-                  <div className="connection-label__row connection-label__row--top">{typeNode}</div>
-                  <div className="connection-label__row">{massNode}{timeNode}</div>
+                  {typeNode && <div className="connection-label__row">{typeNode}</div>}
+                  {massNode && <div className="connection-label__row">{massNode}</div>}
+                  {timeNode && <div className="connection-label__row">{timeNode}</div>}
                 </>
-              ) : count > 0 ? (
-                <div className="connection-label__row">{typeNode}{massNode}{timeNode}</div>
               ) : null}
             </div>
           );


### PR DESCRIPTION
## What

When a connection shows its info badges (type, mass, lifetime), display each part on its own line instead of the previous type-on-top / mass+lifetime side-by-side layout.

## Why

Requested: connection info should read one item per line - type, then mass, then lifetime.

## How

- `ConnectionEdge.tsx`: render each present badge (`typeNode`, `massNode`, `timeNode`) in its own `.connection-label__row`. The `.connection-label` wrapper is already a column flex with a 3px gap, so they stack cleanly for any count (1, 2, or 3 badges).
- `App.css`: removed the now-unused `.connection-label__row--top` rule.

Layout-only change - no new user-facing strings, so no i18n updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)