### PR TITLE
Fix Discord connection notification always showing size "large"

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -21,6 +21,7 @@ import {
 import { reportPresence } from '../services/presence.js';
 import { copyMap } from '../services/mapCopy.js';
 import { notifyDiscord, k162Embed, connectionEmbed, chainEmbed } from '../services/discord.js';
+import { whSizeForCode } from './wormholes.js';
 
 const log = createLogger('maps');
 const discordLog = createLogger('discord');
@@ -494,11 +495,15 @@ function dispatchNewConnection(
       discordLog.info(`new connection ${r.a} <-> ${r.b} suppressed — dest class "${destClass}" not in the org's class filter`);
       return;
     }
-    if (!whListAllows(r.whSizes, (size ?? 'large'))) {
-      discordLog.info(`new connection ${r.a} <-> ${r.b} suppressed — size "${size ?? 'large'}" not in the org's size filter`);
+    // Size: the freshly-scanned hole is at its nominal size, so derive it from
+    // the backing wormhole type (Q003 -> small). Only fall back to the stored
+    // connection size, then 'large', when the type is unknown (e.g. bare K162).
+    const effSize = (await whSizeForCode(ev.whType || whType)) ?? size ?? 'large';
+    if (!whListAllows(r.whSizes, effSize)) {
+      discordLog.info(`new connection ${r.a} <-> ${r.b} suppressed — size "${effSize}" not in the org's size filter`);
       return;
     }
-    notifyDiscord(r.connectionsWebhook, connectionEmbed({ a: r.a, b: r.b, whType: ev.whType || whType, size, mapName: r.mapName, actor }));
+    notifyDiscord(r.connectionsWebhook, connectionEmbed({ a: r.a, b: r.b, whType: ev.whType || whType, size: effSize, mapName: r.mapName, actor }));
   }).catch((e) => discordLog.warn(`connection dispatch query failed: ${(e as Error).message}`));
 }
 
@@ -2040,7 +2045,7 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
   // Only notify on a genuinely new wormhole connection — not a duplicate-id
   // retry, and not an in-game gate or Ansiblex link.
   if (inserted > 0 && effectiveType === 'standard') {
-    dispatchNewConnection(access, mapId, sourceId, targetId, null, size ?? 'large', req.session.characterName ?? null);
+    dispatchNewConnection(access, mapId, sourceId, targetId, null, size ?? null, req.session.characterName ?? null);
   }
   // Return the resolved type so the originating client can reflect an
   // auto-classified gate without waiting for a reload.

--- a/server/src/routes/wormholes.ts
+++ b/server/src/routes/wormholes.ts
@@ -171,6 +171,34 @@ async function loadSpecs(): Promise<Record<string, WormholeSpec>> {
   return inflight;
 }
 
+// Per-jump mass thresholds (kg) — MUST mirror web/src/utils/wormholeSize.ts's
+// WH_JUMP_MASS so the server and client classify a hole's size identically.
+const WH_JUMP_MASS = { xl: 1_000_000_000, large: 300_000_000, medium: 62_000_000 } as const;
+
+export type WhSizeClass = 'xl' | 'large' | 'medium' | 'small';
+
+function sizeClassForMass(maxJumpMass: number | null | undefined): WhSizeClass | null {
+  if (!maxJumpMass || maxJumpMass <= 0) return null;
+  if (maxJumpMass >= WH_JUMP_MASS.xl)     return 'xl';
+  if (maxJumpMass >= WH_JUMP_MASS.large)  return 'large';
+  if (maxJumpMass >= WH_JUMP_MASS.medium) return 'medium';
+  return 'small';
+}
+
+// The nominal size class for a wormhole code (e.g. 'Q003' -> 'small'), derived
+// from the SDE per-jump mass cap. null when the code is unknown/unscanned
+// (e.g. a bare K162) so callers can fall back. Best-effort: a spec-load failure
+// yields null rather than throwing into the caller.
+export async function whSizeForCode(code: string | null | undefined): Promise<WhSizeClass | null> {
+  if (!code) return null;
+  try {
+    const specs = await loadSpecs();
+    return sizeClassForMass(specs[code.toUpperCase()]?.maxJumpMass);
+  } catch {
+    return null;
+  }
+}
+
 router.get('/types', async (_req, res) => {
   try {
     res.json(await loadSpecs());


### PR DESCRIPTION
## Problem
New-connection Discord notifications always reported **Size: large**, even for small holes (e.g. a Q003). The size came from the connection's stored `size` column, which defaults to `'large'` when the client doesn't send one, and was passed straight to the embed and the `wh_sizes` filter.

## Fix
Derive the size from the backing wormhole **type** instead. A freshly-scanned hole is at its nominal size, so `Q003 -> small`. The stored connection size (then `'large'`) is used only when the type is genuinely unknown (e.g. a bare K162).

- `wormholes.ts`: new `whSizeForCode(code)` derives the size class from the SDE per-jump mass cap, mirroring the client's `WH_JUMP_MASS` thresholds.
- `maps.ts` `dispatchNewConnection`: computes `effSize` (type-first) and uses it for both the embed and the `wh_sizes` filter check.
- Call site passes the raw nullable size instead of pre-defaulting to `'large'`.

## Scope
Only corrects what the notification reports + the size filter. The stored `size` column is unchanged (still `'large'` at insert); the map UI already derives edge size from the type client-side.

## Validation
- `tsc --noEmit` passes.
- No import cycle (`wormholes.ts` doesn't import `maps.ts`).