### PR TITLE
Add single-character system tag (A-Z / 0-9)

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -195,6 +195,11 @@ export async function migrate() {
     ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS labels        TEXT[] NOT NULL DEFAULT '{}';
     ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS custom_labels TEXT[] NOT NULL DEFAULT '{}';
 
+    -- Single-character quick tag (A-Z / 0-9), shown as a prominent badge before
+    -- the system name. A scalar like intel (not the labels array): one tag per
+    -- system, NULL means untagged. Used for ad-hoc "system A / B / 1 / 2" marking.
+    ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS tag           TEXT;
+
     CREATE TABLE IF NOT EXISTS map_signatures (
       id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
       system_id   UUID        NOT NULL REFERENCES map_systems(id) ON DELETE CASCADE,

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1569,6 +1569,17 @@ mapsRouter.patch('/:mapId/systems/:systemId', async (req, res) => {
     vals.push(v);
   }
 
+  // Single-character quick tag (one A-Z / 0-9 char), or null to clear. The
+  // strict charset stops a stale client stuffing arbitrary text into the badge.
+  if ('tag' in updates) {
+    const v = updates.tag;
+    if (v !== null && !(typeof v === 'string' && /^[A-Za-z0-9]$/.test(v))) {
+      res.status(400).json({ error: 'invalid tag' }); return;
+    }
+    sets.push(`tag = $${vals.length + 1}`);
+    vals.push(v);
+  }
+
   // Predefined labels — applied as coloured pills above the node. A subset of
   // the fixed id set; deduped before storing.
   if ('labels' in updates) {

--- a/server/src/services/mapCopy.ts
+++ b/server/src/services/mapCopy.ts
@@ -61,11 +61,11 @@ export async function copyMap(params: {
       id: string; eveSystemId: number | null; name: string; systemClass: string; effect: string;
       statics: string[]; regionName: string | null; npcType: string | null; x: number; y: number;
       status: string; isHome: boolean; locked: boolean; notes: string; intel: string | null;
-      labels: string[]; customLabels: string[];
+      labels: string[]; customLabels: string[]; tag: string | null;
     }>(
       `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
               region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
-              status, is_home AS "isHome", locked, notes, intel, labels, custom_labels AS "customLabels"
+              status, is_home AS "isHome", locked, notes, intel, labels, custom_labels AS "customLabels", tag
          FROM map_systems WHERE map_id = $1`,
       [sourceMapId],
     );
@@ -75,11 +75,11 @@ export async function copyMap(params: {
     await insertBatch(client, 'map_systems',
       ['id', 'map_id', 'eve_system_id', 'name', 'system_class', 'effect', 'statics', 'region_name',
        'npc_type', 'position_x', 'position_y', 'status', 'is_home', 'locked', 'notes', 'intel',
-       'labels', 'custom_labels'],
+       'labels', 'custom_labels', 'tag'],
       sysRes.rows.map((s) => [
         sysIdMap.get(s.id), newMapId, s.eveSystemId, s.name, s.systemClass, s.effect, s.statics,
         s.regionName, s.npcType, s.x, s.y, s.status, s.isHome, s.locked,
-        include.notes ? s.notes : '', s.intel, s.labels, s.customLabels,
+        include.notes ? s.notes : '', s.intel, s.labels, s.customLabels, s.tag,
       ]),
     );
 

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -79,7 +79,7 @@ export async function loadFullMap(mapId: string) {
               effect, statics, region_name AS "regionName", npc_type AS "npcType",
               position_x AS x, position_y AS y,
               status, intel, is_home AS "isHome", locked, notes,
-              labels, custom_labels AS "customLabels",
+              labels, custom_labels AS "customLabels", tag,
               (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
               last_activity_at AS "lastActivityAt"
        FROM map_systems WHERE map_id = $1`,

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2398,6 +2398,69 @@
   border: 1px solid #33415c;
 }
 
+/* ── Single-character quick tag badge (inline, before the system name) ── */
+.system-node__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: calc(16px * var(--font-scale, 1));
+  height: calc(16px * var(--font-scale, 1));
+  padding: 0 3px;
+  margin-right: 4px;
+  border-radius: 4px;
+  background: var(--tag-badge, #f5a623);
+  color: #1a1205;
+  font-size: calc(11px * var(--font-scale, 1));
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+/* ── Tag picker grid (context-menu flyout) ──────────────────────────── */
+.tag-picker {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  padding: 8px;
+}
+
+.tag-picker__cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid #2a3446;
+  border-radius: 5px;
+  background: #10151f;
+  color: #f5c518;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.tag-picker__cell:hover:not(:disabled) {
+  background: #1c2634;
+  border-color: #f5c518;
+}
+
+.tag-picker__cell--active {
+  background: #f5a623;
+  border-color: #f5a623;
+  color: #1a1205;
+}
+
+.tag-picker__cell--clear {
+  color: #8a97ad;
+}
+
+.tag-picker__cell:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* ── Custom-label dialog ─────────────────────────────────────────── */
 .custom-label-dialog { width: min(440px, 92vw); }
 

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -25,8 +25,13 @@ import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
   XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
   LinkSimpleIcon, LinkBreakIcon, ArrowsOutIcon, BookmarkSimpleIcon, TextAaIcon, TrashIcon,
+  HashIcon, ProhibitIcon,
 } from '@phosphor-icons/react';
 import { PREDEFINED_LABELS } from '../../data/labels';
+
+// Quick-tag character set: all letters then all digits, laid out in the grid
+// flyout. A single one of these (or none) marks a system via map_systems.tag.
+const TAG_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.split('');
 import { CustomLabelDialog } from '../ui/CustomLabelDialog';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -1060,6 +1065,45 @@ export function MapCanvas() {
         },
       ];
 
+      // Tag: a single A-Z / 0-9 badge before the system name. The flyout is a
+      // grid of characters plus a clear cell; picking one persists through the
+      // same updateSystem path and closes the menu. Single-select only.
+      const tagItem = !multiSelected ? [{
+        label: t('ctxMenu.tag'),
+        icon:  <HashIcon size={16} weight="regular" color="#f5a623" />,
+        flyout: (close: () => void) => (
+          <div className="tag-picker">
+            {TAG_CHARS.map((c) => (
+              <button
+                key={c}
+                className={`tag-picker__cell${sys?.tag === c ? ' tag-picker__cell--active' : ''}`}
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  // Toggle: re-picking the current tag clears it.
+                  updateSystem(contextMenu.nodeId!, { tag: sys?.tag === c ? null : c });
+                  close();
+                }}
+              >
+                {c}
+              </button>
+            ))}
+            <button
+              className="tag-picker__cell tag-picker__cell--clear"
+              disabled={!sys?.tag}
+              aria-label={t('ctxMenu.clearTag')}
+              data-tooltip={t('ctxMenu.clearTag')}
+              onMouseDown={(e) => {
+                e.stopPropagation();
+                updateSystem(contextMenu.nodeId!, { tag: null });
+                close();
+              }}
+            >
+              <ProhibitIcon size={15} weight="regular" />
+            </button>
+          </div>
+        ),
+      }] : [];
+
       // Labels: toggle predefined coloured pills (A/B/C/1/2/3), open the custom
       // dialog, or clear all. Single-select only — each toggle persists via the
       // same updateSystem path intel uses. Closes the menu on click (reopen to
@@ -1115,6 +1159,7 @@ export function MapCanvas() {
           },
         }] : []),
         ...homeItem,
+        ...tagItem,
         ...intelItem,
         ...labelItem,
         ...multiItems,

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -355,6 +355,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <HouseIcon size={14} weight="regular" />
           </span>
         )}
+        {sys.tag && <span className="system-node__tag">{sys.tag}</span>}
         <span className="system-node__name">{sys.name || t('mapNode.unknown')}</span>
         {sys.security != null && Number.isFinite(Number(sys.security)) && (
           <span className="system-node__truesec" style={{ color: truesecColor(Number(sys.security)) }}>

--- a/web/src/components/ui/ContextMenu.tsx
+++ b/web/src/components/ui/ContextMenu.tsx
@@ -12,6 +12,10 @@ export type ContextMenuItem =
       disabled?: boolean;
       checked?: boolean;
       submenu?: ContextMenuItem[];
+      /** Custom flyout content shown in place of a list submenu (e.g. a grid
+       *  picker). Receives the menu's close handler so its own controls can
+       *  dismiss the menu after acting. Ignored when `submenu` is set. */
+      flyout?: (close: () => void) => ReactNode;
     };
 
 interface Props {
@@ -103,15 +107,16 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
         if ('separator' in item && item.separator) {
           return <li key={i} className="context-menu__separator" role="separator" />;
         }
-        const { label, icon, action, disabled, checked, submenu } = item;
+        const { label, icon, action, disabled, checked, submenu, flyout } = item;
+        const hasFlyout = !!submenu || !!flyout;
         return (
-          <li key={label} className="context-menu__li" onMouseEnter={() => setOpenSubmenu(submenu ? i : null)}>
+          <li key={label} className="context-menu__li" onMouseEnter={() => setOpenSubmenu(hasFlyout ? i : null)}>
             <button
               className="context-menu__item"
               disabled={disabled}
               onMouseDown={(e) => {
                 e.stopPropagation();
-                if (!disabled && action && !submenu) {
+                if (!disabled && action && !hasFlyout) {
                   action();
                   onClose();
                 }
@@ -122,10 +127,14 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
               )}
               {icon && <span className="context-menu__icon">{icon}</span>}
               {label}
-              {submenu && <span className="context-menu__arrow"><CaretRightIcon size={12} weight="bold" /></span>}
+              {hasFlyout && <span className="context-menu__arrow"><CaretRightIcon size={12} weight="bold" /></span>}
             </button>
-            {submenu && openSubmenu === i && (
-              <SubMenu items={submenu} onClose={onClose} />
+            {openSubmenu === i && (
+              submenu
+                ? <SubMenu items={submenu} onClose={onClose} />
+                : flyout
+                  ? <div className="context-menu context-menu--sub context-menu--flyout">{flyout(onClose)}</div>
+                  : null
             )}
           </li>
         );

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -722,7 +722,9 @@
     "labels": "Labels",
     "customLabel": "Eigenes Label",
     "clearLabels": "Löschen",
-    "labelNamed": "Label {{name}}"
+    "labelNamed": "Label {{name}}",
+    "tag": "Tag",
+    "clearTag": "Tag entfernen"
   },
   "panel": {
     "notes": "Notizen",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -764,6 +764,8 @@
     "customLabel": "Custom label",
     "clearLabels": "Clear",
     "labelNamed": "Label {{name}}",
+    "tag": "Tag",
+    "clearTag": "Clear tag",
     "lockSystem": "Lock System",
     "unlockSystem": "Unlock System",
     "removeSystem": "Remove System",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -722,7 +722,9 @@
     "labels": "Etiquetas",
     "customLabel": "Etiqueta personalizada",
     "clearLabels": "Borrar",
-    "labelNamed": "Etiqueta {{name}}"
+    "labelNamed": "Etiqueta {{name}}",
+    "tag": "Marca",
+    "clearTag": "Quitar marca"
   },
   "panel": {
     "notes": "Notas",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -722,7 +722,9 @@
     "labels": "Labels",
     "customLabel": "Label personnalisé",
     "clearLabels": "Effacer",
-    "labelNamed": "Label {{name}}"
+    "labelNamed": "Label {{name}}",
+    "tag": "Marqueur",
+    "clearTag": "Effacer le marqueur"
   },
   "panel": {
     "notes": "Notes",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -722,7 +722,9 @@
     "labels": "ラベル",
     "customLabel": "カスタムラベル",
     "clearLabels": "クリア",
-    "labelNamed": "ラベル {{name}}"
+    "labelNamed": "ラベル {{name}}",
+    "tag": "タグ",
+    "clearTag": "タグを消去"
   },
   "panel": {
     "notes": "メモ",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -722,7 +722,9 @@
     "labels": "라벨",
     "customLabel": "사용자 라벨",
     "clearLabels": "지우기",
-    "labelNamed": "라벨 {{name}}"
+    "labelNamed": "라벨 {{name}}",
+    "tag": "태그",
+    "clearTag": "태그 지우기"
   },
   "panel": {
     "notes": "노트",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -722,7 +722,9 @@
     "labels": "Etiquetas",
     "customLabel": "Etiqueta personalizada",
     "clearLabels": "Limpar",
-    "labelNamed": "Etiqueta {{name}}"
+    "labelNamed": "Etiqueta {{name}}",
+    "tag": "Marca",
+    "clearTag": "Limpar marca"
   },
   "panel": {
     "notes": "Notas",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -740,7 +740,9 @@
     "labels": "Метки",
     "customLabel": "Своя метка",
     "clearLabels": "Очистить",
-    "labelNamed": "Метка {{name}}"
+    "labelNamed": "Метка {{name}}",
+    "tag": "Тег",
+    "clearTag": "Убрать тег"
   },
   "panel": {
     "notes": "Заметки",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -722,7 +722,9 @@
     "labels": "标签",
     "customLabel": "自定义标签",
     "clearLabels": "清除",
-    "labelNamed": "标签 {{name}}"
+    "labelNamed": "标签 {{name}}",
+    "tag": "标记",
+    "clearTag": "清除标记"
   },
   "panel": {
     "notes": "笔记",

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -82,6 +82,9 @@ export interface MapSystem {
   labels: string[];
   /** Up to 3 custom labels, each 't:<text>' or 'i:<IconName>' (Phosphor). */
   customLabels: string[];
+  /** Single-character quick tag (A-Z / 0-9), shown as a badge before the name.
+   *  null/undefined = untagged. */
+  tag?: string | null;
   lastActivityAt: string; // ISO timestamp, updated when system or its sigs are touched
 }
 


### PR DESCRIPTION
## What

Adds a per-system **quick tag** - a single letter (A-Z) or digit (0-9) shown as a prominent badge just before the system name, similar to Wanderer's Tag feature. Distinct from the existing multi-label pills: exactly one scalar tag per system, cleared with a dedicated cell (or by re-picking the current tag).

## UX

Right-click a system -> **Tag** -> a grid flyout of A-Z + 0-9 plus a clear cell. Picking one sets the badge; picking the active one again (or the clear cell) removes it.

## How

**Server**
- `migrate.ts`: new nullable `map_systems.tag` column (scalar, modelled on `intel`).
- `routes/maps.ts` PATCH: validates `tag` as a single `[A-Za-z0-9]` char or `null`.
- `mapRead.ts` / `mapCopy.ts`: include `tag` in system reads and map duplication.

**Client**
- `ContextMenu.tsx`: new optional `flyout(close)` render prop so a menu item can open custom submenu content (the grid) instead of a list.
- `MapCanvas.tsx`: the **Tag** menu item + A-Z/0-9 grid picker, persisting via the existing `updateSystem` path.
- `SystemNode.tsx`: renders the badge inline before the name.
- `App.css`: `.system-node__tag` badge + `.tag-picker` grid styles.
- i18n: `ctxMenu.tag` / `ctxMenu.clearTag` added to all 9 locales.

Realtime sync needs no new event: the tag rides the existing `system.update` SSE frame and the store reducer that spreads `updates`.

## Verification

`tsc` (server + web), `eslint` (0 errors), production `vite build`, and JSON parity across all 9 locales all pass. Live UI click-through needs an EVE SSO login, so please sanity-check the badge + picker in the running app.

## Notes

- New DB column is additive and idempotent (`ADD COLUMN IF NOT EXISTS`); applied on server boot by the migration.