### PR TITLE
Show canvas how-to hint only on a visitor's first visit

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -200,6 +200,18 @@ export function MapCanvas() {
   const [customIntel] = useCustomIntel();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  // The canvas how-to hint is onboarding: show it only on a visitor's first
+  // ever visit, then remember (per-device) that they've seen it and hide it.
+  const [showCanvasHint] = useState(() => {
+    try { return localStorage.getItem('nexum.seenMapHint') !== '1'; }
+    catch { return true; } // private mode / storage blocked: just show it
+  });
+  useEffect(() => {
+    if (showCanvasHint) {
+      try { localStorage.setItem('nexum.seenMapHint', '1'); } catch { /* quota / private mode */ }
+    }
+  }, [showCanvasHint]);
+
   // Inverted-zoom handler. When on, React Flow's own wheel AND pinch zoom are
   // off (zoomOnScroll / zoomOnPinch = !invertZoom) and we handle both here with
   // the direction flipped, anchored at the cursor, matching d3-zoom's scaling so
@@ -1304,7 +1316,7 @@ export function MapCanvas() {
         )}
       </ReactFlow>
 
-      <div className="map-canvas__hint">{t('ctxMenu.canvasHint')}</div>
+      {showCanvasHint && <div className="map-canvas__hint">{t('ctxMenu.canvasHint')}</div>}
 
       {contextMenu && (
         <ContextMenu


### PR DESCRIPTION
## What
The "Right-click canvas to add system / Drag between handles to connect / ..." onboarding hint was rendered on the map on every visit. This gates it so it only shows on a visitor's first visit.

## How
- Read `nexum.seenMapHint` from localStorage on mount; show the hint only if unset.
- Mark it seen (write the flag) in an effect once shown, so subsequent visits/reloads hide it.
- Wrapped in try/catch: if storage is blocked (private mode), the hint just shows (fails open).
- Per-device, zero-backend, matching the existing one-time-prompt pattern (proximity opt-in, etc).

## Notes
- The hint text itself is unchanged and already translated, so no i18n changes.
- Existing users (who have no flag yet) will see the hint once more on their next visit, then never again.