### PR TITLE
Release 2.0.2

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -602,13 +602,27 @@ export const useMapStore = create<MapStore>()((set, get) => {
       for (const t of moveTimers.values()) clearTimeout(t);
       moveTimers.clear();
 
+      // Re-selecting the CURRENT map is a resync (SSE reconnect after the tab
+      // was backgrounded, or the merge resync event), not a real switch. Keep
+      // the user's selection + current system across it so alt-tabbing to EVE
+      // and back doesn't drop the system they had open for pasting sigs.
+      const isResync = id === get().activeMapId;
+      const prev = isResync
+        ? { sel: get().selectedSystemId, conn: get().selectedConnectionId, current: get().currentSystemId }
+        : { sel: null, conn: null, current: null };
+
       try {
         const map = await api<WormholeMap>(`/api/maps/${id}`);
         // Older payloads / share responses may omit routes — normalise so the
         // chains slice can always read an array.
         if (!Array.isArray(map.routes)) map.routes = [];
         localStorage.setItem('nexum.lastMapId', id);
-        set({ map, activeMapId: id, selectedSystemId: null, selectedConnectionId: null, currentSystemId: null, undoStack: [], sigTypesBySystem: {}, contentBySystem: {}, contentFilter: { sigTypes: [], anomTypes: [], nameQuery: '' } });
+        // Drop any preserved ref that no longer exists in the refetched map
+        // (e.g. the selected system was deleted while we were disconnected).
+        const keepSel     = prev.sel     && map.systems.some((s) => s.id === prev.sel)      ? prev.sel     : null;
+        const keepConn    = prev.conn    && map.connections.some((c) => c.id === prev.conn) ? prev.conn    : null;
+        const keepCurrent = prev.current && map.systems.some((s) => s.id === prev.current)  ? prev.current : null;
+        set({ map, activeMapId: id, selectedSystemId: keepSel, selectedConnectionId: keepConn, currentSystemId: keepCurrent, undoStack: [], sigTypesBySystem: {}, contentBySystem: {}, contentFilter: { sigTypes: [], anomTypes: [], nameQuery: '' } });
       } catch (err) {
         // 403/404 — the grant was revoked, or the map was deleted. Reload
         // the list (which will trigger the revocation-detection path above


### PR DESCRIPTION
## Release 2.0.2

Patch release merging `release` into `main`.

### Fixes
- **Keep the selected system when alt-tabbing back from EVE** (#382) — backgrounding the tab drops the map SSE stream; the reconnect resync went through `switchMap` and cleared the selection, so the open system (and its sig-paste handler) was lost on every return. `switchMap` now preserves the selection across a resync.

Version bumped to 2.0.2.

After merge: cut the `v2.0.2` GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)