### PR TITLE
Release 2.0.1

### DIFF
--- a/server/data/wormholes.json
+++ b/server/data/wormholes.json
@@ -343,6 +343,17 @@
         "sibling_groups": null,
         "typeID": 34372
     },
+    "C729": {
+        "mass_regen": 0,
+        "dest": "pochven",
+        "src": [],
+        "static": false,
+        "max_mass_per_jump": 1000000000,
+        "lifetime": 0,
+        "total_mass": 720,
+        "sibling_groups": null,
+        "typeID": 56026
+    },
     "F216": {
         "mass_regen": 0,
         "dest": "pochven",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/routes/wormholes.ts
+++ b/server/src/routes/wormholes.ts
@@ -152,11 +152,16 @@ async function loadSpecs(): Promise<Record<string, WormholeSpec>> {
     }
 
     log.info(`Loaded ${Object.keys(out).length} wormhole type specs (derived from SDE dogma + curated src)`);
-    if (newCodes.length) {
-      log.warn(`${newCodes.length} WH code(s) in the SDE have no curated src yet (showing with src: []): ${newCodes.join(', ')}`);
+    // Dedupe before reporting: a single WH code can have many SDE item types
+    // (e.g. C729 has 27 Pochven variants), which would otherwise repeat the code
+    // once per row in these warnings.
+    const uniqNew = [...new Set(newCodes)];
+    if (uniqNew.length) {
+      log.warn(`${uniqNew.length} WH code(s) in the SDE have no curated src yet (showing with src: []): ${uniqNew.join(', ')}`);
     }
-    if (unmapped.length) {
-      log.warn(`${unmapped.length} WH type(s) have an unmapped destination class (skipped): ${unmapped.join(', ')}`);
+    const uniqUnmapped = [...new Set(unmapped)];
+    if (uniqUnmapped.length) {
+      log.warn(`${uniqUnmapped.length} WH type(s) have an unmapped destination class (skipped): ${uniqUnmapped.join(', ')}`);
     }
 
     cache = out;

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -4100,7 +4100,18 @@ div.system-node__easy-handle {
 
 .chains-new { display: flex; flex-direction: column; gap: 6px; }
 .system-combo { width: 100%; }
-.chains-new__name { width: 100%; }
+.chains-new__name {
+  width: 100%;
+  background: #111827;
+  border: 1px solid #1e2740;
+  border-radius: 5px;
+  color: #e2e8f8;
+  font-size: calc(13px * var(--font-scale, 1));
+  padding: 7px 10px;
+  outline: none;
+  box-sizing: border-box;
+}
+.chains-new__name:focus { border-color: #2e4a7a; }
 
 .chains-empty {
   font-size: calc(12px * var(--font-scale, 1));


### PR DESCRIPTION
## Release 2.0.1

Patch release merging `release` into `main`.

### Fixes
- **C729 wormhole log spam** — C729 (the Pochven hole) is one WH code backed by 27 SDE item types; it was missing from curated data, tripping the "no curated src" warning once per row. Added it to `wormholes.json` and deduped the WH warnings by code (#379).
- **Chain-name input colour** — the Chain name field in the Wormhole Chains panel rendered white; styled it to match the dark theme like the From/To inputs (#380).

Version bumped to 2.0.1.

After merge: cut the `v2.0.1` GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)