### PR TITLE
Add selectable columns to the Signature and Anomalies panes

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5167,6 +5167,43 @@ div.system-node__easy-handle {
 }
 .sig-filter-clear:hover { color: #9ec0e8; }
 
+/* Column picker — icon button in the filter row that opens a checkbox popover
+   to hide/show optional columns (slims the pane when undocked). Pushed to the
+   right edge of the wrapping filter row. */
+.sig-col-menu { position: relative; margin-left: auto; }
+.sig-col-menu__btn--active { color: #5a9af8; }
+.sig-col-menu__pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 1000;
+  min-width: 140px;
+  background: #0d1117;
+  border: 1px solid #1e2740;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  padding: 6px;
+}
+.sig-col-menu__title {
+  font-size: calc(11px * var(--font-scale, 1));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6a8ab0;
+  padding: 2px 6px 6px;
+}
+.sig-col-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #c8d0e0;
+  cursor: pointer;
+}
+.sig-col-menu__item:hover { background: rgba(90, 154, 248, 0.12); }
+.sig-col-menu__item input { cursor: pointer; }
+
 .sig-pane__empty {
   font-size: calc(16px * var(--font-scale, 1));
   color: #6a7a98;

--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -5,10 +5,11 @@ import { useMapStore } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useShareMode } from '../../context/ShareModeContext';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import type { Anomaly, AnomType } from '../../types';
 import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
 import { NotesEditor } from './NotesEditor';
-import { XIcon } from '@phosphor-icons/react';
+import { XIcon, ColumnsIcon } from '@phosphor-icons/react';
 import { toast } from './Toaster';
 import { duration, DASH } from '../../i18n/format';
 
@@ -67,6 +68,17 @@ const DEFAULT_WIDTHS: Record<ColKey, number> = {
   created: 80,
   updated: 80,
 };
+
+// Columns the user can hide to slim the pane down (handy for an undocked, narrow
+// window). ID / Type / Name always stay. Label keys reuse the existing header
+// translations. Hidden columns are stored as a list under one ui_settings key;
+// empty (the default) = all shown, so a later-added hideable column defaults
+// visible without migration.
+const HIDEABLE_COLS = [
+  { key: 'notes',   labelKey: 'anomalies.colNotes' },
+  { key: 'created', labelKey: 'anomalies.colAge' },
+  { key: 'updated', labelKey: 'anomalies.colUpdated' },
+] as const satisfies ReadonlyArray<{ key: ColKey; labelKey: string }>;
 
 // Grace-period choices (seconds) offered before an overwrite-paste actually
 // deletes an anomaly absent from the new scan. Mirrors the signature pane.
@@ -151,6 +163,16 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
     () => ({ ...DEFAULT_WIDTHS, ...savedColWidths }) as Record<ColKey, number>,
     [savedColWidths],
   );
+
+  // Hidden columns, persisted per user (shared across every Anomalies pane).
+  const [hiddenColsArr, setHiddenColsArr] = useUserSetting<ColKey[]>('nexum.anomPane.hiddenCols', []);
+  const hiddenCols = useMemo(() => new Set(hiddenColsArr), [hiddenColsArr]);
+  const isColVisible = useCallback((c: ColKey) => !hiddenCols.has(c), [hiddenCols]);
+  const toggleCol = (c: ColKey) =>
+    setHiddenColsArr((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  const [colMenuOpen, setColMenuOpen] = useState(false);
+  const colMenuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(colMenuOpen, colMenuRef, () => setColMenuOpen(false));
 
   const pendingUpdates = useRef<Map<string, Partial<Anomaly>>>(new Map());
   const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -512,6 +534,33 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
               {t('anomalies.filterClear')}
             </button>
           )}
