### PR TITLE
Derive stored connection size from the wormhole type on update

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -2067,7 +2067,18 @@ mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {
     sourceSignatureId: 'source_signature_id', targetSignatureId: 'target_signature_id',
   };
 
-  const updates = req.body as Record<string, unknown>;
+  const updates: Record<string, unknown> = { ...(req.body as Record<string, unknown>) };
+
+  // The stored size should follow the hole type. When the wormhole type is set
+  // without an explicit size — wormhole auto-detect and external API writes both
+  // send `type` alone — derive the nominal size class from the type so a Q003 is
+  // stored as 'small' instead of the 'large' insert-time default. An explicit
+  // client size (e.g. a manual override) is always respected.
+  if ('type' in updates && !('size' in updates)) {
+    const derived = await whSizeForCode(updates.type as string | null);
+    if (derived) updates.size = derived;
+  }
+
   const sets: string[] = [];
   const vals: unknown[] = [];
 


### PR DESCRIPTION
## Problem
A connection's stored `size` defaults to `'large'` at insert (the wh type isn't known yet). The client's `ConnectionPanel` derives size from the type and PATCHes it, but two paths set `type` **without** a size and leave the stored size stale:
- wormhole auto-detect (`whAutoDetect.ts` sends `{ type: best }`),
- external `/api/v1` writes.

So an auto-classified Q003 kept `size = 'large'`.

## Fix
Derive the nominal size from the type **server-side** in the connection PATCH: when `type` is set without an explicit `size`, fill `size` from the type (Q003 -> small). An explicit client size (manual override) is still respected. The derived value is included in the `connection.update` broadcast, so clients reflect it live.

This is the follow-up to #415 — that fixed what the Discord notification *reports*; this fixes the stored value, which is also read by chain "max ship" (`chainMaxSize`) and frig-hole detection (`conn.size === 'small'`).

## Scope / notes
- Interactive + API update path only. Existing rows already stored as `'large'` aren't retroactively rewritten, but auto-detect re-runs on re-scans so most self-correct; say the word if you want a one-off backfill.
- `whSizeForCode` (added in #415) is reused.

## Validation
- `tsc --noEmit` passes.