### PR TITLE
Correct the wormhole system-effect modifier lists

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3652,6 +3652,10 @@
   border-radius: 6px;
   padding: 6px 10px;
   white-space: nowrap;
+  /* Size the box to its widest row. Without this the tooltip's shrink-to-fit
+     width is constrained by its tiny icon container, so longer labels
+     (e.g. "Targeting Range") get clipped. */
+  width: max-content;
   z-index: 9999;
   flex-direction: column;
   gap: 3px;

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -137,21 +137,25 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
     { label: 'Ship Agility',    good: false },
     { label: 'Stasis Web Str',  good: false },
   ],
-  // Cataclysmic Variable: remote reps and cap buffed; local reps, cap recharge
-  // and remote cap transfer punished.
+  // Cataclysmic Variable: remote reps, shield transfer and cap buffed; local
+  // reps, cap recharge and remote cap transfer punished.
   cataclysmic_variable: [
-    { label: 'Remote Rep',   good: true  },
-    { label: 'Cap Capacity', good: true  },
-    { label: 'Local Rep',    good: false },
-    { label: 'Cap Recharge', good: false },
-    { label: 'Remote Cap',   good: false },
+    { label: 'Remote Armor Rep',   good: true  },
+    { label: 'Shield Transfer',    good: true  },
+    { label: 'Cap Capacity',       good: true  },
+    { label: 'Local Armor Rep',    good: false },
+    { label: 'Local Shield Boost', good: false },
+    { label: 'Cap Recharge',       good: false },
+    { label: 'Remote Cap',         good: false },
   ],
-  // Magnetar: huge raw damage, but application (tracking, range, missiles) suffers.
+  // Magnetar: huge raw damage and explosion radius up; tracking, range and
+  // target painting down.
   magnetar: [
     { label: 'Weapon Damage',    good: true  },
-    { label: 'Tracking',         good: false },
+    { label: 'Explosion Radius', good: true  },
+    { label: 'Drone Tracking',   good: false },
+    { label: 'Tracking Speed',   good: false },
     { label: 'Targeting Range',  good: false },
-    { label: 'Explosion Radius', good: false },
     { label: 'Target Painter',   good: false },
   ],
   // Red Giant: overheat, smartbomb and bomb buffs; modules take more heat damage.

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -131,22 +131,20 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
   // Black Hole: speed, range and missiles up; agility and webs down.
   black_hole: [
     { label: 'Ship Velocity',      good: true  },
-    { label: 'Missile Velocity',   good: true  },
-    { label: 'Explosion Velocity', good: true  },
     { label: 'Targeting Range',    good: true  },
+    { label: 'Missile Velocity',   good: true  },
+    { label: 'Missle & Vorton Explosion Velocity', good: true  },
     { label: 'Ship Agility',       good: false },
-    { label: 'Stasis Web Str',     good: false },
+    { label: 'Stasis Web Strength',     good: false },
   ],
   // Cataclysmic Variable: remote reps, shield transfer and cap buffed; local
   // reps, cap recharge and remote cap transfer punished.
   cataclysmic_variable: [
-    { label: 'Remote Armor Rep',   good: true  },
-    { label: 'Shield Transfer',    good: true  },
+    { label: 'Remote Armor Rep & Shield Boost',   good: true  },
     { label: 'Cap Capacity',       good: true  },
-    { label: 'Local Armor Rep',    good: false },
-    { label: 'Local Shield Boost', good: false },
-    { label: 'Cap Recharge',       good: false },
-    { label: 'Remote Cap',         good: false },
+    { label: 'Cap Recharge Rate',       good: false },
+    { label: 'Remote Cap Transfer',         good: false },
+    { label: 'Local Armor Rep & Shield Boost',    good: false },
   ],
   // Magnetar: huge raw damage and explosion radius up; tracking, range and
   // target painting down.
@@ -161,16 +159,15 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
   // Red Giant: overheat, smartbomb and bomb buffs; modules take more heat damage.
   red_giant: [
     { label: 'Overheat',        good: true  },
-    { label: 'Smartbomb Dmg',   good: true  },
-    { label: 'Smartbomb Range', good: true  },
+    { label: 'Smartbomb Damage & Range',   good: true  },
     { label: 'Bomb Damage',     good: true  },
     { label: 'Heat Damage',     good: false },
   ],
   // Wolf-Rayet: armor and small weapons buffed, smaller sig; shield resists punished.
   wolf_rayet: [
-    { label: 'Small Weapons', good: true  },
+    { label: 'Small Weapon Damage', good: true  },
     { label: 'Armor HP',      good: true  },
-    { label: 'Sig Radius',    good: true  },
-    { label: 'Shield Resist', good: false },
+    { label: 'Sig Radius Reduction',    good: true  },
+    { label: 'Shield Resists', good: false },
   ],
 };

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -130,12 +130,12 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
   ],
   // Black Hole: speed, range and missiles up; agility and webs down.
   black_hole: [
-    { label: 'Ship Speed',      good: true  },
-    { label: 'Missile Speed',   good: true  },
-    { label: 'Explosion Vel',   good: true  },
-    { label: 'Targeting Range', good: true  },
-    { label: 'Ship Agility',    good: false },
-    { label: 'Stasis Web Str',  good: false },
+    { label: 'Ship Velocity',      good: true  },
+    { label: 'Missile Velocity',   good: true  },
+    { label: 'Explosion Velocity', good: true  },
+    { label: 'Targeting Range',    good: true  },
+    { label: 'Ship Agility',       good: false },
+    { label: 'Stasis Web Str',     good: false },
   ],
   // Cataclysmic Variable: remote reps, shield transfer and cap buffed; local
   // reps, cap recharge and remote cap transfer punished.

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -115,42 +115,58 @@ export const EFFECT_ICONS: Record<WormholeEffect, { symbol: string; color: strin
   wolf_rayet:           { symbol: '⚔', color: 'var(--cv-effect-wolfrayet)' },
 };
 
