### PR TITLE
Leads-to: space the J-space band labels

### DIFF
--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -21,8 +21,10 @@ interface DestOption { value: string; label: string; color: string; }
 // worst class so the threat reads green → orange → red. C13 / Thera / Pochven /
 // Drifter stay individual (their descriptions are distinct), as does K-space.
 const J_SPACE: DestOption[] = [
-  { value: 'C1-C3', label: 'C1-C3', color: CLASS_COLORS.C3 },
-  { value: 'C4-C5', label: 'C4-C5', color: CLASS_COLORS.C5 },
+  // Stored values stay 'C1-C3' / 'C4-C5' (unchanged for existing data + matching);
+  // only the display labels get spaced hyphens.
+  { value: 'C1-C3', label: 'C1 - C3', color: CLASS_COLORS.C3 },
+  { value: 'C4-C5', label: 'C4 - C5', color: CLASS_COLORS.C5 },
   { value: 'C6',    label: 'C6',    color: CLASS_COLORS.C6 },
   { value: 'C13',     label: CLASS_LABELS.C13,     color: CLASS_COLORS.C13 },
   { value: 'Thera',   label: CLASS_LABELS.Thera,   color: CLASS_COLORS.Thera },


### PR DESCRIPTION
Display the wormhole leads-to bands as `C1 - C3` and `C4 - C5` (spaced hyphens) in the dropdown and its button.

Display-only — the stored values stay `C1-C3` / `C4-C5`, so existing signatures and value matching are unaffected. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)