### PR TITLE
Language switcher: flag-only when logged in

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5414,6 +5414,8 @@ select.sig-toolbar-btn option {
   cursor: pointer;
   transition: border-color 0.15s ease;
 }
+/* Flag-only variant (logged-in toolbar): tighter padding, no gap. */
+.lang-switcher__trigger--compact { gap: 0; padding: 4px 6px; }
 .lang-switcher__trigger:hover { border-color: #4d9de0; }
 .lang-switcher__trigger:focus-visible {
   outline: none;

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -7,7 +7,9 @@ import { LangFlag } from './LangFlag';
 
 // Custom dropdown (not a native <select>) because native <option>s can't render
 // the bundled SVG flags — only plain text. Mirrors the CharacterSwitcher menu.
-export function LanguageSwitcher() {
+// `compact` shows just the flag (used in the toolbar for a logged-in user); the
+// landing page keeps the full flag + language name.
+export function LanguageSwitcher({ compact = false }: { compact?: boolean }) {
   const { t, i18n } = useTranslation();
   const current = (i18n.resolvedLanguage ?? 'en') as SupportedLanguage;
   const [open, setOpen] = useState(false);
@@ -24,7 +26,7 @@ export function LanguageSwitcher() {
     <div className="lang-switcher" ref={wrapRef}>
       <button
         type="button"
-        className="lang-switcher__trigger"
+        className={`lang-switcher__trigger${compact ? ' lang-switcher__trigger--compact' : ''}`}
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -32,8 +34,8 @@ export function LanguageSwitcher() {
         aria-label={t('language.label')}
       >
         <LangFlag lang={current} className="lang-switcher__flag" />
-        <span className="lang-switcher__current">{LANGUAGE_NAMES[current]}</span>
-        <CaretDownIcon size={12} weight="bold" />
+        {!compact && <span className="lang-switcher__current">{LANGUAGE_NAMES[current]}</span>}
+        {!compact && <CaretDownIcon size={12} weight="bold" />}
       </button>
       {open && (
         <div className="lang-switcher__menu" role="listbox" aria-label={t('language.label')}>

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -640,7 +640,7 @@ export function Toolbar() {
     // Language, API keys and sign-out travel together as one movable block.
     actions: user ? (
       <div className="toolbar__group">
-        <LanguageSwitcher />
+        <LanguageSwitcher compact />
         <button
           className="toolbar__toggle toolbar__toggle--icon"
           onClick={() => setShowKeys(true)}


### PR DESCRIPTION
When a user is logged in, the toolbar language selector now shows just the flag (no language name or caret) for a more compact look. The landing page (logged out) keeps the full flag + language name.

- `LanguageSwitcher` gains a `compact` prop; the toolbar passes it, the landing page doesn't.
- Tooltip still shows "Language" on hover, and the dropdown works the same.

tsc, eslint, and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)