### PR TITLE
Discord: don't re-broadcast a K162 for a hole already mapped from the other end

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -359,12 +359,25 @@ async function fireK162(sigId: string, actor: string | null): Promise<void> {
     const { rows } = await db.query<{
       whType: string | null; leadsTo: string | null; system: string; systemClass: string;
       region: string | null; mapName: string; mapEnabled: boolean; allRegions: boolean; regions: string[];
-      connectionsWebhook: string | null;
+      connectionsWebhook: string | null; connectedToDest: boolean;
     }>(
+      // `connectedToDest`: a wormhole connection already links this K162's system
+      // to the system its leads-to names — i.e. the far side of a hole we've
+      // already mapped (and broadcast) from the other end. When true we skip the
+      // K162 ping so the same hole isn't announced twice.
       `SELECT sg.wh_type AS "whType", sg.wh_leads_to AS "leadsTo",
               s.name AS "system", s.system_class AS "systemClass", s.region_name AS "region",
               m.name AS "mapName", m.discord_notify AS "mapEnabled",
-              ${DISCORD_SETTINGS_COLS}
+              ${DISCORD_SETTINGS_COLS},
+              EXISTS (
+                SELECT 1 FROM map_connections c
+                  JOIN map_systems os
+                    ON os.id = (CASE WHEN c.source_id = s.id THEN c.target_id ELSE c.source_id END)
+                 WHERE c.map_id = m.id
+                   AND c.connection_type = 'standard'
+                   AND (c.source_id = s.id OR c.target_id = s.id)
+                   AND UPPER(os.name) = UPPER(sg.wh_leads_to)
+              ) AS "connectedToDest"
          FROM map_signatures sg
          JOIN map_systems s ON s.id = sg.system_id
          JOIN maps m ON m.id = s.map_id
@@ -389,6 +402,10 @@ async function fireK162(sigId: string, actor: string | null): Promise<void> {
     }
     if (!leadsToIsSystem(r.leadsTo)) {
       discordLog.info(`K162 (sig ${sigId}) suppressed — leads-to "${r.leadsTo ?? 'unknown'}" is not a specific destination system`);
+      return;
+    }
+    if (r.connectedToDest) {
+      discordLog.info(`K162 (sig ${sigId}) suppressed — "${r.system}" is already connected to "${r.leadsTo}"; that hole was broadcast from the other end`);
       return;
     }
     notifyDiscord(r.connectionsWebhook, k162Embed({ system: r.system, systemClass: r.systemClass, leadsTo: r.leadsTo, mapName: r.mapName, actor }));


### PR DESCRIPTION
Per request: if System A has a Q003 → System B and we've already broadcast that connection, then scanning the **K162 in B** (leads-to A) is the *same hole* — it shouldn't ping again.

## Why it was double-firing
A hole is one connection but two signatures (the outbound Q003 in A, the inbound K162 in B). The connection broadcasts once (#422), but the K162 sig notification is a **separate** path — and since #421 it fires when the K162's leads-to is a specific system. So scanning the far-side K162 produced a second ping.

## Fix
Suppress the K162 signature notification when a **standard (wormhole) connection already links the K162's system to the system its leads-to names**. The connection is the canonical broadcaster, so the far-side K162 is redundant.

- Constant SQL — an `EXISTS` subquery, sig id still parameterised.
- Only a **wormhole** connection suppresses it (a gate to the same system doesn't, so a genuine new hole between gate-adjacent systems still pings).
- A K162 leading to a system with **no** wormhole connection still notifies — real inbound intel with nothing else representing it.

## Validation
- Server `tsc` passes.