### PR TITLE
Auto-link a connection's backing signature; stop redundant jump prompt

### DIFF
--- a/web/src/hooks/whJumpConfirm.ts
+++ b/web/src/hooks/whJumpConfirm.ts
@@ -56,6 +56,14 @@ export async function maybeConfirmWhJump(ctx: WhJumpContext): Promise<void> {
     return;
   }
 
+  // Already accounted for: a wormhole sig here is pinned to exactly where we
+  // arrived, so this hole is solved and its connection's backing sig is (or will
+  // be) linked by the sig auto-detect. Don't fill a second hole or prompt — this
+  // is the "asked which sig on the way back even though one already leads home"
+  // case.
+  const arrived = toName.toUpperCase();
+  if (sigs.some((s) => s.sigType === 'wormhole' && (s.whLeadsTo || '').toUpperCase() === arrived)) return;
+
   // Eligible = known wormhole sigs not yet pinned to a system, whose class is
   // compatible with where we arrived. Unknowns (non-wormhole) are never touched.
   // Bail before the gate check when there's nothing to fill.

--- a/web/src/utils/whAutoDetect.ts
+++ b/web/src/utils/whAutoDetect.ts
@@ -1,5 +1,5 @@
 import { useMapStore } from '../store/mapStore';
-import type { Signature } from '../types';
+import type { Signature, MapConnection } from '../types';
 
 /**
  * After a signature was edited or deleted, re-evaluate every connection that
@@ -48,12 +48,13 @@ export function reevaluateConnectionsForSystem(
     const oc = otherSys.systemClass.toUpperCase();
     const on = (otherSys.name ?? '').toUpperCase();
 
-    const backingCodes: string[] = [];
-    for (const s of allSigs) {
-      if (!s.whType || !s.whLeadsTo) continue;
-      const target = s.whLeadsTo.toUpperCase();
-      if (target === oc || target === on) backingCodes.push(s.whType.toUpperCase());
-    }
+    // Sigs on this system that back the link: a scanned wormhole whose leads-to
+    // points at the other endpoint, by exact system name (pinned) or by class.
+    const backing = allSigs.filter(
+      (s) => s.whType && s.whLeadsTo &&
+        (s.whLeadsTo.toUpperCase() === oc || s.whLeadsTo.toUpperCase() === on),
+    );
+    const backingCodes = backing.map((s) => (s.whType ?? '').toUpperCase());
     const best = backingCodes.find(t => t !== 'K162') ?? backingCodes[0];
 
     // True when this connection's current type was auto-filled from the sig
@@ -66,29 +67,48 @@ export function reevaluateConnectionsForSystem(
       conn.type && conn.type.toUpperCase() === oldType
     );
 
+    const patch: Partial<Omit<MapConnection, 'id'>> = {};
+
     if (best) {
       if (conn.broken) {
         // A sig backs this link again (e.g. it reappeared in a re-scan) —
         // un-quarantine it and restore the type.
-        updateConnection(conn.id, { broken: false, type: best });
+        patch.broken = false; patch.type = best;
       } else if (conn.type === null || (conn.type.toUpperCase() === 'K162' && best !== 'K162')) {
         // Empty, or a K162 placeholder being upgraded to a real code.
-        updateConnection(conn.id, { type: best });
+        patch.type = best;
       } else if (oldBackedThis && conn.type.toUpperCase() !== best.toUpperCase()) {
         // The sig that auto-filled this connection had its WH type changed —
         // follow it so editing a sig's type updates the map label too.
-        updateConnection(conn.id, { type: best });
+        patch.type = best;
       }
-      // else: '' (user cleared) or a manual real code — leave it.
-      continue;
+      // else: '' (user cleared) or a manual real code — leave the type.
+
+      // Record which sig backs this end so "Backing signatures" fills in
+      // automatically instead of only ever being set by hand. Only when the
+      // backing sig is UNAMBIGUOUS — a single hole pinned to the exact connected
+      // system, or the sole backing hole on this end — and never overriding a
+      // manual link. (A K162 twin pinned to the same system alongside the real
+      // code is fine: the real code wins as the single non-K162 pinned hole.)
+      const endField = conn.sourceId === systemId ? 'sourceSignatureId' : 'targetSignatureId';
+      if (!conn[endField]) {
+        const pinned = backing.filter((s) => (s.whLeadsTo ?? '').toUpperCase() === on);
+        const pinnedReal = pinned.filter((s) => (s.whType ?? '').toUpperCase() !== 'K162');
+        const linkSig =
+          pinnedReal.length === 1 ? pinnedReal[0] :
+          pinned.length === 1     ? pinned[0]     :
+          pinned.length === 0 && backing.length === 1 ? backing[0] :
+          undefined; // several plausible holes — ambiguous, leave it to the user
+        if (linkSig) patch[endField] = linkSig.id;
+      }
+    } else if (oldBackedThis && !conn.broken) {
+      // No sig backs the connection any more. If this sig used to back it:
+      //  - on a delete (breakOnOrphan), quarantine it — the hole collapsed, so
+      //    sever the chain visually but keep it traceable;
+      //  - on an edit, just clear the orphaned auto-filled type as before.
+      if (breakOnOrphan) patch.broken = true; else patch.type = null;
     }
 
-    // No sig backs the connection any more. If this sig used to back it:
-    //  - on a delete (breakOnOrphan), quarantine it — the hole collapsed, so
-    //    sever the chain visually but keep it traceable;
-    //  - on an edit, just clear the orphaned auto-filled type as before.
-    if (oldBackedThis && !conn.broken) {
-      updateConnection(conn.id, breakOnOrphan ? { broken: true } : { type: null });
-    }
+    if (Object.keys(patch).length) updateConnection(conn.id, patch);
   }
 }


### PR DESCRIPTION
Fixes a user-reported bug (screenshot): a U210 connection was mapped but its "Backing signatures" stayed **Not linked** even after the sig's destination was assigned, and the return jump kept asking "which sig did you use?" despite a hole already leading home.

## Root cause
The app never recorded **which** signature backs a connection. Auto-detect (`reevaluateConnectionsForSystem`) and the jump-confirm flow only ever filled the connection's **type label** (and pinned the sig's leads-to). `sourceSignatureId` / `targetSignatureId` were *only* ever set by hand in the ConnectionPanel dropdowns.

## Fix
**A — auto-link the backing sig** (`whAutoDetect.ts`): when a sig on a system unambiguously backs a connection — a single hole pinned to the exact connected system, or the sole backing hole on that end — also set that end's `sourceSignatureId`/`targetSignatureId`. Only when the end is empty (never overrides a manual link). Ambiguous cases (several same-class holes) are left to the user, per the chosen behaviour.

**B — stop the redundant prompt** (`whJumpConfirm.ts`): `maybeConfirmWhJump` now returns early if a wormhole sig in the source system already leads to the arrival system — the hole is solved, so it doesn't prompt about other unpinned sigs on the way back.

## Result
- Setting a sig's destination now links the connection's backing sig automatically (was: stayed "Not linked").
- Auto/jump-filled holes populate the link too, not just the type label.
- The return jump no longer asks "which sig?" when a hole already leads to where you arrived.

## Validation
- `tsc -b` and eslint pass. Client-only; no new user-facing strings (no i18n impact).