### PR TITLE
Lift map controls clear of the canvas hint

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6783,6 +6783,10 @@ select.sig-toolbar-btn option {
   background: #0d1117;
   border: 1px solid #1e2740;
   border-radius: 6px;
+  /* Lift clear of the centred canvas hint (bottom: 12px) so the bottom
+     control (center-on-me) isn't overlapped by the hint text in short /
+     narrow viewports. Overrides React Flow's default 15px panel margin. */
+  margin-bottom: 44px;
 
   button {
     background: #0d1117;


### PR DESCRIPTION
## Bug

In short / narrow viewports the centred canvas hint ("Right-click...") sits at `bottom: 12px` and overlaps the bottom-most map control (center-on-me), which anchors at React Flow's default 15px panel margin.

## Fix

Override the controls panel's bottom margin to 44px so the whole control column clears the hint text. Applies to both bottom-left and bottom-right dock positions (same `.react-flow__controls` class), and the centred hint means either corner is lifted clear.

CSS-only change in `web/src/App.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)