+          <div className="sig-col-menu" ref={colMenuRef}>
+            <button
+              type="button"
+              className={`icon-btn sig-col-menu__btn${hiddenCols.size > 0 ? ' sig-col-menu__btn--active' : ''}`}
+              onClick={() => setColMenuOpen((o) => !o)}
+              aria-expanded={colMenuOpen}
+              aria-label={t('anomalies.columns')}
+              data-tooltip={t('anomalies.columns')}
+            >
+              <ColumnsIcon size={14} weight="regular" />
+            </button>
+            {colMenuOpen && (
+              <div className="sig-col-menu__pop" role="menu">
+                <div className="sig-col-menu__title">{t('anomalies.columns')}</div>
+                {HIDEABLE_COLS.map(({ key, labelKey }) => (
+                  <label key={key} className="sig-col-menu__item">
+                    <input
+                      type="checkbox"
+                      checked={isColVisible(key)}
+                      onChange={() => toggleCol(key)}
+                    />
+                    <span>{t(labelKey)}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
 
@@ -527,9 +576,9 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
             <col style={{ width: colWidths.id }} />
             <col style={{ width: colWidths.type }} />
             <col style={{ width: colWidths.name }} />
-            <col style={{ width: colWidths.notes }} />
-            <col style={{ width: colWidths.created }} />
-            <col style={{ width: colWidths.updated }} />
+            {isColVisible('notes')   && <col style={{ width: colWidths.notes }} />}
+            {isColVisible('created') && <col style={{ width: colWidths.created }} />}
+            {isColVisible('updated') && <col style={{ width: colWidths.updated }} />}
             <col className="sig-col--actions" />
           </colgroup>
           <thead>
@@ -555,18 +604,24 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
                 {t('anomalies.colName')}{sortInd('name')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('name', e)} />
               </th>
-              <th className="sig-th">
-                {t('anomalies.colNotes')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
-              </th>
-              <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('createdAt')}>
-                {t('anomalies.colAge')}{sortInd('createdAt')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('created', e)} />
-              </th>
-              <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('updatedAt')}>
-                {t('anomalies.colUpdated')}{sortInd('updatedAt')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
-              </th>
+              {isColVisible('notes') && (
+                <th className="sig-th">
+                  {t('anomalies.colNotes')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
+                </th>
+              )}
+              {isColVisible('created') && (
+                <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('createdAt')}>
+                  {t('anomalies.colAge')}{sortInd('createdAt')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('created', e)} />
+                </th>
+              )}
+              {isColVisible('updated') && (
+                <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('updatedAt')}>
+                  {t('anomalies.colUpdated')}{sortInd('updatedAt')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
+                </th>
+              )}
               <th className="sig-cell--actions" />
             </tr>
           </thead>
@@ -614,16 +669,18 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
                     placeholder={t('anomalies.namePlaceholder')}
                   />
                 </td>
-                <td className="sig-notes-cell">
-                  <NotesEditor
-                    value={anom.notes}
-                    onChange={(v) => updateAnom(anom.id, { notes: v })}
-                    compact
-                    readOnly={!canEdit}
-                  />
-                </td>
-                <ElapsedCell iso={anom.createdAt} className="sig-td--time" />
-                <ElapsedCell iso={anom.updatedAt} className="sig-td--time sig-td--updated" />
+                {isColVisible('notes') && (
+                  <td className="sig-notes-cell">
+                    <NotesEditor
+                      value={anom.notes}
+                      onChange={(v) => updateAnom(anom.id, { notes: v })}
+                      compact
+                      readOnly={!canEdit}
+                    />
+                  </td>
+                )}
+                {isColVisible('created') && <ElapsedCell iso={anom.createdAt} className="sig-td--time" />}
+                {isColVisible('updated') && <ElapsedCell iso={anom.updatedAt} className="sig-td--time sig-td--updated" />}
                 <td className="sig-cell--actions">
                   {canEdit && (
                     <button

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -5,11 +5,12 @@ import { useMapStore } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useShareMode } from '../../context/ShareModeContext';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import type { Signature, SigType } from '../../types';
 import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
 import { NotesEditor } from './NotesEditor';
 import { WormholeTypePicker } from './WormholeTypePicker';
-import { XIcon, CopyIcon } from '@phosphor-icons/react';
+import { XIcon, CopyIcon, ColumnsIcon } from '@phosphor-icons/react';
 import { LeadsToDropdown } from './LeadsToDropdown';
 import { toast } from './Toaster';
 import { reevaluateConnectionsForSystem } from '../../utils/whAutoDetect';
@@ -123,6 +124,18 @@ const DEFAULT_WIDTHS: Record<ColKey, number> = {
 // on the column width so neither a squeezed narrow viewport nor a saved-narrow
 // layout can clip it.
 const LEADSTO_MIN_WIDTH = 132;
+
+// Columns the user can hide to slim the pane down (handy for an undocked, narrow
+// window). ID / Type / WH Type / Leads To always stay — they're the core scan
+// data. Label keys reuse the existing header translations. Hidden columns are
+// stored as a list under one ui_settings key; empty (the default) = all shown,
+// so a later-added hideable column defaults visible without migration.
+const HIDEABLE_COLS = [
+  { key: 'name',    labelKey: 'signatures.colName' },
+  { key: 'notes',   labelKey: 'signatures.colNotes' },
+  { key: 'created', labelKey: 'signatures.colAge' },
+  { key: 'updated', labelKey: 'signatures.colUpdated' },
+] as const satisfies ReadonlyArray<{ key: ColKey; labelKey: string }>;
 
 // Grace-period choices (seconds) offered before an overwrite-paste actually
 // deletes a despawned sig. 0 = delete immediately. Compact s/m labels read
@@ -240,6 +253,16 @@ export function SignaturePane({ systemId }: { systemId: string }) {
     return merged;
   }, [savedColWidths]);
 
+  // Hidden columns, persisted per user (shared across every Signature pane).
+  const [hiddenColsArr, setHiddenColsArr] = useUserSetting<ColKey[]>('nexum.sigPane.hiddenCols', []);
+  const hiddenCols = useMemo(() => new Set(hiddenColsArr), [hiddenColsArr]);
+  const isColVisible = useCallback((c: ColKey) => !hiddenCols.has(c), [hiddenCols]);
+  const toggleCol = (c: ColKey) =>
+    setHiddenColsArr((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  const [colMenuOpen, setColMenuOpen] = useState(false);
+  const colMenuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(colMenuOpen, colMenuRef, () => setColMenuOpen(false));
+
   const pendingUpdates = useRef<Map<string, Partial<Signature>>>(new Map());
   const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const sigsRef        = useRef<Signature[]>([]);
@@ -321,8 +344,9 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   // squeezing every column down — which is what clipped the leads-to name and
   // spilled the copy button over the next column.
   const tableMinWidth = useMemo(
-    () => Object.values(colWidths).reduce((a, b) => a + b, 0) + (isShareMode ? 0 : 24 + 28),
-    [colWidths, isShareMode],
+    () => (Object.entries(colWidths) as Array<[ColKey, number]>)
+      .reduce((a, [k, w]) => a + (isColVisible(k) ? w : 0), 0) + (isShareMode ? 0 : 24 + 28),
+    [colWidths, isShareMode, isColVisible],
   );
 
   // Bumped when another client changes this system's sigs (live sync).
@@ -777,6 +801,33 @@ export function SignaturePane({ systemId }: { systemId: string }) {
               {t('signatures.filterClear')}
             </button>
           )}
+          <div className="sig-col-menu" ref={colMenuRef}>
+            <button
+              type="button"
+              className={`icon-btn sig-col-menu__btn${hiddenCols.size > 0 ? ' sig-col-menu__btn--active' : ''}`}
+              onClick={() => setColMenuOpen((o) => !o)}
+              aria-expanded={colMenuOpen}
+              aria-label={t('signatures.columns')}
+              data-tooltip={t('signatures.columns')}
+            >
+              <ColumnsIcon size={14} weight="regular" />
+            </button>
+            {colMenuOpen && (
+              <div className="sig-col-menu__pop" role="menu">
+                <div className="sig-col-menu__title">{t('signatures.columns')}</div>
+                {HIDEABLE_COLS.map(({ key, labelKey }) => (
+                  <label key={key} className="sig-col-menu__item">
+                    <input
+                      type="checkbox"
+                      checked={isColVisible(key)}
+                      onChange={() => toggleCol(key)}
+                    />
+                    <span>{t(labelKey)}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
 
@@ -799,10 +850,10 @@ export function SignaturePane({ systemId }: { systemId: string }) {
             <col style={{ width: colWidths.type }} />
             <col style={{ width: colWidths.whtype }} className="sig-col--whtype" />
             <col style={{ width: colWidths.leadsto }} />
-            <col style={{ width: colWidths.name }} />
-            <col style={{ width: colWidths.notes }} />
-            <col style={{ width: colWidths.created }} />
-            <col style={{ width: colWidths.updated }} />
+            {isColVisible('name')    && <col style={{ width: colWidths.name }} />}
+            {isColVisible('notes')   && <col style={{ width: colWidths.notes }} />}
+            {isColVisible('created') && <col style={{ width: colWidths.created }} />}
+            {isColVisible('updated') && <col style={{ width: colWidths.updated }} />}
             {!isShareMode && <col className="sig-col--actions" />}
           </colgroup>
           <thead>
@@ -834,22 +885,30 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                 {t('signatures.colLeadsTo')}{sortInd('whLeadsTo')}
                 <div className="sig-th__resize" onMouseDown={(e) => startResize('leadsto', e)} />
               </th>
-              <th className="sig-th sig-th--sortable" onClick={() => handleSort('name')}>
-                {t('signatures.colName')}{sortInd('name')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('name', e)} />
-              </th>
-              <th className="sig-th">
-                {t('signatures.colNotes')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
-              </th>
-              <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('createdAt')}>
-                {t('signatures.colAge')}{sortInd('createdAt')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('created', e)} />
-              </th>
-              <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('updatedAt')}>
-                {t('signatures.colUpdated')}{sortInd('updatedAt')}
-                <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
-              </th>
+              {isColVisible('name') && (
+                <th className="sig-th sig-th--sortable" onClick={() => handleSort('name')}>
+                  {t('signatures.colName')}{sortInd('name')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('name', e)} />
+                </th>
+              )}
+              {isColVisible('notes') && (
+                <th className="sig-th">
+                  {t('signatures.colNotes')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('notes', e)} />
+                </th>
+              )}
+              {isColVisible('created') && (
+                <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('createdAt')}>
+                  {t('signatures.colAge')}{sortInd('createdAt')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('created', e)} />
+                </th>
+              )}
+              {isColVisible('updated') && (
+                <th className="sig-th sig-th--sortable sig-th--time" onClick={() => handleSort('updatedAt')}>
+                  {t('signatures.colUpdated')}{sortInd('updatedAt')}
+                  <div className="sig-th__resize" onMouseDown={(e) => startResize('updated', e)} />
+                </th>
+              )}
               {!isShareMode && <th className="sig-cell--actions" />}
             </tr>
           </thead>
@@ -935,35 +994,43 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                       )
                   )}
                 </td>
-                <td>
-                  {isShareMode ? (
-                    <span className="sig-text">{sig.name}</span>
-                  ) : (
-                    <input
-                      className="sig-input"
-                      value={sig.name}
-                      onChange={(e) => updateSig(sig.id, { name: e.target.value })}
-                      placeholder={t('signatures.namePlaceholder')}
+                {isColVisible('name') && (
+                  <td>
+                    {isShareMode ? (
+                      <span className="sig-text">{sig.name}</span>
+                    ) : (
+                      <input
+                        className="sig-input"
+                        value={sig.name}
+                        onChange={(e) => updateSig(sig.id, { name: e.target.value })}
+                        placeholder={t('signatures.namePlaceholder')}
+                      />
+                    )}
+                  </td>
+                )}
+                {isColVisible('notes') && (
+                  <td className="sig-notes-cell">
+                    <NotesEditor
+                      value={sig.notes}
+                      onChange={(v) => updateSig(sig.id, { notes: v })}
+                      compact
+                      readOnly={!canEdit || isShareMode}
                     />
-                  )}
-                </td>
-                <td className="sig-notes-cell">
-                  <NotesEditor
-                    value={sig.notes}
-                    onChange={(v) => updateSig(sig.id, { notes: v })}
-                    compact
-                    readOnly={!canEdit || isShareMode}
+                  </td>
+                )}
+                {isColVisible('created') && (
+                  <ElapsedCell
+                    iso={sig.createdAt}
+                    className={`sig-td--time${
+                      isSigStale(sig.sigType, sig.whType, sig.createdAt, tickNow)
+                        ? ' sig-td--age-stale'
+                        : ''
+                    }`}
                   />
-                </td>
-                <ElapsedCell
-                  iso={sig.createdAt}
-                  className={`sig-td--time${
-                    isSigStale(sig.sigType, sig.whType, sig.createdAt, tickNow)
-                      ? ' sig-td--age-stale'
-                      : ''
-                  }`}
-                />
-                <ElapsedCell iso={sig.updatedAt} className="sig-td--time sig-td--updated" />
+                )}
+                {isColVisible('updated') && (
+                  <ElapsedCell iso={sig.updatedAt} className="sig-td--time sig-td--updated" />
+                )}
                 {!isShareMode && (
                   <td className="sig-cell--actions">
                     {canEdit && (

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -963,6 +963,7 @@
     "colNotes": "Notizen",
     "colAge": "Alter",
     "colUpdated": "Aktualisiert",
+    "columns": "Spalten",
     "namePlaceholder": "Seitenname"
   },
   "anomalies": {

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -996,6 +996,7 @@
     "colNotes": "Notizen",
     "colAge": "Alter",
     "colUpdated": "Aktualisiert",
+    "columns": "Spalten",
     "namePlaceholder": "Anomalie-Name"
   },
   "stats": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1049,6 +1049,7 @@
     "colNotes": "Notes",
     "colAge": "Age",
     "colUpdated": "Updated",
+    "columns": "Columns",
     "namePlaceholder": "Anomaly name"
   },
   "stats": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1016,6 +1016,7 @@
     "colNotes": "Notes",
     "colAge": "Age",
     "colUpdated": "Updated",
+    "columns": "Columns",
     "namePlaceholder": "Site name"
   },
   "anomalies": {

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -996,6 +996,7 @@
     "colNotes": "Notas",
     "colAge": "Antigüedad",
     "colUpdated": "Actualizado",
+    "columns": "Columnas",
     "namePlaceholder": "Nombre de la anomalía"
   },
   "stats": {

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -963,6 +963,7 @@
     "colNotes": "Notas",
     "colAge": "Antigüedad",
     "colUpdated": "Actualizado",
+    "columns": "Columnas",
     "namePlaceholder": "Nombre del sitio"
   },
   "anomalies": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -963,6 +963,7 @@
     "colNotes": "Notes",
     "colAge": "Âge",
     "colUpdated": "Mis à jour",
+    "columns": "Colonnes",
     "namePlaceholder": "Nom du site"
   },
   "anomalies": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -996,6 +996,7 @@
     "colNotes": "Notes",
     "colAge": "Âge",
     "colUpdated": "Mis à jour",
+    "columns": "Colonnes",
     "namePlaceholder": "Nom de l'anomalie"
   },
   "stats": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -996,6 +996,7 @@
     "colNotes": "メモ",
     "colAge": "経過",
     "colUpdated": "更新",
+    "columns": "列",
     "namePlaceholder": "アノマリー名"
   },
   "stats": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -963,6 +963,7 @@
     "colNotes": "メモ",
     "colAge": "経過",
     "colUpdated": "更新",
+    "columns": "列",
     "namePlaceholder": "サイト名"
   },
   "anomalies": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -963,6 +963,7 @@
     "colNotes": "노트",
     "colAge": "경과",
     "colUpdated": "업데이트",
+    "columns": "열",
     "namePlaceholder": "사이트 이름"
   },
   "anomalies": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -996,6 +996,7 @@
     "colNotes": "노트",
     "colAge": "경과",
     "colUpdated": "업데이트",
+    "columns": "열",
     "namePlaceholder": "어노말리 이름"
   },
   "stats": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -996,6 +996,7 @@
     "colNotes": "Notas",
     "colAge": "Idade",
     "colUpdated": "Atualizado",
+    "columns": "Colunas",
     "namePlaceholder": "Nome da anomalia"
   },
   "stats": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -963,6 +963,7 @@
     "colNotes": "Notas",
     "colAge": "Idade",
     "colUpdated": "Atualizado",
+    "columns": "Colunas",
     "namePlaceholder": "Nome do site"
   },
   "anomalies": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1032,6 +1032,7 @@
     "colNotes": "Заметки",
     "colAge": "Возраст",
     "colUpdated": "Обновлено",
+    "columns": "Столбцы",
     "namePlaceholder": "Название аномалии"
   },
   "stats": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -995,6 +995,7 @@
     "colNotes": "Заметки",
     "colAge": "Возраст",
     "colUpdated": "Обновлено",