+// System-effect modifiers, per the in-game "Effects" panel. `good` = beneficial
+// (shown ▲ green) vs detrimental (▼ red). Verified against the live client;
+// magnitudes scale by class but the set and direction are fixed per effect.
 export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; good: boolean }>> = {
   none: [],
+  // Pulsar: shield buffed, armor punished; larger sig, faster cap, stronger neuts.
   pulsar: [
     { label: 'Shield HP',      good: true  },
     { label: 'Cap Recharge',   good: true  },
-    { label: 'Armor HP',       good: false },
-    { label: 'Cap Size',       good: false },
+    { label: 'Neut/NOS Drain', good: true  },
+    { label: 'Armor Resist',   good: false },
+    { label: 'Sig Radius',     good: false },
   ],
+  // Black Hole: speed, range and missiles up; agility and webs down.
   black_hole: [
-    { label: 'Ship Speed',         good: true  },
-    { label: 'Missile Speed',      good: true  },
-    { label: 'Stasis Web Str',     good: false },
-    { label: 'Target Painter Str', good: false },
-    { label: 'Explosion Radius',   good: false },
+    { label: 'Ship Speed',      good: true  },
+    { label: 'Missile Speed',   good: true  },
+    { label: 'Explosion Vel',   good: true  },
+    { label: 'Targeting Range', good: true  },
+    { label: 'Ship Agility',    good: false },
+    { label: 'Stasis Web Str',  good: false },
   ],
+  // Cataclysmic Variable: remote reps and cap buffed; local reps, cap recharge
+  // and remote cap transfer punished.
   cataclysmic_variable: [
-    { label: 'Local Rep',    good: true  },
-    { label: 'Cap Recharge', good: true  },
-    { label: 'Remote Rep',   good: false },
-    { label: 'Cap Size',     good: false },
+    { label: 'Remote Rep',   good: true  },
+    { label: 'Cap Capacity', good: true  },
+    { label: 'Local Rep',    good: false },
+    { label: 'Cap Recharge', good: false },
+    { label: 'Remote Cap',   good: false },
   ],
+  // Magnetar: huge raw damage, but application (tracking, range, missiles) suffers.
   magnetar: [
-    { label: 'Drone Damage',      good: true  },
-    { label: 'Targeting Range',   good: false },
-    { label: 'Drone Range',       good: false },
-    { label: 'Explosion Radius',  good: false },
+    { label: 'Weapon Damage',    good: true  },
+    { label: 'Tracking',         good: false },
+    { label: 'Targeting Range',  good: false },
+    { label: 'Explosion Radius', good: false },
+    { label: 'Target Painter',   good: false },
   ],
+  // Red Giant: overheat, smartbomb and bomb buffs; modules take more heat damage.
   red_giant: [
-    { label: 'Overheat Bonus',  good: true  },
+    { label: 'Overheat',        good: true  },
+    { label: 'Smartbomb Dmg',   good: true  },
     { label: 'Smartbomb Range', good: true  },
+    { label: 'Bomb Damage',     good: true  },
     { label: 'Heat Damage',     good: false },
   ],
+  // Wolf-Rayet: armor and small weapons buffed, smaller sig; shield resists punished.
   wolf_rayet: [
-    { label: 'Small Weapons',    good: true  },
-    { label: 'Armor HP',         good: true  },
-    { label: 'Sig Radius',       good: true  },
-    { label: 'Shield HP',        good: false },
+    { label: 'Small Weapons', good: true  },
+    { label: 'Armor HP',      good: true  },
+    { label: 'Sig Radius',    good: true  },
+    { label: 'Shield Resist', good: false },
   ],
 };


### PR DESCRIPTION
The per-effect bonus/penalty lists (node effect tooltip + system panel) were wrong. Two examples from the report:

- **Black Hole** showed "Target Painter Str" and "Explosion Radius" penalties that don't exist, and was missing targeting range, missile explosion velocity, and the agility penalty. In-game (C6): ship velocity+, max targeting range+, missile velocity+, missile explosion velocity+, ship agility−, web strength−.
- **Cataclysmic Variable** had its signs **inverted** — showed Local Rep▲ / Remote Rep▼ / Cap Size▼, when in-game (C3) it's Remote Rep+ / Cap Capacity+ / Local Rep− / Cap Recharge− / Remote Cap Transmit−.

## Fix
Rewrote all six effect lists. Verified against:
- the **live client** Effects panel for Black Hole (C6) and Cataclysmic (C3) — the two screenshotted cases;
- the [EVE University wormhole effects](https://wiki.eveuniversity.org/Wormhole_space) table for Pulsar, Magnetar, Red Giant, Wolf-Rayet.

`good` (▲ green / ▼ red) now matches the in-game bonus/penalty colouring. Data-only change; labels render raw so there's no i18n impact. `tsc` passes.