### PR TITLE
Fix chain-name input colour (dark theme)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -4100,7 +4100,18 @@ div.system-node__easy-handle {
 
 .chains-new { display: flex; flex-direction: column; gap: 6px; }
 .system-combo { width: 100%; }
-.chains-new__name { width: 100%; }
+.chains-new__name {
+  width: 100%;
+  background: #111827;
+  border: 1px solid #1e2740;
+  border-radius: 5px;
+  color: #e2e8f8;
+  font-size: calc(13px * var(--font-scale, 1));
+  padding: 7px 10px;
+  outline: none;
+  box-sizing: border-box;
+}
+.chains-new__name:focus { border-color: #2e4a7a; }
 
 .chains-empty {
   font-size: calc(12px * var(--font-scale, 1));


### PR DESCRIPTION
The **Chain name** input in the Wormhole Chains panel rendered with a white background because `.chains-new__name` only set `width: 100%` — the browser's default input styling showed through, unlike the dark From/To comboboxes next to it.

Applied the same dark input styling as `.search-field__input` (background, border, text colour, padding, focus border). CSS-only; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)