### PR TITLE
Clear map highlight when deleting a wormhole chain

### DIFF
--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -239,7 +239,9 @@ function SortableChainItem({ route, open, steps, canEdit, draggable, onToggle, s
             type="button"
             className="icon-btn chain-item__del"
             title={t('chains.remove')}
-            onClick={() => removeRoute(route.id)}
+            // Clear the hover highlight first — deleting unmounts this row, so
+            // its onMouseLeave never fires and the map would stay dimmed.
+            onClick={() => { setRouteHighlight(null); removeRoute(route.id); }}
           >
             <TrashIcon size={13} weight="regular" />
           </button>


### PR DESCRIPTION
## Bug

Deleting a wormhole chain leaves the map's route highlight stuck on — non-route systems stay greyed out until the browser is refreshed.

## Cause

Hovering a chain row calls `setRouteHighlight(...)` (dimming systems not on the chain), cleared by the row's `onMouseLeave`. Clicking **delete** unmounts the row, so `onMouseLeave` never fires and `routeHighlight` is never cleared — the dim persists.

## Fix

Clear `routeHighlight` in the delete handler before removing the route:

```ts
onClick={() => { setRouteHighlight(null); removeRoute(route.id); }}
```

tsc + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)