### PR TITLE
Release 1.22.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "1.21.1",
+  "version": "1.22.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -195,6 +195,11 @@ export async function migrate() {
     ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS labels        TEXT[] NOT NULL DEFAULT '{}';
     ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS custom_labels TEXT[] NOT NULL DEFAULT '{}';
 
+    -- Single-character quick tag (A-Z / 0-9), shown as a prominent badge before
+    -- the system name. A scalar like intel (not the labels array): one tag per
+    -- system, NULL means untagged. Used for ad-hoc "system A / B / 1 / 2" marking.
+    ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS tag           TEXT;
+
     CREATE TABLE IF NOT EXISTS map_signatures (
       id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
       system_id   UUID        NOT NULL REFERENCES map_systems(id) ON DELETE CASCADE,

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1569,6 +1569,17 @@ mapsRouter.patch('/:mapId/systems/:systemId', async (req, res) => {
     vals.push(v);
   }
 
+  // Single-character quick tag (one A-Z / 0-9 char), or null to clear. The
+  // strict charset stops a stale client stuffing arbitrary text into the badge.
+  if ('tag' in updates) {
+    const v = updates.tag;
+    if (v !== null && !(typeof v === 'string' && /^[A-Za-z0-9]$/.test(v))) {
+      res.status(400).json({ error: 'invalid tag' }); return;
+    }
+    sets.push(`tag = $${vals.length + 1}`);
+    vals.push(v);
+  }
+
   // Predefined labels — applied as coloured pills above the node. A subset of
   // the fixed id set; deduped before storing.
   if ('labels' in updates) {

--- a/server/src/services/mapCopy.ts
+++ b/server/src/services/mapCopy.ts
@@ -61,11 +61,11 @@ export async function copyMap(params: {
       id: string; eveSystemId: number | null; name: string; systemClass: string; effect: string;
       statics: string[]; regionName: string | null; npcType: string | null; x: number; y: number;
       status: string; isHome: boolean; locked: boolean; notes: string; intel: string | null;
-      labels: string[]; customLabels: string[];
+      labels: string[]; customLabels: string[]; tag: string | null;
     }>(
       `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
               region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
-              status, is_home AS "isHome", locked, notes, intel, labels, custom_labels AS "customLabels"
+              status, is_home AS "isHome", locked, notes, intel, labels, custom_labels AS "customLabels", tag
          FROM map_systems WHERE map_id = $1`,
       [sourceMapId],
     );
@@ -75,11 +75,11 @@ export async function copyMap(params: {
     await insertBatch(client, 'map_systems',
       ['id', 'map_id', 'eve_system_id', 'name', 'system_class', 'effect', 'statics', 'region_name',
        'npc_type', 'position_x', 'position_y', 'status', 'is_home', 'locked', 'notes', 'intel',
-       'labels', 'custom_labels'],
+       'labels', 'custom_labels', 'tag'],
       sysRes.rows.map((s) => [
         sysIdMap.get(s.id), newMapId, s.eveSystemId, s.name, s.systemClass, s.effect, s.statics,
         s.regionName, s.npcType, s.x, s.y, s.status, s.isHome, s.locked,
-        include.notes ? s.notes : '', s.intel, s.labels, s.customLabels,
+        include.notes ? s.notes : '', s.intel, s.labels, s.customLabels, s.tag,
       ]),
     );
 

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -79,7 +79,7 @@ export async function loadFullMap(mapId: string) {
               effect, statics, region_name AS "regionName", npc_type AS "npcType",
               position_x AS x, position_y AS y,
               status, intel, is_home AS "isHome", locked, notes,
-              labels, custom_labels AS "customLabels",
+              labels, custom_labels AS "customLabels", tag,
               (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
               last_activity_at AS "lastActivityAt"
        FROM map_systems WHERE map_id = $1`,

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "1.21.1",
+  "version": "1.22.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -753,6 +753,20 @@
 .toolbar__item .toolbar__char-system--clickable { cursor: pointer; }
 .toolbar__item input { cursor: text; }
 
+/* Six-dot drag grip on every item: a persistent "this can be dragged" cue,
+   quiet at rest and emphasised on hover / while dragging. */
+.toolbar__item-grip {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-right: -2px;
+  color: #5a6886;
+  opacity: 0.45;
+  transition: opacity 0.12s, color 0.12s;
+}
+.toolbar__item:hover .toolbar__item-grip { opacity: 0.9; color: #8a9bc4; }
+.toolbar__item--dragging .toolbar__item-grip { opacity: 1; color: #a9b8dc; }
+
 /* Groups several related controls inside a single movable item (e.g. the map
    switcher + name field), keeping them together as one draggable unit. */
 .toolbar__group {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2398,6 +2398,69 @@
   border: 1px solid #33415c;
 }
 
+/* ── Single-character quick tag badge (inline, before the system name) ── */
+.system-node__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: calc(16px * var(--font-scale, 1));
+  height: calc(16px * var(--font-scale, 1));
+  padding: 0 3px;
+  margin-right: 4px;
+  border-radius: 4px;
+  background: var(--tag-badge, #f5a623);
+  color: #1a1205;
+  font-size: calc(11px * var(--font-scale, 1));
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+/* ── Tag picker grid (context-menu flyout) ──────────────────────────── */
+.tag-picker {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  padding: 8px;
+}
+
+.tag-picker__cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid #2a3446;
+  border-radius: 5px;
+  background: #10151f;
+  color: #f5c518;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.tag-picker__cell:hover:not(:disabled) {
+  background: #1c2634;
+  border-color: #f5c518;
+}
+
+.tag-picker__cell--active {
+  background: #f5a623;
+  border-color: #f5a623;
+  color: #1a1205;
+}
+
+.tag-picker__cell--clear {
+  color: #8a97ad;
+}
+
+.tag-picker__cell:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* ── Custom-label dialog ─────────────────────────────────────────── */
 .custom-label-dialog { width: min(440px, 92vw); }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -715,80 +715,64 @@
 .toolbar {
   display: flex;
   align-items: center;
-  gap: 24px;
-  /* Sections are atomic (flex-shrink: 0), so when the row runs out of width
-     whole groups wrap to the next line rather than squishing or clipping —
-     this is what keeps the bar usable on vertical monitors / narrow laptops. */
+  gap: 10px;
+  /* Every control is an atomic flex item (flex-shrink: 0), so when the row runs
+     out of width items wrap to the next line rather than squishing, clipping, or
+     stacking — reordering can never produce an overlap. Keeps the bar usable on
+     vertical monitors / narrow laptops. */
   flex-wrap: wrap;
-  row-gap: 4px;
-  padding: 0 16px;
+  row-gap: 6px;
+  padding: 4px 16px;
   min-height: 48px;
   background: #0d1117;
   border-bottom: 1px solid #1e2740;
   flex-shrink: 0;
   /* Sits above the map sidebar (z-index 20) so tooltips dropping down from
-     toolbar buttons aren't clipped when the sidebar is open. The toolbar
-     header itself doesn't overlap the sidebar visually, so this is purely
-     about giving its absolutely-positioned descendants the right z-context. */
+     toolbar buttons aren't clipped when the sidebar is open. */
   z-index: 30;
   position: relative;
 }
 
-/* A reorderable group of toolbar controls (drag-and-drop via dnd-kit). Always
-   draggable — grab cursor by default; interactive children keep their own. */
-.toolbar__section {
+/* One movable toolbar item (drag-and-drop reorder via dnd-kit sortable). The
+   whole item is the drag handle — grab cursor by default; interactive children
+   keep their own, and the 6px pointer activation distance means a tap still
+   clicks through. Items sit in normal flex flow, never absolutely positioned,
+   so two can never occupy the same space. */
+.toolbar__item {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
   cursor: grab;
-  padding: 2px 6px;
   border-radius: 6px;
-  /* Placed sections get position:absolute + left/top inline; the transform
-     (set inline) tracks the cursor 1:1 while dragging, so don't transition it. */
-  transition: background 0.12s;
   touch-action: none;
 }
-/* Hover chip + brighter grip = "this block is draggable". */
-.toolbar__section:hover { background: rgba(120, 150, 210, 0.08); }
-.toolbar__section--dragging { cursor: grabbing; opacity: 0.85; background: rgba(120, 150, 210, 0.12); }
-.toolbar__section button,
-.toolbar__section a,
-.toolbar__section .toolbar__char-system--clickable { cursor: pointer; }
-.toolbar__section input { cursor: text; }
+.toolbar__item--dragging { cursor: grabbing; }
+.toolbar__item button,
+.toolbar__item a,
+.toolbar__item .toolbar__char-system--clickable { cursor: pointer; }
+.toolbar__item input { cursor: text; }
 
-/* Six-dot drag grip: discoverable but quiet at rest, emphasised on hover/drag. */
-.toolbar__section-grip {
-  display: flex;
-  align-items: center;
-  margin-right: -2px;
-  color: #5a6886;
-  opacity: 0.3;
-  transition: opacity 0.12s, color 0.12s;
-}
-.toolbar__section:hover .toolbar__section-grip { opacity: 0.85; color: #8a9bc4; }
-.toolbar__section--dragging .toolbar__section-grip { opacity: 1; color: #a9b8dc; }
-
-/* Fixed account actions pinned to the far right (not part of the drag set).
-   align-self keeps them in the top row even when the bar grows for a 2nd row. */
-.toolbar__anchor-right {
+/* Groups several related controls inside a single movable item (e.g. the map
+   switcher + name field), keeping them together as one draggable unit. */
+.toolbar__group {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
-  margin-left: auto;
-  align-self: flex-start;
-  height: 48px;
 }
 
-/* Narrow screens (vertical monitors, smaller laptops): tighten the inter-section
-   gap so more fits per row before wrapping, and give the wrapped rows a little
-   vertical breathing room. The desktop 24px gap is untouched above 1600px. */
+/* The reset-layout affordance is pinned to the far right — it's a layout meta
+   action, not a movable item, and only appears once the layout is customised. */
+.toolbar__reset-layout {
+  margin-left: auto;
+  align-self: center;
+}
+
+/* Narrow screens (vertical monitors, smaller laptops): tighten the inter-item
+   gap so more fits per row before wrapping. */
 @media (max-width: 1600px) {
   .toolbar {
-    column-gap: 14px;
-    padding-top: 6px;
-    padding-bottom: 6px;
+    column-gap: 8px;
   }
 }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6783,6 +6783,10 @@ select.sig-toolbar-btn option {
   background: #0d1117;
   border: 1px solid #1e2740;
   border-radius: 6px;
+  /* Lift clear of the centred canvas hint (bottom: 12px) so the bottom
+     control (center-on-me) isn't overlapped by the hint text in short /
+     narrow viewports. Overrides React Flow's default 15px panel margin. */
+  margin-bottom: 44px;
 
   button {
     background: #0d1117;

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -25,8 +25,13 @@ import {
   PathIcon, MapPinSimpleIcon, HouseIcon, LockIcon, LockOpenIcon,
   XIcon, CheckIcon, PlusIcon, SelectionAllIcon, EyeIcon, CrosshairSimpleIcon,
   LinkSimpleIcon, LinkBreakIcon, ArrowsOutIcon, BookmarkSimpleIcon, TextAaIcon, TrashIcon,
+  HashIcon, ProhibitIcon,
 } from '@phosphor-icons/react';
 import { PREDEFINED_LABELS } from '../../data/labels';
+
+// Quick-tag character set: all letters then all digits, laid out in the grid
+// flyout. A single one of these (or none) marks a system via map_systems.tag.
+const TAG_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.split('');
 import { CustomLabelDialog } from '../ui/CustomLabelDialog';
 import type { MapSystem, SystemIntel } from '../../types';
 import { CLASS_COLORS } from '../../data/wormholes';
@@ -1060,6 +1065,45 @@ export function MapCanvas() {
         },
       ];
 
+      // Tag: a single A-Z / 0-9 badge before the system name. The flyout is a
+      // grid of characters plus a clear cell; picking one persists through the
+      // same updateSystem path and closes the menu. Single-select only.
+      const tagItem = !multiSelected ? [{
+        label: t('ctxMenu.tag'),
+        icon:  <HashIcon size={16} weight="regular" color="#f5a623" />,
+        flyout: (close: () => void) => (
+          <div className="tag-picker">
+            {TAG_CHARS.map((c) => (
+              <button
+                key={c}
+                className={`tag-picker__cell${sys?.tag === c ? ' tag-picker__cell--active' : ''}`}
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  // Toggle: re-picking the current tag clears it.
+                  updateSystem(contextMenu.nodeId!, { tag: sys?.tag === c ? null : c });
+                  close();
+                }}
+              >
+                {c}
+              </button>
+            ))}
+            <button
+              className="tag-picker__cell tag-picker__cell--clear"
+              disabled={!sys?.tag}
+              aria-label={t('ctxMenu.clearTag')}
+              data-tooltip={t('ctxMenu.clearTag')}
+              onMouseDown={(e) => {
+                e.stopPropagation();
+                updateSystem(contextMenu.nodeId!, { tag: null });
+                close();
+              }}
+            >
+              <ProhibitIcon size={15} weight="regular" />
+            </button>
+          </div>
+        ),
+      }] : [];
+
       // Labels: toggle predefined coloured pills (A/B/C/1/2/3), open the custom
       // dialog, or clear all. Single-select only — each toggle persists via the
       // same updateSystem path intel uses. Closes the menu on click (reopen to
@@ -1115,6 +1159,7 @@ export function MapCanvas() {
           },
         }] : []),
         ...homeItem,
+        ...tagItem,
         ...intelItem,
         ...labelItem,
         ...multiItems,

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -355,6 +355,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <HouseIcon size={14} weight="regular" />
           </span>
         )}
+        {sys.tag && <span className="system-node__tag">{sys.tag}</span>}
         <span className="system-node__name">{sys.name || t('mapNode.unknown')}</span>
         {sys.security != null && Number.isFinite(Number(sys.security)) && (
           <span className="system-node__truesec" style={{ color: truesecColor(Number(sys.security)) }}>

--- a/web/src/components/ui/ContextMenu.tsx
+++ b/web/src/components/ui/ContextMenu.tsx
@@ -12,6 +12,10 @@ export type ContextMenuItem =
       disabled?: boolean;
       checked?: boolean;
       submenu?: ContextMenuItem[];
+      /** Custom flyout content shown in place of a list submenu (e.g. a grid
+       *  picker). Receives the menu's close handler so its own controls can
+       *  dismiss the menu after acting. Ignored when `submenu` is set. */
+      flyout?: (close: () => void) => ReactNode;
     };
 
 interface Props {
@@ -103,15 +107,16 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
         if ('separator' in item && item.separator) {
           return <li key={i} className="context-menu__separator" role="separator" />;
         }
-        const { label, icon, action, disabled, checked, submenu } = item;
+        const { label, icon, action, disabled, checked, submenu, flyout } = item;
+        const hasFlyout = !!submenu || !!flyout;
         return (
-          <li key={label} className="context-menu__li" onMouseEnter={() => setOpenSubmenu(submenu ? i : null)}>
+          <li key={label} className="context-menu__li" onMouseEnter={() => setOpenSubmenu(hasFlyout ? i : null)}>
             <button
               className="context-menu__item"
               disabled={disabled}
               onMouseDown={(e) => {
                 e.stopPropagation();
-                if (!disabled && action && !submenu) {
+                if (!disabled && action && !hasFlyout) {
                   action();
                   onClose();
                 }
@@ -122,10 +127,14 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
               )}
               {icon && <span className="context-menu__icon">{icon}</span>}
               {label}
-              {submenu && <span className="context-menu__arrow"><CaretRightIcon size={12} weight="bold" /></span>}
+              {hasFlyout && <span className="context-menu__arrow"><CaretRightIcon size={12} weight="bold" /></span>}
             </button>
-            {submenu && openSubmenu === i && (
-              <SubMenu items={submenu} onClose={onClose} />
+            {openSubmenu === i && (
+              submenu
+                ? <SubMenu items={submenu} onClose={onClose} />
+                : flyout
+                  ? <div className="context-menu context-menu--sub context-menu--flyout">{flyout(onClose)}</div>
+                  : null
             )}
           </li>
         );

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -110,12 +110,19 @@ const DEFAULT_WIDTHS: Record<ColKey, number> = {
   id:      72,
   type:    108,
   whtype:  170,
-  leadsto: 105,
+  leadsto: 132,
   name:    140,
   notes:   220,
   created: 80,
   updated: 80,
 };
+
+// The leads-to cell holds the destination picker AND the copy-bookmark button
+// side by side; below this the picker can't show a full J-code (J######)
+// without the copy button spilling into the next column. Enforced as a floor
+// on the column width so neither a squeezed narrow viewport nor a saved-narrow
+// layout can clip it.
+const LEADSTO_MIN_WIDTH = 132;
 
 // Grace-period choices (seconds) offered before an overwrite-paste actually
 // deletes a despawned sig. 0 = delete immediately. Compact s/m labels read
@@ -224,11 +231,14 @@ export function SignaturePane({ systemId }: { systemId: string }) {
     {},
   );
   // Merge with defaults at read time so a later-added column gracefully
-  // picks up its default width without invalidating the saved layout.
-  const colWidths = useMemo(
-    () => ({ ...DEFAULT_WIDTHS, ...savedColWidths }) as Record<ColKey, number>,
-    [savedColWidths],
-  );
+  // picks up its default width without invalidating the saved layout. The
+  // leads-to column is clamped to LEADSTO_MIN_WIDTH so a saved-narrow layout
+  // can't reintroduce the picker/copy-button overlap.
+  const colWidths = useMemo(() => {
+    const merged = { ...DEFAULT_WIDTHS, ...savedColWidths } as Record<ColKey, number>;
+    merged.leadsto = Math.max(LEADSTO_MIN_WIDTH, merged.leadsto);
+    return merged;
+  }, [savedColWidths]);
 
   const pendingUpdates = useRef<Map<string, Partial<Signature>>>(new Map());
   const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -304,6 +314,17 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   }, []);
 
   const { isShareMode } = useShareMode();
+
+  // Sum of all column widths (plus the fixed checkbox / actions columns when
+  // present). Applied as the table's min-width so a narrow pane scrolls
+  // horizontally inside .sig-table-wrap instead of table-layout:fixed
+  // squeezing every column down — which is what clipped the leads-to name and
+  // spilled the copy button over the next column.
+  const tableMinWidth = useMemo(
+    () => Object.values(colWidths).reduce((a, b) => a + b, 0) + (isShareMode ? 0 : 24 + 28),
+    [colWidths, isShareMode],
+  );
+
   // Bumped when another client changes this system's sigs (live sync).
   const sigRev = useMapStore((s) => s.sigRev[systemId] ?? 0);
 
@@ -767,7 +788,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
         <div className="sig-pane__empty">{t('signatures.noMatchFilter')}</div>
       ) : (
         <div className="sig-table-wrap">
-        <table className="sig-table">
+        <table className="sig-table" style={{ minWidth: tableMinWidth }}>
           <colgroup>
             {/* In share mode the checkbox and per-row delete cells are
                 gone, so their <col> entries must drop too — otherwise

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -170,7 +170,7 @@ function CheckedAtIcon({ checkedAt }: { checkedAt: Date }) {
 // reflows and wraps instead of stacking. Conditional items (admin, proximity,
 // account actions) simply drop out of the rendered list when absent.
 const DEFAULT_TOOLBAR_ORDER = [
-  'brand', 'map', 'stats', 'proximity', 'tools', 'server', 'account',
+  'map', 'stats', 'proximity', 'tools', 'server', 'account',
   'actions',
 ];
 
@@ -320,12 +320,6 @@ export function Toolbar() {
   // Each movable item's content, keyed by id. Items that evaluate to null are
   // simply not rendered (and not persisted in the order).
   const items: Record<string, ReactNode> = {
-    brand: (
-      <div className="toolbar__brand">
-        <span className="toolbar__logo">◈</span>
-      </div>
-    ),
-
     map: (
       <div className="toolbar__group">
         <div className="toolbar__map-switcher" ref={mapSwitcherRef}>
@@ -661,6 +655,11 @@ export function Toolbar() {
   return (
     <>
     <header className="toolbar toolbar--free">
+      {/* Fixed brand anchor — always top-left, never draggable. */}
+      <div className="toolbar__brand">
+        <span className="toolbar__logo">◈</span>
+      </div>
+
       <DndContext sensors={dragSensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <SortableContext items={renderOrder} strategy={rectSortingStrategy}>
           {renderOrder.map((id) => (

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, type ReactNode, type CSSProperties } from 'react';
+import { useState, useEffect, useRef, type ReactNode, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { timeAgo, jumps } from '../../i18n/format';
@@ -23,14 +23,18 @@ import { useProximityAlerts } from '../../hooks/useProximityAlerts';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { useUserSetting } from '../../hooks/useUserSetting';
 import {
-  DndContext, PointerSensor, useSensor, useSensors, useDraggable,
+  DndContext, PointerSensor, useSensor, useSensors, closestCenter,
   type DragEndEvent,
 } from '@dnd-kit/core';
+import {
+  SortableContext, useSortable, arrayMove, rectSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
-  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon, DotsSixVerticalIcon,
+  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { charPortrait, typeIcon } from '../../utils/eveImages';
@@ -160,93 +164,36 @@ function CheckedAtIcon({ checkedAt }: { checkedAt: Date }) {
   );
 }
 
-// Persistent indicator for the nearest live threat (incursion / insurgency).
-// Mounts the proximity hook (which also fires the browser notification + beep
-// on threshold crossings — Toolbar is rendered once for every logged-in user).
-function ProximityChip() {
-  const { nearest, threshold } = useProximityAlerts();
-  const { t } = useTranslation();
-  // The user's configurable threshold gates both display and the alert state —
-  // if the chip is shown, the threat is in-zone by definition. Filters out the
-  // permanent "20 jumps — …" noise on most maps.
-  if (!nearest || nearest.jumps > threshold) return null;
-  const { label, Icon }: { label: string; Icon: PhosphorIcon } =
-    nearest.kind === 'incursion'   ? { label: t('toolbar.proximity.incursion'),  Icon: WarningIcon } :
-    nearest.kind === 'insurgency'  ? { label: t('toolbar.proximity.insurgency'), Icon: SkullIcon } :
-    nearest.kind === 'hostile-sov' ? { label: t('toolbar.proximity.hostileSov'), Icon: XCircleIcon } :
-    { label: t('toolbar.proximity.threat'), Icon: QuestionIcon };
-  return (
-    <span
-      className="toolbar__proximity toolbar__proximity--alert tooltip-right"
-      data-tooltip={t('toolbar.proximity.closest', { label: label.toLowerCase() })}
-    >
-      <span className="toolbar__proximity-icon"><Icon size={14} weight="bold" /></span>
-      <span className="toolbar__proximity-text">
-        {nearest.jumps === 0 ? 'IN' : jumps(t, nearest.jumps)} - {label}
-      </span>
-    </span>
-  );
-}
+// Every movable toolbar control, in default left-to-right order. Each id maps to
+// a node built in the component below; the persisted layout is just a reordering
+// of these ids, so two items can never occupy the same space — the flex row
+// reflows and wraps instead of stacking. Conditional items (admin, proximity,
+// account actions) simply drop out of the rendered list when absent.
+const DEFAULT_TOOLBAR_ORDER = [
+  'brand', 'map', 'stats', 'proximity', 'admin', 'userstats', 'help',
+  'whchart', 'heatmap', 'mapoptions', 'trackjumps', 'server', 'account',
+  'actions',
+];
 
-// The reorderable toolbar groups, in their default left-to-right order. The
-// brand (far left) and the account actions — API keys + sign out (far right) —
-// are fixed and deliberately NOT in this list.
-// Default left-to-right order of the freely-placeable sections (used for the
-// flow layout that seeds their default positions).
-const DEFAULT_TOOLBAR_ORDER = ['map', 'status', 'tools', 'server', 'account'];
-
-// Min gap (px) kept between sections so they never visually touch.
-const SECTION_GAP = 6;
-
-// Snap a dropped section's x to the nearest spot that doesn't overlap any
-// section sharing its row, so groups can't land on top of each other. `bars`
-// are the x-intervals {l,r} of those same-row sections. If the drop point is
-// already clear it's kept; otherwise the closest free slot (just before/after
-// an obstacle, or a bar edge) is chosen.
-function nearestFreeX(desiredX: number, w: number, bars: { l: number; r: number }[], barW: number): number {
-  const fits = (px: number) =>
-    px >= 0 && px + w <= barW && !bars.some((b) => px < b.r + SECTION_GAP && px + w + SECTION_GAP > b.l);
-  if (fits(desiredX)) return desiredX;
-  const cands = [0, Math.max(0, barW - w)];
-  for (const b of bars) { cands.push(b.r + SECTION_GAP, b.l - w - SECTION_GAP); }
-  const valid = cands.filter(fits);
-  if (!valid.length) return desiredX; // row full — nothing we can do, leave it
-  valid.sort((a, b) => Math.abs(a - desiredX) - Math.abs(b - desiredX));
-  return valid[0];
-}
-
-// One freely-placeable toolbar group. Always draggable, no separate handle: the
-// 6px pointer activation distance (see the DndContext sensor) means a tap still
-// clicks the controls inside — only a press-and-move starts a drag. The dragged
-// section follows the cursor (transform); nothing else shifts. `gap` is a saved
-// margin-left so the group keeps the empty space you dropped it with, and the
-// left-to-right flow makes overlap impossible.
-function ToolbarSection({
-  id, pos, registerRef, children,
-}: {
-  id: string;
-  // Absolute position once known; null while it's still in flow (pre-measure).
-  pos: { x: number; y: number } | null;
-  registerRef: (id: string, el: HTMLElement | null) => void;
-  children: ReactNode;
-}) {
-  const { setNodeRef, listeners, transform, isDragging } = useDraggable({ id });
-  const moved = transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined;
-  const style: CSSProperties = pos
-    ? { position: 'absolute', left: pos.x, top: pos.y, transform: moved, zIndex: isDragging ? 50 : undefined }
-    : { transform: moved, zIndex: isDragging ? 50 : undefined };
+// One movable toolbar item. The whole item is the drag handle; the 6px pointer
+// activation distance (see the DndContext sensor) means a tap still clicks the
+// control inside — only a press-and-move starts a reorder. Sortable transforms
+// animate the other items out of the way, so nothing ever overlaps.
+function SortableItem({ id, children }: { id: string; children: ReactNode }) {
+  const { setNodeRef, listeners, transform, transition, isDragging } = useSortable({ id });
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+    opacity: isDragging ? 0.85 : undefined,
+  };
   return (
     <div
-      ref={(el) => { setNodeRef(el); registerRef(id, el); }}
-      className={`toolbar__section${isDragging ? ' toolbar__section--dragging' : ''}${pos ? ' toolbar__section--placed' : ''}`}
+      ref={setNodeRef}
+      className={`toolbar__item${isDragging ? ' toolbar__item--dragging' : ''}`}
       style={style}
       {...listeners}
     >
-      {/* Drag affordance: faint at rest, brightens on hover (the whole section
-          is the drag target, this just signals it). */}
-      <span className="toolbar__section-grip" aria-hidden="true">
-        <DotsSixVerticalIcon size={13} weight="bold" />
-      </span>
       {children}
     </div>
   );
@@ -312,77 +259,28 @@ export function Toolbar() {
   const mapSwitcherRef = useRef<HTMLDivElement>(null);
   useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
 
-  // Per-user, cross-device toolbar layout. Each reorderable section is freely
-  // placed: an absolute {x,y} relative to the bar. `savedPositions` holds only
-  // the sections the user has actually dragged; everything else falls back to a
-  // measured default — a tidy left-to-right row laid out in flow, then captured
-  // (and re-captured on resize so it stays responsive). Reset clears the saved
-  // positions and drops back to those defaults.
-  const [savedPositions, setSavedPositions] =
-    useUserSetting<Record<string, { x: number; y: number }>>('nexum.toolbar.positions', {});
-  const [defaultPositions, setDefaultPositions] = useState<Record<string, { x: number; y: number }>>({});
-  const posOf = (id: string): { x: number; y: number } | null =>
-    savedPositions[id] ?? defaultPositions[id] ?? null;
-  const atDefaultLayout = Object.keys(savedPositions).length === 0;
-  // Clear the measured defaults too, so EVERY section re-flows into a clean
-  // tidy row and re-seeds. Clearing only the saved positions would leave the
-  // sections you'd dragged with no default (back to flow) while the rest stayed
-  // absolute at their old defaults — and the two would overlap.
-  const resetLayout = () => { setSavedPositions({}); setDefaultPositions({}); };
+  // The proximity hook is mounted here (not inside the chip) so it keeps firing
+  // the browser notification + beep on threshold crossings even when the chip
+  // itself is hidden — the chip is only a visual item that drops out of the
+  // toolbar when there's no in-zone threat.
+  const { nearest: nearestThreat, threshold: threatThreshold } = useProximityAlerts();
+
+  // Per-user, cross-device toolbar layout: a saved ORDER of item ids. Storing an
+  // order (not x/y positions) means the flex row simply reflows — items can be
+  // moved anywhere but can never overlap. Empty = the default order.
+  const [savedOrder, setSavedOrder] = useUserSetting<string[]>('nexum.toolbar.order', []);
+  const atDefaultLayout = savedOrder.length === 0;
+  const resetLayout = () => setSavedOrder([]);
 
   const dragSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
-  const toolbarRef = useRef<HTMLElement>(null);
-  const sectionEls = useRef<Map<string, HTMLElement>>(new Map());
-  const registerSectionRef = (id: string, el: HTMLElement | null) => {
-    if (el) sectionEls.current.set(id, el); else sectionEls.current.delete(id);
-  };
 
-  // Seed the default position of any section that doesn't have one yet by
-  // measuring where it lands in flow (it renders in flow, vertically centred,
-  // until placed). Runs after layout; a no-op once every section has a position.
-  useLayoutEffect(() => {
-    const tb = toolbarRef.current?.getBoundingClientRect();
-    if (!tb) return;
-    let patch: Record<string, { x: number; y: number }> | null = null;
-    sectionEls.current.forEach((el, id) => {
-      if (savedPositions[id] || defaultPositions[id]) return;
-      const r = el.getBoundingClientRect();
-      (patch ??= {})[id] = { x: Math.round(r.left - tb.left), y: Math.round(r.top - tb.top) };
-    });
-    if (patch) setDefaultPositions((d) => ({ ...d, ...patch }));
-  }, [savedPositions, defaultPositions, user]);
-
-  // On resize, drop the measured defaults so un-customised sections re-flow and
-  // re-seed at the new width. User-dragged (saved) positions are left alone.
-  useEffect(() => {
-    let t: ReturnType<typeof setTimeout>;
-    const onResize = () => { clearTimeout(t); t = setTimeout(() => setDefaultPositions({}), 150); };
-    window.addEventListener('resize', onResize);
-    return () => { clearTimeout(t); window.removeEventListener('resize', onResize); };
-  }, []);
-
-  const onSectionDragEnd = (e: DragEndEvent) => {
-    const id = e.active.id as string;
-    const cur = posOf(id);
-    const tb = toolbarRef.current?.getBoundingClientRect();
-    const el = sectionEls.current.get(id);
-    if (!cur || !tb || !el) return;
-    // Land where dropped (start + drag delta); clamp to stay on the bar and
-    // within ~two rows. Absolute placement means no reflow — it stays put.
-    const w = el.offsetWidth, h = el.offsetHeight;
-    const y = Math.min(Math.max(0, Math.round(cur.y + e.delta.y)), 56);
-    const dropX = Math.min(Math.max(0, Math.round(cur.x + e.delta.x)), Math.max(0, tb.width - w));
-    // Sections that share the dropped row (vertically overlapping) are obstacles;
-    // snap x to the nearest free slot so groups can't be dropped onto each other.
-    const bars: { l: number; r: number }[] = [];
-    sectionEls.current.forEach((oel, oid) => {
-      if (oid === id) return;
-      const p = posOf(oid);
-      if (!p || y + h <= p.y || y >= p.y + oel.offsetHeight) return;
-      bars.push({ l: p.x, r: p.x + oel.offsetWidth });
-    });
-    const x = nearestFreeX(dropX, w, bars, tb.width);
-    setSavedPositions({ ...savedPositions, [id]: { x, y } });
+  const onDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const from = fullOrder.indexOf(active.id as string);
+    const to   = fullOrder.indexOf(over.id as string);
+    if (from < 0 || to < 0) return;
+    setSavedOrder(arrayMove(fullOrder, from, to));
   };
 
   async function handleDeleteMap() {
@@ -390,11 +288,43 @@ export function Toolbar() {
     await deleteMap(activeMapId);
   }
 
-  // Each reorderable section's content, keyed by id. Brand and the account
-  // actions (API keys / sign out) live outside this map — they're pinned.
-  const sections: Record<string, ReactNode> = {
+  // Nearest-threat chip: null unless an in-zone threat exists (the user's
+  // threshold gates both the alert and the chip). Built here from the lifted
+  // hook so it can be an independently movable item.
+  const proximityNode: ReactNode = (nearestThreat && nearestThreat.jumps <= threatThreshold)
+    ? (() => {
+        const { label, Icon }: { label: string; Icon: PhosphorIcon } =
+          nearestThreat.kind === 'incursion'   ? { label: t('toolbar.proximity.incursion'),  Icon: WarningIcon } :
+          nearestThreat.kind === 'insurgency'  ? { label: t('toolbar.proximity.insurgency'), Icon: SkullIcon } :
+          nearestThreat.kind === 'hostile-sov' ? { label: t('toolbar.proximity.hostileSov'), Icon: XCircleIcon } :
+          { label: t('toolbar.proximity.threat'), Icon: QuestionIcon };
+        return (
+          <span
+            className="toolbar__proximity toolbar__proximity--alert tooltip-right"
+            data-tooltip={t('toolbar.proximity.closest', { label: label.toLowerCase() })}
+          >
+            <span className="toolbar__proximity-icon"><Icon size={14} weight="bold" /></span>
+            <span className="toolbar__proximity-text">
+              {nearestThreat.jumps === 0 ? 'IN' : jumps(t, nearestThreat.jumps)} - {label}
+            </span>
+          </span>
+        );
+      })()
+    : null;
+
+  const showAdmin = !!user && (user.canViewReports || (user.role === 'admin' && user.corpMode));
+
+  // Each movable item's content, keyed by id. Items that evaluate to null are
+  // simply not rendered (and not persisted in the order).
+  const items: Record<string, ReactNode> = {
+    brand: (
+      <div className="toolbar__brand">
+        <span className="toolbar__logo">◈</span>
+      </div>
+    ),
+
     map: (
-      <>
+      <div className="toolbar__group">
         <div className="toolbar__map-switcher" ref={mapSwitcherRef}>
           <button
             className="toolbar__map-name-btn"
@@ -495,97 +425,103 @@ export function Toolbar() {
             value={mapName}
             onChange={(e) => setMapName(e.target.value)}
             // Let the field own its pointer (caret / text selection) without the
-            // surrounding section reading the drag as a reorder.
+            // surrounding item reading the drag as a reorder.
             onPointerDown={(e) => e.stopPropagation()}
             spellCheck={false}
             readOnly={!canEdit || !isMapOwner}
           />
         </div>
-      </>
+      </div>
     ),
 
-    status: (
-      <>
-        <div className="toolbar__stats">
-          <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>
-            <PlanetIcon size={16} weight="regular" />
-            <span className="toolbar__stat-count">{systemCount}</span>
-          </span>
-          <span className="toolbar__stat" data-tooltip={t('toolbar.totalConnections')}>
-            <LinkSimpleIcon size={16} weight="regular" />
-            <span className="toolbar__stat-count">{connectionCount}</span>
-          </span>
-        </div>
-        <ProximityChip />
-      </>
+    stats: (
+      <div className="toolbar__stats">
+        <span className="toolbar__stat" data-tooltip={t('toolbar.totalSystems')}>
+          <PlanetIcon size={16} weight="regular" />
+          <span className="toolbar__stat-count">{systemCount}</span>
+        </span>
+        <span className="toolbar__stat" data-tooltip={t('toolbar.totalConnections')}>
+          <LinkSimpleIcon size={16} weight="regular" />
+          <span className="toolbar__stat-count">{connectionCount}</span>
+        </span>
+      </div>
     ),
 
-    tools: (
-      <>
-        {user && (user.canViewReports || (user.role === 'admin' && user.corpMode)) && (
-          <button
-            className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-            onClick={() => { window.location.hash = '#/admin/users'; }}
-            data-tooltip={t('toolbar.admin')}
-            aria-label={t('toolbar.admin')}
-          >
-            <ShieldStarIcon size={18} weight="regular" />
-          </button>
-        )}
-        <button
-          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-          onClick={() => setShowStats(true)}
-          data-tooltip={t('toolbar.userStats')}
-          aria-label={t('toolbar.userStats')}
-        >
-          <ChartBarIcon size={18} weight="regular" />
-        </button>
+    proximity: proximityNode,
 
-        <a
-          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-          href="/help/"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-tooltip={t('toolbar.help')}
-          aria-label={t('toolbar.help')}
-        >
-          <QuestionIcon size={18} weight="regular" />
-        </a>
+    admin: showAdmin ? (
+      <button
+        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+        onClick={() => { window.location.hash = '#/admin/users'; }}
+        data-tooltip={t('toolbar.admin')}
+        aria-label={t('toolbar.admin')}
+      >
+        <ShieldStarIcon size={18} weight="regular" />
+      </button>
+    ) : null,
 
-        <button
-          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-          onClick={() => setShowWhChart(true)}
-          data-tooltip={t('whChart.tooltip')}
-          aria-label={t('whChart.title')}
-        >
-          <GraphIcon size={18} weight="regular" />
-        </button>
+    userstats: (
+      <button
+        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+        onClick={() => setShowStats(true)}
+        data-tooltip={t('toolbar.userStats')}
+        aria-label={t('toolbar.userStats')}
+      >
+        <ChartBarIcon size={18} weight="regular" />
+      </button>
+    ),
 
-        <HeatmapMenu />
+    help: (
+      <a
+        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+        href="/help/"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-tooltip={t('toolbar.help')}
+        aria-label={t('toolbar.help')}
+      >
+        <QuestionIcon size={18} weight="regular" />
+      </a>
+    ),
 
-        <button
-          className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
-          onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
-          aria-pressed={mapOptionsOpen}
-          data-tooltip={t('toolbar.mapOptions')}
-          aria-label={t('toolbar.mapOptions')}
-        >
-          <SlidersHorizontalIcon size={18} weight="regular" />
-        </button>
+    whchart: (
+      <button
+        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+        onClick={() => setShowWhChart(true)}
+        data-tooltip={t('whChart.tooltip')}
+        aria-label={t('whChart.title')}
+      >
+        <GraphIcon size={18} weight="regular" />
+      </button>
+    ),
 
-        <button
-          className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
-          onClick={() => setTrackJumps(!trackJumps)}
-          aria-pressed={trackJumps}
-          aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
-          data-tooltip={trackJumps
-            ? t('toolbar.trackJumpsTooltipOn')
-            : t('toolbar.trackJumpsTooltipOff')}
-        >
-          <FootprintsIcon size={18} weight="regular" />
-          <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
-        </button>
-      </>
+    heatmap: <HeatmapMenu />,
+
+    mapoptions: (
+      <button
+        className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
+        onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
+        aria-pressed={mapOptionsOpen}
+        data-tooltip={t('toolbar.mapOptions')}
+        aria-label={t('toolbar.mapOptions')}
+      >
+        <SlidersHorizontalIcon size={18} weight="regular" />
+      </button>
+    ),
+
+    trackjumps: (
+      <button
+        className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
+        onClick={() => setTrackJumps(!trackJumps)}
+        aria-pressed={trackJumps}
+        aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
+        data-tooltip={trackJumps
+          ? t('toolbar.trackJumpsTooltipOn')
+          : t('toolbar.trackJumpsTooltipOff')}
+      >
+        <FootprintsIcon size={18} weight="regular" />
+        <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
+      </button>
     ),
 
     server: (
@@ -690,60 +626,61 @@ export function Toolbar() {
         <CharacterSwitcher />
       </div>
     ) : null,
+
+    // Language, API keys and sign-out travel together as one movable block.
+    actions: user ? (
+      <div className="toolbar__group">
+        <LanguageSwitcher />
+        <button
+          className="toolbar__toggle toolbar__toggle--icon"
+          onClick={() => setShowKeys(true)}
+          data-tooltip={t('apiKeys.title')}
+          aria-label={t('apiKeys.title')}
+        >
+          <KeyIcon size={18} weight="regular" />
+        </button>
+        <button
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          onClick={logout}
+          data-tooltip={t('toolbar.signOut')}
+          aria-label={t('toolbar.signOut')}
+        >
+          <SignOutIcon size={18} weight="regular" />
+        </button>
+      </div>
+    ) : null,
   };
 
-  const renderOrder = DEFAULT_TOOLBAR_ORDER.filter((id) => sections[id] != null);
-  // Grow the bar to fit the lowest-placed section (so a second row isn't clipped).
-  // ROW_H is a generous single-row height — erring tall just adds a little slack.
-  const ROW_H = 52;
-  const maxY = renderOrder.reduce((m, id) => Math.max(m, posOf(id)?.y ?? 0), 0);
-  const toolbarMinHeight = Math.max(ROW_H, maxY + ROW_H);
+  // The full known ordering: saved order first (any stale ids that no longer
+  // exist are dropped), then any items the user hasn't placed yet appended in
+  // default order — so a newly-added control shows up without wiping the layout.
+  const fullOrder = [
+    ...savedOrder.filter((id) => DEFAULT_TOOLBAR_ORDER.includes(id)),
+    ...DEFAULT_TOOLBAR_ORDER.filter((id) => !savedOrder.includes(id)),
+  ];
+  // Only items that actually render this pass participate in the sortable list.
+  const renderOrder = fullOrder.filter((id) => items[id] != null);
 
   return (
     <>
-    <header className="toolbar toolbar--free" ref={toolbarRef} style={{ minHeight: toolbarMinHeight }}>
-      <div className="toolbar__brand">
-        <span className="toolbar__logo">◈</span>
-      </div>
-
-      <DndContext sensors={dragSensors} onDragEnd={onSectionDragEnd}>
-        {renderOrder.map((id) => (
-          <ToolbarSection key={id} id={id} pos={posOf(id)} registerRef={registerSectionRef}>
-            {sections[id]}
-          </ToolbarSection>
-        ))}
+    <header className="toolbar toolbar--free">
+      <DndContext sensors={dragSensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+        <SortableContext items={renderOrder} strategy={rectSortingStrategy}>
+          {renderOrder.map((id) => (
+            <SortableItem key={id} id={id}>{items[id]}</SortableItem>
+          ))}
+        </SortableContext>
       </DndContext>
 
-      {user && (
-        <div className="toolbar__anchor-right">
-          {!atDefaultLayout && (
-            <button
-              className="toolbar__toggle toolbar__toggle--icon"
-              onClick={resetLayout}
-              data-tooltip={t('toolbar.resetLayout')}
-              aria-label={t('toolbar.resetLayout')}
-            >
-              <ArrowCounterClockwiseIcon size={16} weight="regular" />
-            </button>
-          )}
-          <LanguageSwitcher />
-          <button
-            className="toolbar__toggle toolbar__toggle--icon"
-            onClick={() => setShowKeys(true)}
-            data-tooltip={t('apiKeys.title')}
-            aria-label={t('apiKeys.title')}
-          >
-            <KeyIcon size={18} weight="regular" />
-          </button>
-          <button
-            className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-            onClick={logout}
-            data-tooltip={t('toolbar.signOut')}
-            aria-label={t('toolbar.signOut')}
-          >
-            <SignOutIcon size={18} weight="regular" />
-          </button>
-        </div>
+      {user && !atDefaultLayout && (
+        <button
+          className="toolbar__toggle toolbar__toggle--icon toolbar__reset-layout"
+          onClick={resetLayout}
+          data-tooltip={t('toolbar.resetLayout')}
+          aria-label={t('toolbar.resetLayout')}
+        >
+          <ArrowCounterClockwiseIcon size={16} weight="regular" />
+        </button>
       )}
     </header>
 

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -34,7 +34,7 @@ import {
   WarningIcon, SkullIcon, XCircleIcon, QuestionIcon,
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
-  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon,
+  KeyIcon, GraphIcon, ArrowCounterClockwiseIcon, DotsSixVerticalIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { charPortrait, typeIcon } from '../../utils/eveImages';
@@ -170,15 +170,15 @@ function CheckedAtIcon({ checkedAt }: { checkedAt: Date }) {
 // reflows and wraps instead of stacking. Conditional items (admin, proximity,
 // account actions) simply drop out of the rendered list when absent.
 const DEFAULT_TOOLBAR_ORDER = [
-  'brand', 'map', 'stats', 'proximity', 'admin', 'userstats', 'help',
-  'whchart', 'heatmap', 'mapoptions', 'trackjumps', 'server', 'account',
+  'brand', 'map', 'stats', 'proximity', 'tools', 'server', 'account',
   'actions',
 ];
 
-// One movable toolbar item. The whole item is the drag handle; the 6px pointer
-// activation distance (see the DndContext sensor) means a tap still clicks the
-// control inside — only a press-and-move starts a reorder. Sortable transforms
-// animate the other items out of the way, so nothing ever overlaps.
+// One movable toolbar item. The whole item is the drag handle (with a visible
+// six-dot grip signalling it can be dragged); the 6px pointer activation
+// distance (see the DndContext sensor) means a tap still clicks the control
+// inside — only a press-and-move starts a reorder. Sortable transforms animate
+// the other items out of the way, so nothing ever overlaps.
 function SortableItem({ id, children }: { id: string; children: ReactNode }) {
   const { setNodeRef, listeners, transform, transition, isDragging } = useSortable({ id });
   const style: CSSProperties = {
@@ -194,6 +194,9 @@ function SortableItem({ id, children }: { id: string; children: ReactNode }) {
       style={style}
       {...listeners}
     >
+      <span className="toolbar__item-grip" aria-hidden="true">
+        <DotsSixVerticalIcon size={13} weight="bold" />
+      </span>
       {children}
     </div>
   );
@@ -449,79 +452,73 @@ export function Toolbar() {
 
     proximity: proximityNode,
 
-    admin: showAdmin ? (
-      <button
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        onClick={() => { window.location.hash = '#/admin/users'; }}
-        data-tooltip={t('toolbar.admin')}
-        aria-label={t('toolbar.admin')}
-      >
-        <ShieldStarIcon size={18} weight="regular" />
-      </button>
-    ) : null,
+    // All the explicit action buttons travel together as one movable block.
+    tools: (
+      <div className="toolbar__group">
+        {showAdmin && (
+          <button
+            className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+            onClick={() => { window.location.hash = '#/admin/users'; }}
+            data-tooltip={t('toolbar.admin')}
+            aria-label={t('toolbar.admin')}
+          >
+            <ShieldStarIcon size={18} weight="regular" />
+          </button>
+        )}
+        <button
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          onClick={() => setShowStats(true)}
+          data-tooltip={t('toolbar.userStats')}
+          aria-label={t('toolbar.userStats')}
+        >
+          <ChartBarIcon size={18} weight="regular" />
+        </button>
 
-    userstats: (
-      <button
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        onClick={() => setShowStats(true)}
-        data-tooltip={t('toolbar.userStats')}
-        aria-label={t('toolbar.userStats')}
-      >
-        <ChartBarIcon size={18} weight="regular" />
-      </button>
-    ),
+        <a
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          href="/help/"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-tooltip={t('toolbar.help')}
+          aria-label={t('toolbar.help')}
+        >
+          <QuestionIcon size={18} weight="regular" />
+        </a>
 
-    help: (
-      <a
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        href="/help/"
-        target="_blank"
-        rel="noopener noreferrer"
-        data-tooltip={t('toolbar.help')}
-        aria-label={t('toolbar.help')}
-      >
-        <QuestionIcon size={18} weight="regular" />
-      </a>
-    ),
+        <button
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          onClick={() => setShowWhChart(true)}
+          data-tooltip={t('whChart.tooltip')}
+          aria-label={t('whChart.title')}
+        >
+          <GraphIcon size={18} weight="regular" />
+        </button>
 
-    whchart: (
-      <button
-        className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
-        onClick={() => setShowWhChart(true)}
-        data-tooltip={t('whChart.tooltip')}
-        aria-label={t('whChart.title')}
-      >
-        <GraphIcon size={18} weight="regular" />
-      </button>
-    ),
+        <HeatmapMenu />
 
-    heatmap: <HeatmapMenu />,
+        <button
+          className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
+          onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
+          aria-pressed={mapOptionsOpen}
+          data-tooltip={t('toolbar.mapOptions')}
+          aria-label={t('toolbar.mapOptions')}
+        >
+          <SlidersHorizontalIcon size={18} weight="regular" />
+        </button>
 
-    mapoptions: (
-      <button
-        className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${mapOptionsOpen ? ' toolbar__toggle--on' : ''}`}
-        onClick={() => setMapOptionsOpen(!mapOptionsOpen)}
-        aria-pressed={mapOptionsOpen}
-        data-tooltip={t('toolbar.mapOptions')}
-        aria-label={t('toolbar.mapOptions')}
-      >
-        <SlidersHorizontalIcon size={18} weight="regular" />
-      </button>
-    ),
-
-    trackjumps: (
-      <button
-        className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
-        onClick={() => setTrackJumps(!trackJumps)}
-        aria-pressed={trackJumps}
-        aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
-        data-tooltip={trackJumps
-          ? t('toolbar.trackJumpsTooltipOn')
-          : t('toolbar.trackJumpsTooltipOff')}
-      >
-        <FootprintsIcon size={18} weight="regular" />
-        <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
-      </button>
+        <button
+          className={`toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent${trackJumps ? ' toolbar__toggle--on' : ''}`}
+          onClick={() => setTrackJumps(!trackJumps)}
+          aria-pressed={trackJumps}
+          aria-label={trackJumps ? t('toolbar.trackJumpsOn') : t('toolbar.trackJumpsOff')}
+          data-tooltip={trackJumps
+            ? t('toolbar.trackJumpsTooltipOn')
+            : t('toolbar.trackJumpsTooltipOff')}
+        >
+          <FootprintsIcon size={18} weight="regular" />
+          <span className={`toolbar__toggle-led${trackJumps ? ' toolbar__toggle-led--on' : ' toolbar__toggle-led--off'}`} />
+        </button>
+      </div>
     ),
 
     server: (

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -187,7 +187,7 @@ const nexumDebug = {
     import('./utils/debugFlags').then(({ getDebugFlag, setDebugFlag }) => {
       const next = typeof on === 'boolean' ? on : !getDebugFlag('showThreats');
       setDebugFlag('showThreats', next);
-      console.log(`[nexum] Show nearby threats: ${next ? 'ON — toolbar shows the nearest threat ignoring your alert threshold' : 'OFF — toolbar respects your alert threshold'}.`);
+      console.log(`[nexum] Show nearby threats: ${next ? 'ON — toolbar shows the nearest threat ignoring your alert threshold (a demo chip if none is detected)' : 'OFF — toolbar respects your alert threshold'}.`);
     });
   },
 

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -179,6 +179,18 @@ const nexumDebug = {
     else console.log('[nexum] No jump simulation running.');
   },
 
+  // Toggle showing the nearest detected threat (incursion / insurgency /
+  // hostile-sov) in the toolbar regardless of the proximity alert threshold —
+  // for verifying the proximity chip without an actual in-zone threat. Pass a
+  // boolean to force on/off, or call with no argument to flip it.
+  showThreats(on?: boolean) {
+    import('./utils/debugFlags').then(({ getDebugFlag, setDebugFlag }) => {
+      const next = typeof on === 'boolean' ? on : !getDebugFlag('showThreats');
+      setDebugFlag('showThreats', next);
+      console.log(`[nexum] Show nearby threats: ${next ? 'ON — toolbar shows the nearest threat ignoring your alert threshold' : 'OFF — toolbar respects your alert threshold'}.`);
+    });
+  },
+
   clear() {
     log.length = 0;
     console.log('[nexum] Debug log cleared.');
@@ -195,6 +207,7 @@ const nexumDebug = {
     console.log("nexumDebug.simulateJumps(['Jita','Perimeter','Jita'], 2000) — replay a route, one hop / interval");
     console.log("nexumDebug.simulateJumps([...], 1000, { dryRun: true }) — replay without firing server writes (logged-out safe)");
     console.log('nexumDebug.stopJumps() — cancel a running jump simulation');
+    console.log('nexumDebug.showThreats(on?)  — toggle showing the nearest threat in the toolbar, ignoring the alert threshold');
     console.log('nexumDebug.clear()     — clear the log buffer');
     console.groupEnd();
   },

--- a/web/src/hooks/useProximityAlerts.ts
+++ b/web/src/hooks/useProximityAlerts.ts
@@ -7,6 +7,7 @@ import { useStandings } from './useStandings';
 import { ensureSovLoaded, getSovEntries } from './useSovData';
 import { useUserSetting, readUserSetting, writeUserSetting } from './useUserSetting';
 import { NOTIFY, notifyOn } from '../utils/notificationPrefs';
+import { useDebugFlag } from '../utils/debugFlags';
 
 export type ThreatKind = 'incursion' | 'insurgency' | 'hostile-sov';
 
@@ -87,6 +88,11 @@ export function useProximityAlerts(): {
   const insurgency = useInsurgency();
   const standings  = useStandings();
   const [threshold] = useProximityThreshold();
+  // nexumDebug.showThreats() flips this to surface the nearest threat in the
+  // toolbar regardless of the alert threshold. Only affects what's DISPLAYED —
+  // the notification/beep below still uses the real threshold so debug mode
+  // doesn't spam alerts for far-off threats.
+  const debugShowThreats = useDebugFlag('showThreats');
 
   // Cluster-wide sov data loads asynchronously the first time anyone
   // consumes it. We need to know when it's ready so we can fold the
@@ -165,5 +171,8 @@ export function useProximityAlerts(): {
     }
   }, [nearest, threshold, nameMap]);
 
-  return { nearest, threshold };
+  // Callers gate display on `nearest.jumps <= threshold`; boosting the returned
+  // threshold under the debug flag makes any detected threat show, while the
+  // real `threshold` above still governs notifications.
+  return { nearest, threshold: debugShowThreats ? Number.MAX_SAFE_INTEGER : threshold };
 }

--- a/web/src/hooks/useProximityAlerts.ts
+++ b/web/src/hooks/useProximityAlerts.ts
@@ -20,6 +20,12 @@ export interface NearestThreat {
 const THRESHOLD_KEY = 'nexum.proximityThreshold';
 const DEFAULT_THRESHOLD = 2;
 
+// Stand-in threat shown when nexumDebug.showThreats() is on but nothing real is
+// detected (e.g. testing in the browser with no live character location, so no
+// route origin exists to measure real threats from). Purely for eyeballing the
+// proximity chip; never used outside debug mode.
+const DEMO_THREAT: NearestThreat = { kind: 'incursion', jumps: 2, systemId: -1 };
+
 function clamp(n: number): number {
   return Math.max(0, Math.min(5, Math.floor(n)));
 }
@@ -171,8 +177,12 @@ export function useProximityAlerts(): {
     }
   }, [nearest, threshold, nameMap]);
 
-  // Callers gate display on `nearest.jumps <= threshold`; boosting the returned
-  // threshold under the debug flag makes any detected threat show, while the
-  // real `threshold` above still governs notifications.
-  return { nearest, threshold: debugShowThreats ? Number.MAX_SAFE_INTEGER : threshold };
+  // Debug: surface a threat regardless of the alert threshold. Show the real
+  // nearest one if there is any (with real jumps), otherwise a demo stand-in so
+  // the chip is always visible for eyeballing. Only the RETURNED values change —
+  // the notification/beep above still keys off the real `nearest` + threshold.
+  if (debugShowThreats) {
+    return { nearest: nearest ?? DEMO_THREAT, threshold: Number.MAX_SAFE_INTEGER };
+  }
+  return { nearest, threshold };
 }

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -722,7 +722,9 @@
     "labels": "Labels",
     "customLabel": "Eigenes Label",
     "clearLabels": "Löschen",
-    "labelNamed": "Label {{name}}"
+    "labelNamed": "Label {{name}}",
+    "tag": "Tag",
+    "clearTag": "Tag entfernen"
   },
   "panel": {
     "notes": "Notizen",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -764,6 +764,8 @@
     "customLabel": "Custom label",
     "clearLabels": "Clear",
     "labelNamed": "Label {{name}}",
+    "tag": "Tag",
+    "clearTag": "Clear tag",
     "lockSystem": "Lock System",
     "unlockSystem": "Unlock System",
     "removeSystem": "Remove System",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -722,7 +722,9 @@
     "labels": "Etiquetas",
     "customLabel": "Etiqueta personalizada",
     "clearLabels": "Borrar",
-    "labelNamed": "Etiqueta {{name}}"
+    "labelNamed": "Etiqueta {{name}}",
+    "tag": "Marca",
+    "clearTag": "Quitar marca"
   },
   "panel": {
     "notes": "Notas",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -722,7 +722,9 @@
     "labels": "Labels",
     "customLabel": "Label personnalisé",
     "clearLabels": "Effacer",
-    "labelNamed": "Label {{name}}"
+    "labelNamed": "Label {{name}}",
+    "tag": "Marqueur",
+    "clearTag": "Effacer le marqueur"
   },
   "panel": {
     "notes": "Notes",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -722,7 +722,9 @@
     "labels": "ラベル",
     "customLabel": "カスタムラベル",
     "clearLabels": "クリア",
-    "labelNamed": "ラベル {{name}}"
+    "labelNamed": "ラベル {{name}}",
+    "tag": "タグ",
+    "clearTag": "タグを消去"
   },
   "panel": {
     "notes": "メモ",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -722,7 +722,9 @@
     "labels": "라벨",
     "customLabel": "사용자 라벨",
     "clearLabels": "지우기",
-    "labelNamed": "라벨 {{name}}"
+    "labelNamed": "라벨 {{name}}",
+    "tag": "태그",
+    "clearTag": "태그 지우기"
   },
   "panel": {
     "notes": "노트",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -722,7 +722,9 @@
     "labels": "Etiquetas",
     "customLabel": "Etiqueta personalizada",
     "clearLabels": "Limpar",
-    "labelNamed": "Etiqueta {{name}}"
+    "labelNamed": "Etiqueta {{name}}",
+    "tag": "Marca",
+    "clearTag": "Limpar marca"
   },
   "panel": {
     "notes": "Notas",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -740,7 +740,9 @@
     "labels": "Метки",
     "customLabel": "Своя метка",
     "clearLabels": "Очистить",
-    "labelNamed": "Метка {{name}}"
+    "labelNamed": "Метка {{name}}",
+    "tag": "Тег",
+    "clearTag": "Убрать тег"
   },
   "panel": {
     "notes": "Заметки",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -722,7 +722,9 @@
     "labels": "标签",
     "customLabel": "自定义标签",
     "clearLabels": "清除",
-    "labelNamed": "标签 {{name}}"
+    "labelNamed": "标签 {{name}}",
+    "tag": "标记",
+    "clearTag": "清除标记"
   },
   "panel": {
     "notes": "笔记",

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -82,6 +82,9 @@ export interface MapSystem {
   labels: string[];
   /** Up to 3 custom labels, each 't:<text>' or 'i:<IconName>' (Phosphor). */
   customLabels: string[];
+  /** Single-character quick tag (A-Z / 0-9), shown as a badge before the name.
+   *  null/undefined = untagged. */
+  tag?: string | null;
   lastActivityAt: string; // ISO timestamp, updated when system or its sigs are touched
 }
 

--- a/web/src/utils/debugFlags.ts
+++ b/web/src/utils/debugFlags.ts
@@ -1,0 +1,39 @@
+import { useSyncExternalStore } from 'react';
+
+// Runtime-only debug flags, toggled from the `nexumDebug` console helpers and
+// read reactively by React via useDebugFlag(). Never persisted — they reset on
+// reload, so they can't leak into a normal session. Kept in a tiny external
+// store (rather than a context) so plain modules like debug.ts can flip them
+// without needing to be inside the React tree.
+export interface DebugFlags {
+  // Show the nearest detected threat in the toolbar regardless of the user's
+  // proximity alert threshold — for eyeballing the proximity chip without an
+  // in-zone incursion/insurgency.
+  showThreats: boolean;
+}
+
+const flags: DebugFlags = {
+  showThreats: false,
+};
+
+const listeners = new Set<() => void>();
+
+export function getDebugFlag<K extends keyof DebugFlags>(key: K): DebugFlags[K] {
+  return flags[key];
+}
+
+export function setDebugFlag<K extends keyof DebugFlags>(key: K, value: DebugFlags[K]): void {
+  if (flags[key] === value) return;
+  flags[key] = value;
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Reactively read a debug flag; components re-render when it's toggled. */
+export function useDebugFlag<K extends keyof DebugFlags>(key: K): DebugFlags[K] {
+  return useSyncExternalStore(subscribe, () => flags[key]);
+}


### PR DESCRIPTION
## Release 1.22.0

Minor release merging `release` into `main`.

### Features
- **Single-character system tags** (A-Z / 0-9) - mark a system with a prominent badge before its name, set from a grid picker in the right-click menu (#368).
- **Reorderable, non-overlapping toolbar** - every control is a draggable block in a reflowing row; overlaps are now structurally impossible, and the previously-pinned account actions are movable. The brand logo stays fixed. Drag handles on every block (#371).
- **`nexumDebug.showThreats()`** - debug toggle to surface the proximity/threat chip regardless of the alert threshold (demo chip when none is detected) (#372).

### Fixes
- Map controls no longer sit under the canvas hint on short/narrow viewports (#369).
- Signature leads-to column no longer clips the destination system name or overlaps the next column on narrow panes (#370).

Version bumped to 1.22.0.

After merge: cut the `v1.22.0` GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)