### PR TITLE
Release 2.6.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/services/releases.ts
+++ b/server/src/services/releases.ts
@@ -8,7 +8,7 @@ const log = createLogger('releases');
 
 const REPO       = 'GQuantrill/eve-nexum';
 const LIST_URL   = `https://api.github.com/repos/${REPO}/releases?per_page=10`;
-const OK_TTL_MS   = 6 * 60 * 60 * 1000;
+const OK_TTL_MS   = 60 * 60 * 1000; // 1h — in sync with the version check
 const FAIL_TTL_MS = 15 * 60 * 1000;
 const MAX_BODY    = 20_000; // release notes are small; cap defensively
 

--- a/server/src/services/versionCheck.ts
+++ b/server/src/services/versionCheck.ts
@@ -12,8 +12,8 @@ const log = createLogger('versionCheck');
 // release, not when their own fork tags something.
 const REPO = 'GQuantrill/eve-nexum';
 const LATEST_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
-const OK_TTL_MS   = 6 * 60 * 60 * 1000; // cache a good result 6h
-const FAIL_TTL_MS = 15 * 60 * 1000;     // retry a failure after 15m
+const OK_TTL_MS   = 60 * 60 * 1000; // cache a good result 1h — so a new release surfaces within ~1.5h
+const FAIL_TTL_MS = 15 * 60 * 1000; // retry a failure after 15m
 
 // Running version, read from package.json at the process cwd (/app in Docker,
 // server/ in dev — both have package.json at the root). Mirrors telemetry.

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
## Release 2.6.1

Patch release merging `release` into `main`.

### Changes
- Shorten the update-check + patch-notes server caches from 6h to 1h, so a new release surfaces in the admin update badge (and patch-notes modal) within ~1.5h instead of up to ~6.5h (#408).

Version bumped to 2.6.1.

After merge: cut the `v2.6.1` GitHub release/tag.