+    "columns": "Столбцы",
     "namePlaceholder": "Название сайта"
   },
   "anomalies": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -963,6 +963,7 @@
     "colNotes": "笔记",
     "colAge": "存在时长",
     "colUpdated": "更新时间",
+    "columns": "列",
     "namePlaceholder": "站点名称"
   },
   "anomalies": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -996,6 +996,7 @@
     "colNotes": "笔记",
     "colAge": "存在时长",
     "colUpdated": "更新时间",
+    "columns": "列",
     "namePlaceholder": "异常空间名称"
   },
   "stats": {


### PR DESCRIPTION
## What

A **Columns** picker on the Signature and Anomalies panes so you can hide optional columns and slim them down -- handy for an undocked, narrow window.

An icon button (columns glyph) sits at the right of the filter-chip row; clicking it opens a checkbox popover to toggle columns.

- **Signature pane** -- toggle **Name / Notes / Created / Updated**. ID / Type / WH Type / Leads To always stay.
- **Anomalies pane** -- toggle **Notes / Age / Updated**. ID / Type / Name always stay.

## Design

- **One shared setting per pane type** -- applies everywhere that pane appears, docked or floating.
- Persisted per user under `nexum.sigPane.hiddenCols` / `nexum.anomPane.hiddenCols`, stored as the list of *hidden* columns so the default (empty) means all shown, and any future hideable column defaults visible with no migration.

## Implementation notes

- Reuses the column-conditional-render pattern the tables already use (`<col>` / `<th>` / `<td>` per column), the `useUserSetting` persistence already used for column widths, and the `useClickOutside` popover idiom from `HeatmapMenu`. The Anomalies pane reuses the `.sig-col-menu` styles added for the Signature pane.
- Signature pane's `tableMinWidth` now sums only visible columns, so a slimmed table doesn't reserve width for hidden columns.
- Hiding is display-only: it doesn't touch the underlying data, so probe-scanner paste parsing and the Ctrl+A/Ctrl+C scan-routing are unaffected.

## i18n

New keys `signatures.columns` and `anomalies.columns` added to all 9 locales; the per-column checkbox labels reuse the existing header translations.

## Test

- `tsc -b`, `vite build`, locale parity check all clean (0 keys missing vs en; both new keys present in every locale).