### PR TITLE
Fix Discord migration: add discord_notified_known independently

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -321,20 +321,28 @@ export async function migrate() {
     -- every EXISTING connection as already-handled so the current chain isn't
     -- re-announced when its holes are next edited after deploy — guarded so the
     -- backfill runs exactly once, not on every boot.
+    -- discord_notified: broadcast at least once. discord_notified_known: the
+    -- broadcast carried a KNOWN wormhole type (not a bare K162) — lets a hole
+    -- first announced as an unknown K162 re-broadcast once when its real type is
+    -- scanned. Each column is guarded and backfilled INDEPENDENTLY (TRUE for
+    -- pre-existing connections, so the current chain isn't re-announced) — the
+    -- second must not be gated on the first, since an earlier deploy may already
+    -- have added discord_notified alone.
     DO $$
     BEGIN
       IF NOT EXISTS (
         SELECT 1 FROM information_schema.columns
         WHERE table_name = 'map_connections' AND column_name = 'discord_notified'
       ) THEN
-        -- discord_notified: broadcast at least once. discord_notified_known: the
-        -- broadcast carried a KNOWN wormhole type (not a bare K162) — lets a hole
-        -- first announced as an unknown K162 re-broadcast once when its real type
-        -- is scanned. Both TRUE for pre-existing connections so the current chain
-        -- isn't re-announced after deploy.
-        ALTER TABLE map_connections ADD COLUMN discord_notified       BOOLEAN NOT NULL DEFAULT FALSE;
+        ALTER TABLE map_connections ADD COLUMN discord_notified BOOLEAN NOT NULL DEFAULT FALSE;
+        UPDATE map_connections SET discord_notified = TRUE;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'map_connections' AND column_name = 'discord_notified_known'
+      ) THEN
         ALTER TABLE map_connections ADD COLUMN discord_notified_known BOOLEAN NOT NULL DEFAULT FALSE;
-        UPDATE map_connections SET discord_notified = TRUE, discord_notified_known = TRUE;
+        UPDATE map_connections SET discord_notified_known = TRUE;
       END IF;
     END $$;
 


### PR DESCRIPTION
Follow-up to #425. That PR added `discord_notified_known` **inside** the `IF NOT EXISTS (discord_notified)` guard, so any server that had already added `discord_notified` on an earlier boot (#422) skips creating the new column — producing `column c.discord_notified_known does not exist` at query time.

**Production will hit this**: the #422 merge added `discord_notified`, so the #425 migration will skip `discord_notified_known` on the prod DB.

This guards and backfills each column on its **own** existence check, so `discord_notified_known` is added regardless of whether `discord_notified` already exists. Idempotent and safe to re-run.

Verified fixed on a server that already had `discord_notified`.