### PR TITLE
Release 2.9.2

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "2.9.1",
+  "version": "2.9.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "2.9.1",
+  "version": "2.9.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3652,6 +3652,10 @@
   border-radius: 6px;
   padding: 6px 10px;
   white-space: nowrap;
+  /* Size the box to its widest row. Without this the tooltip's shrink-to-fit
+     width is constrained by its tiny icon container, so longer labels
+     (e.g. "Targeting Range") get clipped. */
+  width: max-content;
   z-index: 9999;
   flex-direction: column;
   gap: 3px;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2349,6 +2349,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  /* Wrap onto extra rows on a narrow (docked) panel instead of shrinking the
+     controls to nothing. Kicks in only when they no longer fit side by side —
+     wide layouts are unchanged. Paired with the min-widths below, since a
+     min-width of 0 would let items shrink forever and never wrap. */
+  flex-wrap: wrap;
 }
 
 .watchlist__drag-handle {
@@ -2383,11 +2388,11 @@
 }
 
 .watchlist__marker { width: 82px; }
-.watchlist__by { flex: 1; min-width: 0; }
+.watchlist__by { flex: 1; min-width: 80px; }
 
 .watchlist__char-label {
   flex: 1;
-  min-width: 0;
+  min-width: 80px;
   font-size: calc(12px * var(--font-scale, 1));
   color: #c8d4f0;
   white-space: nowrap;
@@ -2399,7 +2404,7 @@
 .watchlist__note {
   flex: 1;
   width: 100%;
-  min-width: 0;
+  min-width: 96px;
   background: #0a0e1a;
   border: 1px solid #1e2740;
   border-radius: 4px;
@@ -2435,7 +2440,7 @@
 .watchlist__search,
 .watchlist__whpick {
   flex: 1;
-  min-width: 0;
+  min-width: 96px;
 }
 
 /* Red outline on the picker button when the wormhole type duplicates another

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -137,21 +137,25 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
     { label: 'Ship Agility',    good: false },
     { label: 'Stasis Web Str',  good: false },
   ],
-  // Cataclysmic Variable: remote reps and cap buffed; local reps, cap recharge
-  // and remote cap transfer punished.
+  // Cataclysmic Variable: remote reps, shield transfer and cap buffed; local
+  // reps, cap recharge and remote cap transfer punished.
   cataclysmic_variable: [
-    { label: 'Remote Rep',   good: true  },
-    { label: 'Cap Capacity', good: true  },
-    { label: 'Local Rep',    good: false },
-    { label: 'Cap Recharge', good: false },
-    { label: 'Remote Cap',   good: false },
+    { label: 'Remote Armor Rep',   good: true  },
+    { label: 'Shield Transfer',    good: true  },
+    { label: 'Cap Capacity',       good: true  },
+    { label: 'Local Armor Rep',    good: false },
+    { label: 'Local Shield Boost', good: false },
+    { label: 'Cap Recharge',       good: false },
+    { label: 'Remote Cap',         good: false },
   ],
-  // Magnetar: huge raw damage, but application (tracking, range, missiles) suffers.
+  // Magnetar: huge raw damage and explosion radius up; tracking, range and
+  // target painting down.
   magnetar: [
     { label: 'Weapon Damage',    good: true  },
-    { label: 'Tracking',         good: false },
+    { label: 'Explosion Radius', good: true  },
+    { label: 'Drone Tracking',   good: false },
+    { label: 'Tracking Speed',   good: false },
     { label: 'Targeting Range',  good: false },
-    { label: 'Explosion Radius', good: false },
     { label: 'Target Painter',   good: false },
   ],
   // Red Giant: overheat, smartbomb and bomb buffs; modules take more heat damage.

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -131,22 +131,20 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
   // Black Hole: speed, range and missiles up; agility and webs down.
   black_hole: [
     { label: 'Ship Velocity',      good: true  },
-    { label: 'Missile Velocity',   good: true  },
-    { label: 'Explosion Velocity', good: true  },
     { label: 'Targeting Range',    good: true  },
+    { label: 'Missile Velocity',   good: true  },
+    { label: 'Missle & Vorton Explosion Velocity', good: true  },
     { label: 'Ship Agility',       good: false },
-    { label: 'Stasis Web Str',     good: false },
+    { label: 'Stasis Web Strength',     good: false },
   ],
   // Cataclysmic Variable: remote reps, shield transfer and cap buffed; local
   // reps, cap recharge and remote cap transfer punished.
   cataclysmic_variable: [
-    { label: 'Remote Armor Rep',   good: true  },
-    { label: 'Shield Transfer',    good: true  },
+    { label: 'Remote Armor Rep & Shield Boost',   good: true  },
     { label: 'Cap Capacity',       good: true  },
-    { label: 'Local Armor Rep',    good: false },
-    { label: 'Local Shield Boost', good: false },
-    { label: 'Cap Recharge',       good: false },
-    { label: 'Remote Cap',         good: false },
+    { label: 'Cap Recharge Rate',       good: false },
+    { label: 'Remote Cap Transfer',         good: false },
+    { label: 'Local Armor Rep & Shield Boost',    good: false },
   ],
   // Magnetar: huge raw damage and explosion radius up; tracking, range and
   // target painting down.
@@ -161,16 +159,15 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
   // Red Giant: overheat, smartbomb and bomb buffs; modules take more heat damage.
   red_giant: [
     { label: 'Overheat',        good: true  },
-    { label: 'Smartbomb Dmg',   good: true  },
-    { label: 'Smartbomb Range', good: true  },
+    { label: 'Smartbomb Damage & Range',   good: true  },
     { label: 'Bomb Damage',     good: true  },
     { label: 'Heat Damage',     good: false },
   ],
   // Wolf-Rayet: armor and small weapons buffed, smaller sig; shield resists punished.
   wolf_rayet: [
-    { label: 'Small Weapons', good: true  },
+    { label: 'Small Weapon Damage', good: true  },
     { label: 'Armor HP',      good: true  },
-    { label: 'Sig Radius',    good: true  },
-    { label: 'Shield Resist', good: false },
+    { label: 'Sig Radius Reduction',    good: true  },
+    { label: 'Shield Resists', good: false },
   ],
 };

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -130,12 +130,12 @@ export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; goo
   ],
   // Black Hole: speed, range and missiles up; agility and webs down.
   black_hole: [
-    { label: 'Ship Speed',      good: true  },
-    { label: 'Missile Speed',   good: true  },
-    { label: 'Explosion Vel',   good: true  },
-    { label: 'Targeting Range', good: true  },
-    { label: 'Ship Agility',    good: false },
-    { label: 'Stasis Web Str',  good: false },
+    { label: 'Ship Velocity',      good: true  },
+    { label: 'Missile Velocity',   good: true  },
+    { label: 'Explosion Velocity', good: true  },
+    { label: 'Targeting Range',    good: true  },
+    { label: 'Ship Agility',       good: false },
+    { label: 'Stasis Web Str',     good: false },
   ],
   // Cataclysmic Variable: remote reps, shield transfer and cap buffed; local
   // reps, cap recharge and remote cap transfer punished.

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -115,42 +115,58 @@ export const EFFECT_ICONS: Record<WormholeEffect, { symbol: string; color: strin
   wolf_rayet:           { symbol: '⚔', color: 'var(--cv-effect-wolfrayet)' },
 };
 
+// System-effect modifiers, per the in-game "Effects" panel. `good` = beneficial
+// (shown ▲ green) vs detrimental (▼ red). Verified against the live client;
+// magnitudes scale by class but the set and direction are fixed per effect.
 export const EFFECT_MODIFIERS: Record<WormholeEffect, Array<{ label: string; good: boolean }>> = {
   none: [],
+  // Pulsar: shield buffed, armor punished; larger sig, faster cap, stronger neuts.
   pulsar: [
     { label: 'Shield HP',      good: true  },
     { label: 'Cap Recharge',   good: true  },
-    { label: 'Armor HP',       good: false },
-    { label: 'Cap Size',       good: false },
+    { label: 'Neut/NOS Drain', good: true  },
+    { label: 'Armor Resist',   good: false },
+    { label: 'Sig Radius',     good: false },
   ],
+  // Black Hole: speed, range and missiles up; agility and webs down.
   black_hole: [
-    { label: 'Ship Speed',         good: true  },
-    { label: 'Missile Speed',      good: true  },
-    { label: 'Stasis Web Str',     good: false },
-    { label: 'Target Painter Str', good: false },
-    { label: 'Explosion Radius',   good: false },
+    { label: 'Ship Speed',      good: true  },
+    { label: 'Missile Speed',   good: true  },
+    { label: 'Explosion Vel',   good: true  },
+    { label: 'Targeting Range', good: true  },
+    { label: 'Ship Agility',    good: false },
+    { label: 'Stasis Web Str',  good: false },
   ],
+  // Cataclysmic Variable: remote reps and cap buffed; local reps, cap recharge
+  // and remote cap transfer punished.
   cataclysmic_variable: [
-    { label: 'Local Rep',    good: true  },
-    { label: 'Cap Recharge', good: true  },
-    { label: 'Remote Rep',   good: false },
-    { label: 'Cap Size',     good: false },
+    { label: 'Remote Rep',   good: true  },
+    { label: 'Cap Capacity', good: true  },
+    { label: 'Local Rep',    good: false },
+    { label: 'Cap Recharge', good: false },
+    { label: 'Remote Cap',   good: false },
   ],
+  // Magnetar: huge raw damage, but application (tracking, range, missiles) suffers.
   magnetar: [
-    { label: 'Drone Damage',      good: true  },
-    { label: 'Targeting Range',   good: false },
-    { label: 'Drone Range',       good: false },
-    { label: 'Explosion Radius',  good: false },
+    { label: 'Weapon Damage',    good: true  },
+    { label: 'Tracking',         good: false },
+    { label: 'Targeting Range',  good: false },
+    { label: 'Explosion Radius', good: false },
+    { label: 'Target Painter',   good: false },
   ],
+  // Red Giant: overheat, smartbomb and bomb buffs; modules take more heat damage.
   red_giant: [
-    { label: 'Overheat Bonus',  good: true  },
+    { label: 'Overheat',        good: true  },
+    { label: 'Smartbomb Dmg',   good: true  },
     { label: 'Smartbomb Range', good: true  },
+    { label: 'Bomb Damage',     good: true  },
     { label: 'Heat Damage',     good: false },
   ],
+  // Wolf-Rayet: armor and small weapons buffed, smaller sig; shield resists punished.
   wolf_rayet: [
-    { label: 'Small Weapons',    good: true  },
-    { label: 'Armor HP',         good: true  },
-    { label: 'Sig Radius',       good: true  },
-    { label: 'Shield HP',        good: false },
+    { label: 'Small Weapons', good: true  },
+    { label: 'Armor HP',      good: true  },
+    { label: 'Sig Radius',    good: true  },
+    { label: 'Shield Resist', good: false },
   ],
 };


### PR DESCRIPTION
## Release 2.9.2

Patch release.

- **#431** Wrap watchlist row controls on narrow (docked) panels instead of clipping the system-name / note fields.
- **#432** Correct the wormhole system-effect tooltips — the per-effect bonus/penalty lists were wrong (Black Hole had bogus penalties, Cataclysmic was inverted, others had missing/wrong stats). Rewritten to match the in-game Effects panel and the canonical Pathfinder source, tooltip now sizes to its content, and Black Hole uses "Velocity" wording.

Version bumped to **2.9.2** in both `web` and `server`.