### PR TITLE
Undock bottom-dock panels into floating windows

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -4890,6 +4890,90 @@ div.system-node__easy-handle {
   padding: 8px 10px;
 }
 
+/* Undock button in a dock card header — subtle, brightens on hover. */
+.info-card__undock-btn {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  color: #6a80a0;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+.info-card__undock-btn:hover { color: #8ab8f0; }
+
+/* ── Floating (undocked) panel window ─────────────────────────────── */
+.floating-panel {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  background: #0d1117;
+  border: 1px solid #2e4a7a;
+  border-radius: 8px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  min-width: 260px;
+  min-height: 140px;
+}
+.floating-panel__bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: #111827;
+  border-bottom: 1px solid #1e2740;
+  cursor: move;
+  touch-action: none;
+  user-select: none;
+  flex-shrink: 0;
+}
+.floating-panel__title {
+  flex: 1;
+  font-size: calc(15px * var(--font-scale, 1));
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #c0ccde;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.floating-panel__redock {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  color: #6a80a0;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.floating-panel__redock:hover { color: #8ab8f0; }
+.floating-panel__body {
+  flex: 1;
+  overflow: auto;
+  padding: 8px 10px;
+}
+.floating-panel__resize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  touch-action: none;
+}
+.floating-panel__resize::after {
+  content: '';
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 7px;
+  height: 7px;
+  border-right: 2px solid #3a4a62;
+  border-bottom: 2px solid #3a4a62;
+}
+
 .notes-editor {
   .w-md-editor {
     background: transparent;

--- a/web/src/components/ui/DraggableCard.tsx
+++ b/web/src/components/ui/DraggableCard.tsx
@@ -2,17 +2,21 @@ import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { ArrowSquareOutIcon } from '@phosphor-icons/react';
 import { useUserSetting } from '../../hooks/useUserSetting';
 
 interface Props {
   id: string;
   title: string;
   children: ReactNode;
+  /** When provided, an "undock" button pops this card out into a floating
+   *  window. Only the bottom dock passes it; the sidebar cards omit it. */
+  onUndock?: () => void;
 }
 
 function storageKey(id: string) { return `nexum.panel.collapsed.${id}`; }
 
-export function DraggableCard({ id, title, children }: Props) {
+export function DraggableCard({ id, title, children, onUndock }: Props) {
   const { t } = useTranslation();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
 
@@ -40,6 +44,17 @@ export function DraggableCard({ id, title, children }: Props) {
           <span className={`info-card__chevron${collapsed ? ' info-card__chevron--collapsed' : ''}`}>▾</span>
         </button>
         <span className="info-card__title">{title}</span>
+        {onUndock && (
+          <button
+            type="button"
+            className="info-card__undock-btn"
+            onClick={(e) => { e.stopPropagation(); onUndock(); }}
+            title={t('panel.undock')}
+            aria-label={t('panel.undock')}
+          >
+            <ArrowSquareOutIcon size={13} weight="regular" />
+          </button>
+        )}
         <button
           type="button"
           className="info-card__drag-handle"

--- a/web/src/components/ui/FloatingPanel.tsx
+++ b/web/src/components/ui/FloatingPanel.tsx
@@ -1,0 +1,106 @@
+import { useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowSquareInIcon } from '@phosphor-icons/react';
+
+export interface PanelGeometry { x: number; y: number; w: number; h: number; }
+
+interface Props {
+  title:      string;
+  geometry:   PanelGeometry;
+  /** Called on drag/resize end with the settled geometry (parent persists). */
+  onCommit:   (g: PanelGeometry) => void;
+  onRedock:   () => void;
+  onFocus?:   () => void;
+  zIndex?:    number;
+  children:   ReactNode;
+}
+
+const MIN_W = 260;
+const MIN_H = 140;
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+// A floating, draggable + resizable window hosting an undocked panel. Portals to
+// document.body so it escapes the dock's overflow:hidden and sits above the
+// canvas. Drag via the title bar, resize from the bottom-right corner — both use
+// the pointer-capture idiom used elsewhere (Sidebar resize), and geometry is
+// committed to the parent only on release to avoid re-rendering on every move.
+export function FloatingPanel({ title, geometry, onCommit, onRedock, onFocus, zIndex, children }: Props) {
+  const { t } = useTranslation();
+  const [geo, setGeo] = useState<PanelGeometry>(geometry);
+  const latest = useRef<PanelGeometry>(geo);
+  const apply = (next: PanelGeometry) => { latest.current = next; setGeo(next); };
+
+  const dragRef   = useRef<{ px: number; py: number; ox: number; oy: number } | null>(null);
+  const resizeRef = useRef<{ px: number; py: number; ow: number; oh: number } | null>(null);
+
+  const onBarPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    onFocus?.();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = { px: e.clientX, py: e.clientY, ox: latest.current.x, oy: latest.current.y };
+  };
+  const onBarPointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d) return;
+    const x = clamp(d.ox + (e.clientX - d.px), 0, window.innerWidth  - 80);
+    const y = clamp(d.oy + (e.clientY - d.py), 0, window.innerHeight - 40);
+    apply({ ...latest.current, x, y });
+  };
+  const endDrag = () => { if (dragRef.current) { dragRef.current = null; onCommit(latest.current); } };
+
+  const onResizePointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    onFocus?.();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    resizeRef.current = { px: e.clientX, py: e.clientY, ow: latest.current.w, oh: latest.current.h };
+  };
+  const onResizePointerMove = (e: React.PointerEvent) => {
+    const r = resizeRef.current;
+    if (!r) return;
+    const w = Math.max(MIN_W, r.ow + (e.clientX - r.px));
+    const h = Math.max(MIN_H, r.oh + (e.clientY - r.py));
+    apply({ ...latest.current, w, h });
+  };
+  const endResize = () => { if (resizeRef.current) { resizeRef.current = null; onCommit(latest.current); } };
+
+  return createPortal(
+    <div
+      className="floating-panel"
+      style={{ left: geo.x, top: geo.y, width: geo.w, height: geo.h, zIndex }}
+      onPointerDown={onFocus}
+    >
+      <div
+        className="floating-panel__bar"
+        onPointerDown={onBarPointerDown}
+        onPointerMove={onBarPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <span className="floating-panel__title">{title}</span>
+        <button
+          type="button"
+          className="floating-panel__redock"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={onRedock}
+          title={t('panel.redock')}
+          aria-label={t('panel.redock')}
+        >
+          <ArrowSquareInIcon size={14} weight="regular" />
+        </button>
+      </div>
+      <div className="floating-panel__body">{children}</div>
+      <div
+        className="floating-panel__resize"
+        onPointerDown={onResizePointerDown}
+        onPointerMove={onResizePointerMove}
+        onPointerUp={endResize}
+        onPointerCancel={endResize}
+        aria-hidden="true"
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -11,6 +11,8 @@ import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-ki
 import { useMapStore } from '../../store/mapStore';
 import { CLASS_COLORS, CLASS_LABELS, EFFECT_LABELS, EFFECT_MODIFIERS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
 import { DraggableCard } from './DraggableCard';
+import { FloatingPanel, type PanelGeometry } from './FloatingPanel';
+import { useUserSetting } from '../../hooks/useUserSetting';
 import { SignaturePane } from './SignaturePane';
 import { AnomalyPane } from './AnomalyPane';
 import { StructuresPane } from './StructuresPane';
@@ -195,6 +197,11 @@ export function SystemPanel() {
   const shareIncludesStructures = useMapStore((s) => s.map.shareIncludeStructures === true);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
+  // Undocked (floating) panels: id -> {x,y,w,h}, persisted per user. `topFloat`
+  // is the last-focused floating window, lifted above the others.
+  const [floatingPanels, setFloatingPanels] = useUserSetting<Record<string, PanelGeometry>>('nexum.floatingPanels', {});
+  const [topFloat, setTopFloat] = useState<string | null>(null);
+
   const [height, setHeight] = useState(() => {
     const v = localStorage.getItem(HEIGHT_KEY);
     return v ? clamp(parseInt(v, 10)) : DEFAULT_H;
@@ -308,7 +315,42 @@ export function SystemPanel() {
     activity:    <ActivityPane eveSystemId={sys.eveSystemId} />,
   };
 
+  // Whether each pane still renders in share mode (guests only see the
+  // categories the owner opted into at link time).
+  const shareVisible = (id: string): boolean => {
+    if (!isShareMode) return true;
+    if (id === 'notes')      return shareIncludesNotes;
+    if (id === 'structures') return shareIncludesStructures;
+    if (id === 'signatures') return shareIncludesSigs;
+    // Anomalies aren't embedded in the share payload yet — always empty for a
+    // guest, so hide the pane for now.
+    if (id === 'anomalies')  return false;
+    return true;
+  };
+
+  // Panes popped out into floating windows: id -> geometry. A floating pane is
+  // removed from the docked stack and shown as its own window; redocking clears
+  // it. Order in the dock still comes from panelOrder, so a redocked pane
+  // returns to its place.
+  const undock = (id: string) => setFloatingPanels((prev) => {
+    if (prev[id]) return prev;
+    const n = Object.keys(prev).length;
+    return { ...prev, [id]: { x: 140 + n * 28, y: 120 + n * 28, w: 460, h: 320 } };
+  });
+  const redock = (id: string) => setFloatingPanels((prev) => {
+    const next = { ...prev };
+    delete next[id];
+    return next;
+  });
+  const commitGeo = (id: string, g: PanelGeometry) => setFloatingPanels((prev) => ({ ...prev, [id]: g }));
+
+  // Docked (stacked) panes = order minus anything floating, minus share-hidden.
+  const dockedIds = panelOrder.filter((id) => !floatingPanels[id]).filter(shareVisible);
+  // Floating panes that are still valid ids and share-visible.
+  const floatingIds = Object.keys(floatingPanels).filter((id) => cards[id] && shareVisible(id));
+
   return (
+    <>
     <aside className="system-panel" style={{ height }}>
       <div className="system-panel__resize-handle" onMouseDown={onResizeMouseDown} />
 
@@ -666,32 +708,33 @@ export function SystemPanel() {
       )}
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={panelOrder} strategy={verticalListSortingStrategy}>
+        <SortableContext items={dockedIds} strategy={verticalListSortingStrategy}>
           <div className="panel-stack">
-            {panelOrder
-              // In share mode each panel category is gated on the
-              // matching include-flag the owner picked at link time.
-              // Anything off → hide the tab entirely so a guest never
-              // sees an empty pane.
-              .filter((id) => {
-                if (!isShareMode) return true;
-                if (id === 'notes')      return shareIncludesNotes;
-                if (id === 'structures') return shareIncludesStructures;
-                if (id === 'signatures') return shareIncludesSigs;
-                // Anomalies aren't embedded in the share payload yet, so the
-                // pane would always be empty for a guest — hide it for now.
-                if (id === 'anomalies')  return false;
-                return true;
-              })
-              .map((id) => (
-                <DraggableCard key={id} id={id} title={panelTitle[id] ?? id}>
-                  {cards[id]}
-                </DraggableCard>
-              ))}
+            {dockedIds.map((id) => (
+              <DraggableCard key={id} id={id} title={panelTitle[id] ?? id} onUndock={() => undock(id)}>
+                {cards[id]}
+              </DraggableCard>
+            ))}
           </div>
         </SortableContext>
       </DndContext>
     </aside>
+
+    {/* Undocked panes — portaled floating windows that follow the selection. */}
+    {floatingIds.map((id) => (
+      <FloatingPanel
+        key={id}
+        title={panelTitle[id] ?? id}
+        geometry={floatingPanels[id]}
+        onCommit={(g) => commitGeo(id, g)}
+        onRedock={() => redock(id)}
+        onFocus={() => setTopFloat(id)}
+        zIndex={id === topFloat ? 46 : 41}
+      >
+        {cards[id]}
+      </FloatingPanel>
+    ))}
+    </>
   );
 }
 

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -748,7 +748,9 @@
     "structures": "Strukturen",
     "npcStations": "NPC-Stationen",
     "killboard": "zKillboard",
-    "activity": "Aktivität"
+    "activity": "Aktivität",
+    "undock": "In ein schwebendes Fenster ablösen",
+    "redock": "Wieder andocken"
   },
   "systemPanel": {
     "unknownSystem": "Unbekanntes System",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -801,7 +801,9 @@
     "structures": "Structures",
     "npcStations": "NPC Stations",
     "killboard": "zKillboard",
-    "activity": "Activity"
+    "activity": "Activity",
+    "undock": "Undock to a floating window",
+    "redock": "Dock back"
   },
   "systemPanel": {
     "unknownSystem": "Unknown System",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -748,7 +748,9 @@
     "structures": "Estructuras",
     "npcStations": "Estaciones PNJ",
     "killboard": "zKillboard",
-    "activity": "Actividad"
+    "activity": "Actividad",
+    "undock": "Desacoplar a una ventana flotante",
+    "redock": "Volver a acoplar"
   },
   "systemPanel": {
     "unknownSystem": "Sistema desconocido",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -748,7 +748,9 @@
     "structures": "Structures",
     "npcStations": "Stations PNJ",
     "killboard": "zKillboard",
-    "activity": "Activité"
+    "activity": "Activité",
+    "undock": "Détacher dans une fenêtre flottante",
+    "redock": "Réancrer"
   },
   "systemPanel": {
     "unknownSystem": "Système inconnu",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -748,7 +748,9 @@
     "structures": "ストラクチャ",
     "npcStations": "NPC ステーション",
     "killboard": "zKillboard",
-    "activity": "アクティビティ"
+    "activity": "アクティビティ",
+    "undock": "フローティングウィンドウに切り離す",
+    "redock": "元に戻す"
   },
   "systemPanel": {
     "unknownSystem": "不明な星系",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -748,7 +748,9 @@
     "structures": "구조물",
     "npcStations": "NPC 정거장",
     "killboard": "zKillboard",
-    "activity": "활동"
+    "activity": "활동",
+    "undock": "플로팅 창으로 분리",
+    "redock": "다시 도킹"
   },
   "systemPanel": {
     "unknownSystem": "알 수 없는 성계",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -748,7 +748,9 @@
     "structures": "Estruturas",
     "npcStations": "Estações PNJ",
     "killboard": "zKillboard",
-    "activity": "Atividade"
+    "activity": "Atividade",
+    "undock": "Desacoplar para uma janela flutuante",
+    "redock": "Reacoplar"
   },
   "systemPanel": {
     "unknownSystem": "Sistema desconhecido",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -766,7 +766,9 @@
     "structures": "Структуры",
     "npcStations": "Станции NPC",
     "killboard": "zKillboard",
-    "activity": "Активность"
+    "activity": "Активность",
+    "undock": "Открепить в плавающее окно",
+    "redock": "Пристыковать обратно"
   },
   "systemPanel": {
     "unknownSystem": "Неизвестная система",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -748,7 +748,9 @@
     "structures": "建筑",
     "npcStations": "NPC 空间站",
     "killboard": "zKillboard",
-    "activity": "活动"
+    "activity": "活动",
+    "undock": "分离为浮动窗口",
+    "redock": "重新停靠"
   },
   "systemPanel": {
     "unknownSystem": "未知星系",


### PR DESCRIPTION
Lets a user pop any bottom-section pane (Signatures, Notes, Structures, Anomalies, zKillboard, NPC Stations, Activity) out of the dock into its own **draggable, resizable** window, and dock it back.

## Design (per the agreed choices)
- **Moves out:** undocking removes the pane from the bottom stack and shows it as a floating window; redocking returns it to its place in `panelOrder`. One instance at a time — no double `window` paste-handlers.
- **Follows selection:** a floating window re-derives the selected system from the store, so it always shows the current system just like the docked pane.
- **Persisted per user:** float state + position/size are remembered across reloads via a new server-backed `nexum.floatingPanels` setting (`{ id: {x,y,w,h} }`).

## How it's built
- **`FloatingPanel`** — a new component portaled to `document.body` (escapes the dock's `overflow:hidden`). Title-bar drag + bottom-right resize using the house pointer-capture idiom (mirrors the sidebar resize); geometry committed to the parent only on pointer release, so drags don't re-render the app per move. z-index 41–46 (above toolbar/sidebar, below modals); the last-focused window lifts to the front.
- **`DraggableCard`** — gains an opt-in **undock** button in the header. Only `SystemPanel` passes `onUndock`, so the sidebar cards are unchanged.
- **`SystemPanel`** — a pane is either docked *or* floating; `dockedIds` drives the stack, floating panes render as `FloatingPanel`s.
- i18n `panel.undock` / `panel.redock` across all 9 locales.

## Verification
tsc, production build, eslint (0 issues), and i18n parity all pass. It's login-gated (needs a selected system on a map), so I couldn't drive it headlessly — please try undocking a pane, dragging/resizing it, switching systems (it should follow), reloading (position/size persist), and redocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)