### PR TITLE
Discord: only notify a K162 once its leads-to is a specific system

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -336,6 +336,22 @@ const DISCORD_SETTINGS_COLS = `
   COALESCE(cds.connections_webhook, ads.connections_webhook)    AS "connectionsWebhook",
   COALESCE(cds.chains_webhook,      ads.chains_webhook)         AS "chainsWebhook"`;
 
+// leads-to tokens that are a class/band/unknown rather than a pinned system —
+// mirrors the client's CLASS_OR_UNKNOWN set. A leads-to NOT in here is a
+// specific connected system, i.e. the hole is resolved to a real destination.
+const LEADS_TO_NON_SYSTEM = new Set([
+  '', 'UNKNOWN',
+  'C1-C3', 'C4-C5', 'C6', 'C13', 'THERA', 'POCHVEN', 'DRIFTER',
+  'HS', 'LS', 'NS',
+  'C1', 'C2', 'C3', 'C4', 'C5',
+]);
+// True once a hole's leads-to names a specific destination system (not empty,
+// "unknown", or a class/band). Discord notifications fire only then — an
+// unknown/class-only hole is surfaced on the map instead, not broadcast.
+function leadsToIsSystem(leadsTo: string | null): boolean {
+  return !LEADS_TO_NON_SYSTEM.has((leadsTo ?? '').trim().toUpperCase());
+}
+
 // Re-read the signature now (after the defer window) and send if it's still a
 // K162, including the leads-to if one was set in the meantime.
 async function fireK162(sigId: string, actor: string | null): Promise<void> {
@@ -369,6 +385,10 @@ async function fireK162(sigId: string, actor: string | null): Promise<void> {
     }
     if (!regionAllowed(r.allRegions, r.regions, [r.region])) {
       discordLog.info(`K162 (sig ${sigId}) suppressed — region "${r.region ?? 'unknown'}" not in the org filter`);
+      return;
+    }
+    if (!leadsToIsSystem(r.leadsTo)) {
+      discordLog.info(`K162 (sig ${sigId}) suppressed — leads-to "${r.leadsTo ?? 'unknown'}" is not a specific destination system`);
       return;
     }
     notifyDiscord(r.connectionsWebhook, k162Embed({ system: r.system, systemClass: r.systemClass, leadsTo: r.leadsTo, mapName: r.mapName, actor }));


### PR DESCRIPTION
Per request: only broadcast a Discord message when a hole's **leads-to names a specific destination system** — ignore unknown or class/band-only holes (which are now surfaced on the map as pills instead of pinged).

## Change
The K162 signature notification is the only one keyed on a `leads-to`. It now suppresses the send unless `wh_leads_to` names a specific system (not empty, `unknown`, or a class/band token like `LS` / `C1-C3`).

## Why this is complete
- Unknown / class-only K162s → no ping (the noise this removes).
- A hole you actually **dive/resolve** still notifies via the **new-connection** notification, which always carries both endpoint systems — so resolved holes are still broadcast.
- If a K162 itself gets pinned to a specific system within its detection window, it still fires (now with a real destination).

Connection notifications are unchanged (they never had an unknown leads-to).

## Validation
- Server `tsc` passes.