### PR TITLE
Release 2.8.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -2067,7 +2067,18 @@ mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {
     sourceSignatureId: 'source_signature_id', targetSignatureId: 'target_signature_id',
   };
 
-  const updates = req.body as Record<string, unknown>;
+  const updates: Record<string, unknown> = { ...(req.body as Record<string, unknown>) };
+
+  // The stored size should follow the hole type. When the wormhole type is set
+  // without an explicit size — wormhole auto-detect and external API writes both
+  // send `type` alone — derive the nominal size class from the type so a Q003 is
+  // stored as 'small' instead of the 'large' insert-time default. An explicit
+  // client size (e.g. a manual override) is always respected.
+  if ('type' in updates && !('size' in updates)) {
+    const derived = await whSizeForCode(updates.type as string | null);
+    if (derived) updates.size = derived;
+  }
+
   const sets: string[] = [];
   const vals: unknown[] = [];
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
## Release 2.8.1

Patch release.

- **#417** Derive a connection's stored `size` from the wormhole type on update — an auto-classified Q003 is now stored as `small` instead of the `large` insert-time default. Follow-up to #415; also corrects chain "max ship" and frig-hole detection, which read the stored size. _(fix)_

Version bumped to **2.8.1** in both `web` and `server` package.json.