### PR TITLE
Wrap watchlist row controls on narrow panels

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2349,6 +2349,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  /* Wrap onto extra rows on a narrow (docked) panel instead of shrinking the
+     controls to nothing. Kicks in only when they no longer fit side by side —
+     wide layouts are unchanged. Paired with the min-widths below, since a
+     min-width of 0 would let items shrink forever and never wrap. */
+  flex-wrap: wrap;
 }
 
 .watchlist__drag-handle {
@@ -2383,11 +2388,11 @@
 }
 
 .watchlist__marker { width: 82px; }
-.watchlist__by { flex: 1; min-width: 0; }
+.watchlist__by { flex: 1; min-width: 80px; }
 
 .watchlist__char-label {
   flex: 1;
-  min-width: 0;
+  min-width: 80px;
   font-size: calc(12px * var(--font-scale, 1));
   color: #c8d4f0;
   white-space: nowrap;
@@ -2399,7 +2404,7 @@
 .watchlist__note {
   flex: 1;
   width: 100%;
-  min-width: 0;
+  min-width: 96px;
   background: #0a0e1a;
   border: 1px solid #1e2740;
   border-radius: 4px;
@@ -2435,7 +2440,7 @@
 .watchlist__search,
 .watchlist__whpick {
   flex: 1;
-  min-width: 0;
+  min-width: 96px;
 }
 
 /* Red outline on the picker button when the wormhole type duplicates another


### PR DESCRIPTION
On a narrow (docked) sidebar the watchlist row controls overflowed — the system-name and note fields were clipped (screenshot).

## Cause
The row-top/row-bottom are flex rows, but the growable controls had `min-width: 0`, so instead of wrapping they shrank to nothing and clipped.

## Fix (CSS only)
- `flex-wrap: wrap` on `.watchlist__row-top` / `.watchlist__row-bottom`.
- A small `min-width` on the growable controls (match-type select, system/wh-type value, note input, characteristic label) so they wrap onto a new line instead of shrinking to zero.

Only engages when the controls no longer fit side by side — wide layouts render exactly as before, and no fixed sizes were changed.

## Validation
- `yarn build` passes. CSS-only; worth an eyeball at a narrow docked width.