### PR TITLE
Self-flush the offline write queue so raced writes recover on their own

### DIFF
--- a/web/src/store/pendingQueue.ts
+++ b/web/src/store/pendingQueue.ts
@@ -12,14 +12,27 @@ interface PendingOp {
 const MAX_ATTEMPTS = 5;
 const queue: PendingOp[] = [];
 let flushing = false;
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
 function opId() {
   return Math.random().toString(36).slice(2, 9);
 }
 
+// Retry the queue on our own shortly after a write is enqueued, rather than only
+// when the 10s location poll happens to flush it — and never at all when nothing
+// polls (the jump simulator, or a stationary/logged-out session). The short
+// delay lets an in-flight dependency land first: the common case is a connection
+// POST that 409'd because its endpoint system's POST hadn't committed yet, so a
+// ~0.6s retry succeeds instead of the link sitting broken until the next poll.
+function scheduleFlush(delayMs = 600): void {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => { flushTimer = null; void flushQueue(); }, delayMs);
+}
+
 export function enqueue(label: string, url: string, method: string, body: string) {
   queue.push({ id: opId(), label, url, method, body, attempts: 0 });
   console.warn(`[queue] Enqueued (${queue.length} pending): ${label}`);
+  scheduleFlush();
 }
 
 export async function flushQueue(): Promise<void> {
@@ -45,6 +58,14 @@ export async function flushQueue(): Promise<void> {
   }
 
   flushing = false;
+
+  // Anything still queued after a failed pass: retry with a backoff that grows
+  // with the worst attempt count, so a dependency that's slow to appear gets
+  // time to land without the queue spinning.
+  if (queue.length > 0) {
+    const worst = Math.max(...queue.map((op) => op.attempts));
+    scheduleFlush(Math.min(8000, 600 * 2 ** worst));
+  }
 }
 
 export function getQueue(): PendingOp[] {


### PR DESCRIPTION
## Symptom
On a jump, the new system and its connection are POSTed near-simultaneously. The connection POST can beat the system's insert → `409 "Endpoint system missing"` → the connection is enqueued for retry (and the new system's sig/anom/structure GETs 404 for the same brief window).

## Root cause
The retry queue was **passive** — `enqueue()` didn't trigger anything; the queue only drained on the 10s `useCharacterLocation` poll, and **never** when nothing polls (the jump simulator, or a stationary session). So a raced connection could sit broken for up to 10s, or indefinitely.

## Fix
- `enqueue()` now schedules a flush (~0.6s later).
- `flushQueue()` re-schedules itself with a growing backoff (0.6s → capped 8s) while anything remains, so a write whose dependency is slow to land keeps retrying without spinning.

Independent of location polling, so it fixes both the simulator and stationary sessions, and shortens real-jump recovery from ≤10s to ~0.6s.

## Note
This makes a **raced** connection self-heal. If a jump's connection stays broken *after* this, it means the **system's own POST is failing** (e.g. a 409 "system already on map" the client doesn't reconcile) — that's a separate fix; see the PR discussion for the diagnostic to confirm which.