### PR TITLE
Shorten update-check + patch-notes cache to 1h

### DIFF
--- a/server/src/services/releases.ts
+++ b/server/src/services/releases.ts
@@ -8,7 +8,7 @@ const log = createLogger('releases');
 
 const REPO       = 'GQuantrill/eve-nexum';
 const LIST_URL   = `https://api.github.com/repos/${REPO}/releases?per_page=10`;
-const OK_TTL_MS   = 6 * 60 * 60 * 1000;
+const OK_TTL_MS   = 60 * 60 * 1000; // 1h — in sync with the version check
 const FAIL_TTL_MS = 15 * 60 * 1000;
 const MAX_BODY    = 20_000; // release notes are small; cap defensively
 

--- a/server/src/services/versionCheck.ts
+++ b/server/src/services/versionCheck.ts
@@ -12,8 +12,8 @@ const log = createLogger('versionCheck');
 // release, not when their own fork tags something.
 const REPO = 'GQuantrill/eve-nexum';
 const LATEST_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
-const OK_TTL_MS   = 6 * 60 * 60 * 1000; // cache a good result 6h
-const FAIL_TTL_MS = 15 * 60 * 1000;     // retry a failure after 15m
+const OK_TTL_MS   = 60 * 60 * 1000; // cache a good result 1h — so a new release surfaces within ~1.5h
+const FAIL_TTL_MS = 15 * 60 * 1000; // retry a failure after 15m
 
 // Running version, read from package.json at the process cwd (/app in Docker,
 // server/ in dev — both have package.json at the root). Mirrors telemetry.


### PR DESCRIPTION
## What

Drops both server-side GitHub caches from **6h → 1h**, kept in sync:
- **`versionCheck.ts`** (`OK_TTL_MS`) — the admin "update available" badge now surfaces a new release within **~1.5h** (1h server cache + the ≤30-min client poll) instead of up to ~6.5h.
- **`releases.ts`** (patch-notes list) — matched to 1h so the patch-notes modal reflects a new release on the same cadence.

Still cheap: ~24 GitHub calls/day per endpoint at most, regardless of how many admins/users are polling. Failure retry stays at 15m.

## Test

- Server `tsc` clean.