### PR TITLE
Keep the selected system when alt-tabbing back from EVE

### DIFF
--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -602,13 +602,27 @@ export const useMapStore = create<MapStore>()((set, get) => {
       for (const t of moveTimers.values()) clearTimeout(t);
       moveTimers.clear();
 
+      // Re-selecting the CURRENT map is a resync (SSE reconnect after the tab
+      // was backgrounded, or the merge resync event), not a real switch. Keep
+      // the user's selection + current system across it so alt-tabbing to EVE
+      // and back doesn't drop the system they had open for pasting sigs.
+      const isResync = id === get().activeMapId;
+      const prev = isResync
+        ? { sel: get().selectedSystemId, conn: get().selectedConnectionId, current: get().currentSystemId }
+        : { sel: null, conn: null, current: null };
+
       try {
         const map = await api<WormholeMap>(`/api/maps/${id}`);
         // Older payloads / share responses may omit routes — normalise so the
         // chains slice can always read an array.
         if (!Array.isArray(map.routes)) map.routes = [];
         localStorage.setItem('nexum.lastMapId', id);
-        set({ map, activeMapId: id, selectedSystemId: null, selectedConnectionId: null, currentSystemId: null, undoStack: [], sigTypesBySystem: {}, contentBySystem: {}, contentFilter: { sigTypes: [], anomTypes: [], nameQuery: '' } });
+        // Drop any preserved ref that no longer exists in the refetched map
+        // (e.g. the selected system was deleted while we were disconnected).
+        const keepSel     = prev.sel     && map.systems.some((s) => s.id === prev.sel)      ? prev.sel     : null;
+        const keepConn    = prev.conn    && map.connections.some((c) => c.id === prev.conn) ? prev.conn    : null;
+        const keepCurrent = prev.current && map.systems.some((s) => s.id === prev.current)  ? prev.current : null;
+        set({ map, activeMapId: id, selectedSystemId: keepSel, selectedConnectionId: keepConn, currentSystemId: keepCurrent, undoStack: [], sigTypesBySystem: {}, contentBySystem: {}, contentFilter: { sigTypes: [], anomTypes: [], nameQuery: '' } });
       } catch (err) {
         // 403/404 — the grant was revoked, or the map was deleted. Reload
         // the list (which will trigger the revocation-detection path above


### PR DESCRIPTION
## Report

> Whenever i click back into my EVE Client, nexum de-selects all systems, so when i want to paste in new sigs i always have to click on the system im in again.

## Cause

Backgrounding the tab (clicking into the EVE client) drops the map's live-edit **SSE** connection. On return, `EventSource` reconnects and — since it can't know what changed while disconnected — fires a **resync** that re-fetches the map via `switchMap`. `switchMap` was written for *switching to a different map*, so it nulled `selectedSystemId` (and current system). Result: every alt-tab back wiped the open system, unmounting the signature pane / paste handler.

## Fix

`switchMap` now detects a **resync** (the target id equals the current `activeMapId`) and preserves `selectedSystemId` / `selectedConnectionId` / `currentSystemId` across it — dropping only refs that no longer exist in the refetched map (e.g. the system was deleted while disconnected). A genuine map switch changes the id, so that path is unchanged.

No new option needed — the selection now simply persists, so pasting sigs after alt-tabbing back Just Works.

tsc + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)