### PR TITLE
Fix C729 wormhole log spam (Pochven hole)

### DIFF
--- a/server/data/wormholes.json
+++ b/server/data/wormholes.json
@@ -343,6 +343,17 @@
         "sibling_groups": null,
         "typeID": 34372
     },
+    "C729": {
+        "mass_regen": 0,
+        "dest": "pochven",
+        "src": [],
+        "static": false,
+        "max_mass_per_jump": 1000000000,
+        "lifetime": 0,
+        "total_mass": 720,
+        "sibling_groups": null,
+        "typeID": 56026
+    },
     "F216": {
         "mass_regen": 0,
         "dest": "pochven",

--- a/server/src/routes/wormholes.ts
+++ b/server/src/routes/wormholes.ts
@@ -152,11 +152,16 @@ async function loadSpecs(): Promise<Record<string, WormholeSpec>> {
     }
 
     log.info(`Loaded ${Object.keys(out).length} wormhole type specs (derived from SDE dogma + curated src)`);
-    if (newCodes.length) {
-      log.warn(`${newCodes.length} WH code(s) in the SDE have no curated src yet (showing with src: []): ${newCodes.join(', ')}`);
+    // Dedupe before reporting: a single WH code can have many SDE item types
+    // (e.g. C729 has 27 Pochven variants), which would otherwise repeat the code
+    // once per row in these warnings.
+    const uniqNew = [...new Set(newCodes)];
+    if (uniqNew.length) {
+      log.warn(`${uniqNew.length} WH code(s) in the SDE have no curated src yet (showing with src: []): ${uniqNew.join(', ')}`);
     }
-    if (unmapped.length) {
-      log.warn(`${unmapped.length} WH type(s) have an unmapped destination class (skipped): ${unmapped.join(', ')}`);
+    const uniqUnmapped = [...new Set(unmapped)];
+    if (uniqUnmapped.length) {
+      log.warn(`${uniqUnmapped.length} WH type(s) have an unmapped destination class (skipped): ${uniqUnmapped.join(', ')}`);
     }
 
     cache = out;


### PR DESCRIPTION
## Symptom

On a fresh install the server logs:

```
[wormholes] 27 WH code(s) in the SDE have no curated src yet (showing with src: []): C729 (×27)
```

## Cause

C729 (the Pochven / Triglavian hole) is a **single WH code with 27 distinct SDE item types**, all with `dest_class = -1`. The existing `DEST_OVERRIDE` already resolves it to `pochven` (routing works and the 27 collapse to one spec), but:

1. C729 was **missing from curated `data/wormholes.json`**, so it tripped the "no curated src" warning.
2. That warning pushes the code **once per SDE row**, so it printed `C729` 27 times.

## Fix

- Add `C729` to `wormholes.json` alongside its sibling Pochven holes (F216, etc., which were already present with `src: []`). With a curated entry present, the "no curated src" warning no longer fires for it.
- Dedupe both WH warnings by code before logging, so any code backed by multiple SDE item types can't repeat once per row.

Routing behaviour is unchanged (C729 already resolved to Pochven via the override). `tsc` passes and `wormholes.json` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)