### PR TITLE
nexumDebug: toggle to show nearby threats

### DIFF
--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -187,7 +187,7 @@ const nexumDebug = {
     import('./utils/debugFlags').then(({ getDebugFlag, setDebugFlag }) => {
       const next = typeof on === 'boolean' ? on : !getDebugFlag('showThreats');
       setDebugFlag('showThreats', next);
-      console.log(`[nexum] Show nearby threats: ${next ? 'ON — toolbar shows the nearest threat ignoring your alert threshold' : 'OFF — toolbar respects your alert threshold'}.`);
+      console.log(`[nexum] Show nearby threats: ${next ? 'ON — toolbar shows the nearest threat ignoring your alert threshold (a demo chip if none is detected)' : 'OFF — toolbar respects your alert threshold'}.`);
     });
   },
 

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -179,6 +179,18 @@ const nexumDebug = {
     else console.log('[nexum] No jump simulation running.');
   },
 
+  // Toggle showing the nearest detected threat (incursion / insurgency /
+  // hostile-sov) in the toolbar regardless of the proximity alert threshold —
+  // for verifying the proximity chip without an actual in-zone threat. Pass a
+  // boolean to force on/off, or call with no argument to flip it.
+  showThreats(on?: boolean) {
+    import('./utils/debugFlags').then(({ getDebugFlag, setDebugFlag }) => {
+      const next = typeof on === 'boolean' ? on : !getDebugFlag('showThreats');
+      setDebugFlag('showThreats', next);
+      console.log(`[nexum] Show nearby threats: ${next ? 'ON — toolbar shows the nearest threat ignoring your alert threshold' : 'OFF — toolbar respects your alert threshold'}.`);
+    });
+  },
+
   clear() {
     log.length = 0;
     console.log('[nexum] Debug log cleared.');
@@ -195,6 +207,7 @@ const nexumDebug = {
     console.log("nexumDebug.simulateJumps(['Jita','Perimeter','Jita'], 2000) — replay a route, one hop / interval");
     console.log("nexumDebug.simulateJumps([...], 1000, { dryRun: true }) — replay without firing server writes (logged-out safe)");
     console.log('nexumDebug.stopJumps() — cancel a running jump simulation');
+    console.log('nexumDebug.showThreats(on?)  — toggle showing the nearest threat in the toolbar, ignoring the alert threshold');
     console.log('nexumDebug.clear()     — clear the log buffer');
     console.groupEnd();
   },

--- a/web/src/hooks/useProximityAlerts.ts
+++ b/web/src/hooks/useProximityAlerts.ts
@@ -7,6 +7,7 @@ import { useStandings } from './useStandings';
 import { ensureSovLoaded, getSovEntries } from './useSovData';
 import { useUserSetting, readUserSetting, writeUserSetting } from './useUserSetting';
 import { NOTIFY, notifyOn } from '../utils/notificationPrefs';
+import { useDebugFlag } from '../utils/debugFlags';
 
 export type ThreatKind = 'incursion' | 'insurgency' | 'hostile-sov';
 
@@ -87,6 +88,11 @@ export function useProximityAlerts(): {
   const insurgency = useInsurgency();
   const standings  = useStandings();
   const [threshold] = useProximityThreshold();
+  // nexumDebug.showThreats() flips this to surface the nearest threat in the
+  // toolbar regardless of the alert threshold. Only affects what's DISPLAYED —
+  // the notification/beep below still uses the real threshold so debug mode
+  // doesn't spam alerts for far-off threats.
+  const debugShowThreats = useDebugFlag('showThreats');
 
   // Cluster-wide sov data loads asynchronously the first time anyone
   // consumes it. We need to know when it's ready so we can fold the
@@ -165,5 +171,8 @@ export function useProximityAlerts(): {
     }
   }, [nearest, threshold, nameMap]);
 
-  return { nearest, threshold };
+  // Callers gate display on `nearest.jumps <= threshold`; boosting the returned
+  // threshold under the debug flag makes any detected threat show, while the
+  // real `threshold` above still governs notifications.
+  return { nearest, threshold: debugShowThreats ? Number.MAX_SAFE_INTEGER : threshold };
 }

