### PR TITLE
Stop location tracking from stealing the selection on an ESI online flicker

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -210,6 +210,11 @@ export function useLocationTracking(enabled: boolean) {
   const lastEveSystemId = useRef<number | null>(null);
   const lastMapSystemId = useRef<string | null>(null);
   const lastActiveMapId = useRef<string | null>(null);
+  // The eve system we last auto-selected. Guards the "follow the character"
+  // selection so it fires only on a GENUINE move — not when ESI's online flag
+  // flickers (which resets lastEveSystemId and would otherwise re-select the
+  // same system, yanking the user off whatever they'd manually clicked).
+  const lastSelectedEveId = useRef<number | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
@@ -224,6 +229,7 @@ export function useLocationTracking(enabled: boolean) {
       lastActiveMapId.current = map.id;
       lastEveSystemId.current = null;
       lastMapSystemId.current = null;
+      lastSelectedEveId.current = null;
     }
 
     const system = location.system;
@@ -272,6 +278,13 @@ export function useLocationTracking(enabled: boolean) {
 
     lastMapSystemId.current = mapSystemId;
     setCurrentSystem(mapSystemId);
-    selectSystem(mapSystemId, { fromJump: true });
+    // Follow the character onto the new system only when it's genuinely a
+    // different system than the one we last auto-selected. An ESI online-status
+    // flicker resets lastEveSystemId (above), which would otherwise re-run this
+    // for the SAME system and steal a selection the user made by hand.
+    if (system.eveSystemId !== lastSelectedEveId.current) {
+      lastSelectedEveId.current = system.eveSystemId;
+      selectSystem(mapSystemId, { fromJump: true });
+    }
   }, [enabled, location, canEdit]);
 }


### PR DESCRIPTION
## Report

Users with EVE + nexum in **side-by-side windows** (not alt-tabbing, just clicking between them) kept losing the system they had selected for pasting sigs — after some time unfocused, without moving in EVE.

## Root cause

For a *visible* side-by-side window the map SSE stream stays connected (25s heartbeat), so the earlier "resync clears selection" fix (#382) isn't the path here.

The real cause is `useLocationTracking`: it follows the character by calling `selectSystem(...)` whenever the location advances. The **offline branch resets `lastEveSystemId` to `null`**, so when ESI's `online` flag *flickers* false→true — which happens on its own, independent of the pilot actually jumping — the tracker re-runs and re-selects the **same** system on recovery, yanking the user off whatever they'd clicked by hand.

## Fix

Guard the follow-selection with a dedicated `lastSelectedEveId` ref so it fires **only on a genuine system change**, never on a same-system online recovery. The current-system "you are here" indicator and passive auto-add are unchanged; steady-state polls already early-return, so this only affects the flicker-recovery path.

tsc, eslint, and build pass.

> Note: this complements #382 (which handles the alt-tab / true-reconnect case). Together they cover both ways the selection was getting lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)