### PR TITLE
Release 2.0.3

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/ChainsPane.tsx
+++ b/web/src/components/ui/ChainsPane.tsx
@@ -239,7 +239,9 @@ function SortableChainItem({ route, open, steps, canEdit, draggable, onToggle, s
             type="button"
             className="icon-btn chain-item__del"
             title={t('chains.remove')}
-            onClick={() => removeRoute(route.id)}
+            // Clear the hover highlight first — deleting unmounts this row, so
+            // its onMouseLeave never fires and the map would stay dimmed.
+            onClick={() => { setRouteHighlight(null); removeRoute(route.id); }}
           >
             <TrashIcon size={13} weight="regular" />
           </button>


### PR DESCRIPTION
## Release 2.0.3

Patch release merging `release` into `main`.

### Fixes
- **Clear the map highlight when a wormhole chain is deleted** (#384) — deleting a chain while its hover-highlight was active left non-route systems greyed out until a browser refresh, because the row unmounted before its `onMouseLeave` could clear the highlight.

Version bumped to 2.0.3.

After merge: cut the `v2.0.3` GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)