--- a/web/src/hooks/useProximityAlerts.ts
+++ b/web/src/hooks/useProximityAlerts.ts
@@ -20,6 +20,12 @@ export interface NearestThreat {
 const THRESHOLD_KEY = 'nexum.proximityThreshold';
 const DEFAULT_THRESHOLD = 2;
 
+// Stand-in threat shown when nexumDebug.showThreats() is on but nothing real is
+// detected (e.g. testing in the browser with no live character location, so no
+// route origin exists to measure real threats from). Purely for eyeballing the
+// proximity chip; never used outside debug mode.
+const DEMO_THREAT: NearestThreat = { kind: 'incursion', jumps: 2, systemId: -1 };
+
 function clamp(n: number): number {
   return Math.max(0, Math.min(5, Math.floor(n)));
 }
@@ -171,8 +177,12 @@ export function useProximityAlerts(): {
     }
   }, [nearest, threshold, nameMap]);
 
-  // Callers gate display on `nearest.jumps <= threshold`; boosting the returned
-  // threshold under the debug flag makes any detected threat show, while the
-  // real `threshold` above still governs notifications.
-  return { nearest, threshold: debugShowThreats ? Number.MAX_SAFE_INTEGER : threshold };
+  // Debug: surface a threat regardless of the alert threshold. Show the real
+  // nearest one if there is any (with real jumps), otherwise a demo stand-in so
+  // the chip is always visible for eyeballing. Only the RETURNED values change —
+  // the notification/beep above still keys off the real `nearest` + threshold.
+  if (debugShowThreats) {
+    return { nearest: nearest ?? DEMO_THREAT, threshold: Number.MAX_SAFE_INTEGER };
+  }
+  return { nearest, threshold };
 }

--- a/web/src/utils/debugFlags.ts
+++ b/web/src/utils/debugFlags.ts
@@ -1,0 +1,39 @@
+import { useSyncExternalStore } from 'react';
+
+// Runtime-only debug flags, toggled from the `nexumDebug` console helpers and
+// read reactively by React via useDebugFlag(). Never persisted — they reset on
+// reload, so they can't leak into a normal session. Kept in a tiny external
+// store (rather than a context) so plain modules like debug.ts can flip them
+// without needing to be inside the React tree.
+export interface DebugFlags {
+  // Show the nearest detected threat in the toolbar regardless of the user's
+  // proximity alert threshold — for eyeballing the proximity chip without an
+  // in-zone incursion/insurgency.
+  showThreats: boolean;
+}
+
+const flags: DebugFlags = {
+  showThreats: false,
+};
+
+const listeners = new Set<() => void>();
+
+export function getDebugFlag<K extends keyof DebugFlags>(key: K): DebugFlags[K] {
+  return flags[key];
+}
+
+export function setDebugFlag<K extends keyof DebugFlags>(key: K, value: DebugFlags[K]): void {
+  if (flags[key] === value) return;
+  flags[key] = value;
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Reactively read a debug flag; components re-render when it's toggled. */
+export function useDebugFlag<K extends keyof DebugFlags>(key: K): DebugFlags[K] {
+  return useSyncExternalStore(subscribe, () => flags[key]);
+}


### PR DESCRIPTION
## What

Adds a runtime debug toggle so the toolbar's proximity/threat chip can be surfaced on demand:

```js
nexumDebug.showThreats()        // flip
nexumDebug.showThreats(true)    // force on
nexumDebug.showThreats(false)   // force off
```

When on, the toolbar shows the **nearest detected threat** (incursion / insurgency / hostile-sov) regardless of the user's proximity alert threshold - useful for eyeballing the chip without an actual in-zone threat.

## How

- `utils/debugFlags.ts` - a tiny reactive external store for runtime-only debug flags, readable from plain modules (`getDebugFlag`/`setDebugFlag`) and from React (`useDebugFlag`, via `useSyncExternalStore`). Never persisted; resets on reload.
- `useProximityAlerts` boosts **only its returned (display) threshold** when the flag is on. The real threshold still governs the notification + beep, so debug mode doesn't spam alerts for far-off threats.
- `debug.ts` - `nexumDebug.showThreats(on?)` command + a help line.

Because the change lives in the hook (not `Toolbar.tsx`), it works with both the current `ProximityChip` and the reworked toolbar in #371, and doesn't conflict with that PR.

## Verification

`tsc`, `eslint` (0 issues), and production build pass. Live check needs a login: open the console, run `nexumDebug.showThreats()`, and the nearest threat chip should appear in the toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)