### PR TITLE
Release 1.21.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.21.0",
+  "version": "1.21.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3941,10 +3941,6 @@ div.system-node__easy-handle {
   align-items: center;
 }
 
-.connection-label__row--top {
-  margin-bottom: 1px;
-}
-
 .connection-label__type {
   font-size: calc(13px * var(--font-scale, 1));
   font-weight: 700;

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -227,13 +227,12 @@ export const ConnectionEdge = memo(({
               style={{ transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`, zIndex: highlighted ? 1001 : undefined }}
               onClick={() => selectConnection(id)}
             >
-              {count === 3 ? (
+              {count > 0 ? (
                 <>
-                  <div className="connection-label__row connection-label__row--top">{typeNode}</div>
-                  <div className="connection-label__row">{massNode}{timeNode}</div>
+                  {typeNode && <div className="connection-label__row">{typeNode}</div>}
+                  {massNode && <div className="connection-label__row">{massNode}</div>}
+                  {timeNode && <div className="connection-label__row">{timeNode}</div>}
                 </>
-              ) : count > 0 ? (
-                <div className="connection-label__row">{typeNode}{massNode}{timeNode}</div>
               ) : null}
             </div>
           );


### PR DESCRIPTION
## Release 1.21.1

Patch release merging `release` into `main`.

### Changes
- Stack connection label badges vertically - connection type, mass and lifetime each render on their own line (#366).
- Version bump to 1.21.1.

After merge: cut the `v1.21.1` GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)