### PR TITLE
Route wormhole destinations through one SDE-backed source

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -7,7 +7,7 @@ import {
 } from '@phosphor-icons/react';
 import type { NodeProps } from '@xyflow/react';
 import type { MapSystem } from '../../types';
-import { CLASS_COLORS, CLASS_LABELS, EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
+import { CLASS_COLORS, CLASS_LABELS, EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS } from '../../data/wormholes';
 import { useMapStore } from '../../store/mapStore';
 import { usePresenceStore } from '../../store/presenceStore';
 import { useAccountLocations } from '../../hooks/useAccountLocations';
@@ -16,6 +16,8 @@ import { useStandings } from '../../hooks/useStandings';
 import { useFleet } from '../../hooks/useFleet';
 import { useAuth } from '../../context/AuthContext';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
+import { holeDisplay, whDestClass } from '../../utils/whDest';
 import { useIncursions, findIncursion } from '../../hooks/useIncursions';
 import { useInsurgency, findInsurgency } from '../../hooks/useInsurgency';
 import { useStorms, findStorm } from '../../hooks/useStorms';
@@ -180,6 +182,10 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   // matched by the content filter's "undived wormhole" state.
   const undivedHoles    = useMapStore((s) => s.undivedWhBySystem[sys.id]);
   const [showUndivedWh] = useUserSetting<boolean>('nexum.map.showUndivedWh', true);
+  // SDE-derived wormhole catalog (the single source of truth for destinations),
+  // used to colour statics and undived-hole pills consistently with the rest of
+  // the app rather than the drift-prone hardcoded map.
+  const whTypes         = useWormholeTypes();
   const filterOn        = contentFilterActive(contentFilter);
   const contentMatch    = filterOn && systemMatchesContent(sysContent, contentFilter, (undivedHoles?.length ?? 0) > 0);
   const filteredOut     = filterOn && !contentMatch;
@@ -469,7 +475,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
         <div className="system-node__statics">
           <div className="title">{t('mapNode.statics')}</div>
           {sys.statics.map((s) => {
-            const dest = WORMHOLE_DESTINATIONS[s];
+            const dest = whDestClass(s, whTypes);
             return (
               <WHTypeInfo key={s} code={s}>
               <span className="system-node__static-tag">
@@ -490,16 +496,21 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
       )}
 
       {showUndivedWh && undivedHoles && undivedHoles.length > 0 && (
-        <div className="system-node__holes" title={t('mapNode.undivedWhTitle')}>
-          {undivedHoles.map((h) => (
-            <span
-              key={h.id}
-              className="system-node__hole"
-              style={h.dest ? { background: CLASS_COLORS[h.dest] } : undefined}
-              title={`${h.sigId || '?'} · ${h.code || t('mapNode.undivedUnknown')}${h.dest ? ` → ${h.dest}` : ''}`}
-              onClick={(e) => { e.stopPropagation(); selectSystem(sys.id); }}
-            />
-          ))}
+        <div className="system-node__holes">
+          {undivedHoles.map((h) => {
+            // Destination + colour from the single SDE-backed source (type first,
+            // else the leads-to band) so pills match the signature pane.
+            const disp = holeDisplay(h.code, h.leadsTo, whTypes);
+            return (
+              <span
+                key={h.id}
+                className="system-node__hole"
+                style={disp ? { background: disp.color } : undefined}
+                title={`${t('mapNode.undivedWhTitle')} — ${h.sigId || '?'} · ${h.code || t('mapNode.undivedUnknown')}${disp ? ` → ${disp.label}` : ''}`}
+                onClick={(e) => { e.stopPropagation(); selectSystem(sys.id); }}
+              />
+            );
+          })}
         </div>
       )}
 

--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -9,7 +9,9 @@ import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from 
 import type { DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import { useMapStore } from '../../store/mapStore';
-import { CLASS_COLORS, CLASS_LABELS, EFFECT_LABELS, EFFECT_MODIFIERS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
+import { CLASS_COLORS, CLASS_LABELS, EFFECT_LABELS, EFFECT_MODIFIERS } from '../../data/wormholes';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
+import { whDestClass } from '../../utils/whDest';
 import { DraggableCard } from './DraggableCard';
 import { FloatingPanel, type PanelGeometry } from './FloatingPanel';
 import { useUserSetting } from '../../hooks/useUserSetting';
@@ -173,6 +175,7 @@ function clamp(v: number) {
 
 export function SystemPanel() {
   const { t } = useTranslation();
+  const whTypes = useWormholeTypes();
   const panelTitle: Record<string, string> = {
     notes:       t('panel.notes'),
     signatures:  t('panel.signatures'),
@@ -532,7 +535,7 @@ export function SystemPanel() {
               <div className="sys-info__section-label">{t('systemPanel.statics')}</div>
               <div className="sys-info__row">
                 {sys.statics.map((s) => {
-                  const dest = WORMHOLE_DESTINATIONS[s];
+                  const dest = whDestClass(s, whTypes);
                   return (
                     <WHTypeInfo key={s} code={s}>
                       <span className="sys-info__static">

--- a/web/src/components/ui/WormholeTypePicker.tsx
+++ b/web/src/components/ui/WormholeTypePicker.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowRightIcon, CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react';
-import { CLASS_COLORS, CLASS_LABELS, WORMHOLE_DESTINATIONS } from '../../data/wormholes';
+import { CLASS_COLORS, CLASS_LABELS } from '../../data/wormholes';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
+import { whDestClass, DEST_TO_CLASS } from '../../utils/whDest';
 import { usePopover } from '../../hooks/usePopover';
 import type { SystemClass } from '../../types';
 
@@ -11,14 +12,6 @@ interface Props {
   onChange: (whType: string, leadsTo: string) => void;
   statics?: string[];
 }
-
-// Map server's lowercase `dest` values to the SystemClass union used by
-// CLASS_COLORS / CLASS_LABELS.
-const DEST_TO_CLASS: Record<string, SystemClass> = {
-  c1: 'C1', c2: 'C2', c3: 'C3', c4: 'C4', c5: 'C5', c6: 'C6', c13: 'C13',
-  hs: 'HS', ls: 'LS', ns: 'NS',
-  thera: 'Thera', pochven: 'Pochven', drifter: 'Drifter',
-};
 
 // Display order for the picker's groups. Anything from the server whose
 // `dest` isn't covered here still gets shown — appended at the bottom under
@@ -40,14 +33,8 @@ const GROUP_ORDER: { key: string; label: string; dest: SystemClass }[] = [
   { key: 'drifter', label: 'Drifter',  dest: 'Drifter' },
 ];
 
-function destFor(code: string, types: ReturnType<typeof useWormholeTypes>): SystemClass | null {
-  const fromServer = types[code]?.dest;
-  if (fromServer) return DEST_TO_CLASS[fromServer.toLowerCase()] ?? null;
-  return WORMHOLE_DESTINATIONS[code] ?? null;
-}
-
 function DestBadge({ code, types }: { code: string; types: ReturnType<typeof useWormholeTypes> }) {
-  const dest = destFor(code, types);
+  const dest = whDestClass(code, types);
   if (!dest) return null;
   return (
     <>
@@ -73,7 +60,7 @@ export function WormholeTypePicker({ value, onChange, statics = [] }: Props) {
   };
 
   const select = (code: string) => {
-    const dest = code === 'K162' ? null : destFor(code, types);
+    const dest = code === 'K162' ? null : whDestClass(code, types);
     onChange(code, dest ?? '');
     setOpen(false);
   };

--- a/web/src/data/wormholes.ts
+++ b/web/src/data/wormholes.ts
@@ -45,13 +45,13 @@ export const WORMHOLE_DESTINATIONS: Record<string, SystemClass> = {
   // → C4
   E175: 'C4', X877: 'C4', Y683: 'C4', Z457: 'C4',
   // → C5
-  H296: 'C5', H900: 'C5', N062: 'C5', V911: 'C5',
+  H296: 'C5', H900: 'C5', N062: 'C5', N432: 'C5', V911: 'C5',
   // → C6
   R474: 'C6', U574: 'C6', V753: 'C6', W237: 'C6',
   // → Hi-Sec
   B274: 'HS', D845: 'HS', N110: 'HS', Q063: 'HS',
   // → Low-Sec
-  A239: 'LS', J244: 'LS', N432: 'LS', U210: 'LS', V898: 'LS',
+  A239: 'LS', J244: 'LS', U210: 'LS', V898: 'LS',
   // → Null-Sec
   E545: 'NS', E587: 'NS', K346: 'NS', S047: 'NS', Z060: 'NS',
   // → Thera
@@ -91,7 +91,7 @@ export const WORMHOLE_TYPES: Record<string, { leadsTo: SystemClass; maxMassKg: n
   D382:  { leadsTo: 'C5', maxMassKg: 3_000_000_000, jumpMassKg: 1_000_000_000, lifetimeH: 16 },
   W237:  { leadsTo: 'C6', maxMassKg: 3_000_000_000, jumpMassKg: 1_000_000_000, lifetimeH: 24 },
   S047:  { leadsTo: 'NS', maxMassKg: 2_000_000_000, jumpMassKg: 300_000_000, lifetimeH: 16 },
-  N432:  { leadsTo: 'LS', maxMassKg: 2_000_000_000, jumpMassKg: 300_000_000, lifetimeH: 16 },
+  N432:  { leadsTo: 'C5', maxMassKg: 2_000_000_000, jumpMassKg: 300_000_000, lifetimeH: 16 },
 };
 
 export const SYSTEM_CLASSES: SystemClass[] = [

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}} Systeme passen",
     "clear": "Filter löschen",
     "holes": "Wurmlöcher",
-    "undivedWh": "Ungetauchtes Loch"
+    "undivedWh": "Unerforscht"
   },
   "watchMarker": {
     "target": "Ziel",

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "{{name}}-Verbindung",
     "scoutConnections_other": "{{name}}-Verbindungen",
     "scoutConnectionsMulti": "{{names}}-Verbindungen",
-    "undivedWhTitle": "Gescannte, aber nicht getauchte Wurmlöcher",
+    "undivedWhTitle": "Unerforschtes Wurmloch",
     "undivedUnknown": "unbekannt"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -606,7 +606,7 @@
     "sigs": "Signatures",
     "anoms": "Anomalies",
     "holes": "Wormholes",
-    "undivedWh": "Undived hole",
+    "undivedWh": "Unexplored",
     "namePlaceholder": "Site name contains…",
     "matchCount_one": "{{count}} system matches",
     "matchCount_other": "{{count}} systems match",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1590,7 +1590,7 @@
     "stormLastReport": "Last report: {{value}}",
     "stormReportedBy": "By: {{value}}",
     "statics": "Statics",
-    "undivedWhTitle": "Scanned but not dived wormholes",
+    "undivedWhTitle": "Unexplored Wormhole",
     "undivedUnknown": "unknown",
     "staging": "Staging",
     "incursionBadge": "Incursion",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}} sistemas coinciden",
     "clear": "Limpiar filtro",
     "holes": "Agujeros de gusano",
-    "undivedWh": "Agujero sin explorar"
+    "undivedWh": "Inexplorado"
   },
   "watchMarker": {
     "target": "Objetivo",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "Conexión de {{name}}",
     "scoutConnections_other": "Conexiones de {{name}}",
     "scoutConnectionsMulti": "Conexiones de {{names}}",
-    "undivedWhTitle": "Agujeros de gusano escaneados pero no explorados",
+    "undivedWhTitle": "Agujero de gusano inexplorado",
     "undivedUnknown": "desconocido"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}} systèmes correspondent",
     "clear": "Effacer le filtre",
     "holes": "Trous de ver",
-    "undivedWh": "Trou non exploré"
+    "undivedWh": "Inexploré"
   },
   "watchMarker": {
     "target": "Cible",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "Connexion {{name}}",
     "scoutConnections_other": "Connexions {{name}}",
     "scoutConnectionsMulti": "Connexions {{names}}",
-    "undivedWhTitle": "Trous de ver scannés mais non explorés",
+    "undivedWhTitle": "Trou de ver inexploré",
     "undivedUnknown": "inconnu"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}} 件のシステムが一致",
     "clear": "フィルターをクリア",
     "holes": "ワームホール",
-    "undivedWh": "未ダイブホール"
+    "undivedWh": "未探索"
   },
   "watchMarker": {
     "target": "ターゲット",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "{{name}} 接続",
     "scoutConnections_other": "{{name}} 接続",
     "scoutConnectionsMulti": "{{names}} 接続",
-    "undivedWhTitle": "スキャン済みだが未ダイブのワームホール",
+    "undivedWhTitle": "未探索のワームホール",
     "undivedUnknown": "不明"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}}개 시스템 일치",
     "clear": "필터 지우기",
     "holes": "웜홀",
-    "undivedWh": "미탐사 홀"
+    "undivedWh": "미탐사"
   },
   "watchMarker": {
     "target": "표적",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "{{name}} 연결",
     "scoutConnections_other": "{{name}} 연결",
     "scoutConnectionsMulti": "{{names}} 연결",
-    "undivedWhTitle": "스캔했지만 아직 다이브하지 않은 웜홀",
+    "undivedWhTitle": "미탐사 웜홀",
     "undivedUnknown": "알 수 없음"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}} sistemas correspondem",
     "clear": "Limpar filtro",
     "holes": "Buracos de minhoca",
-    "undivedWh": "Buraco não mergulhado"
+    "undivedWh": "Inexplorado"
   },
   "watchMarker": {
     "target": "Alvo",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "Conexão de {{name}}",
     "scoutConnections_other": "Conexões de {{name}}",
     "scoutConnectionsMulti": "Conexões de {{names}}",
-    "undivedWhTitle": "Buracos de minhoca escaneados mas não mergulhados",
+    "undivedWhTitle": "Buraco de minhoca inexplorado",
     "undivedUnknown": "desconhecido"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -582,7 +582,7 @@
     "matchCount_other": "{{count}} систем подходит",
     "clear": "Сбросить фильтр",
     "holes": "Червоточины",
-    "undivedWh": "Непройденная дыра"
+    "undivedWh": "Неисследованные"
   },
   "watchMarker": {
     "target": "Цель",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1582,7 +1582,7 @@
     "scoutConnections_many": "{{name}}: соединений",
     "scoutConnections_other": "{{name}}: соединений",
     "scoutConnectionsMulti": "Соединения: {{names}}",
-    "undivedWhTitle": "Просканированные, но не пройденные червоточины",
+    "undivedWhTitle": "Неисследованная червоточина",
     "undivedUnknown": "неизвестно"
   },
   "mapEdge": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -566,7 +566,7 @@
     "matchCount_other": "{{count}} 个星系匹配",
     "clear": "清除筛选",
     "holes": "虫洞",
-    "undivedWh": "未跳跃虫洞"
+    "undivedWh": "未探索"
   },
   "watchMarker": {
     "target": "目标",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1544,7 +1544,7 @@
     "scoutConnections_one": "{{name}} 连接",
     "scoutConnections_other": "{{name}} 连接",
     "scoutConnectionsMulti": "{{names}} 连接",
-    "undivedWhTitle": "已扫描但未跳跃的虫洞",
+    "undivedWhTitle": "未探索的虫洞",
     "undivedUnknown": "未知"
   },
   "mapEdge": {

--- a/web/src/utils/undivedWormholes.ts
+++ b/web/src/utils/undivedWormholes.ts
@@ -1,6 +1,4 @@
-import type { SystemClass } from '../types';
 import type { MapConnection } from '../types';
-import { WORMHOLE_DESTINATIONS } from '../data/wormholes';
 
 // A "scanned but not dived" wormhole: you know a hole is here (and maybe its
 // type/destination class) but you haven't jumped it, so no connection on the
@@ -15,13 +13,15 @@ export interface WhSig {
   leadsTo:  string;   // pinned system name, a class/band token, or "" / "unknown"
 }
 
-// A resolved undived hole, ready to render: its scan id, code, and the
-// destination class we can colour it by (null when unknown).
+// An undived hole, ready to render. Its destination/colour is resolved at
+// render time from the wormhole type (via the shared SDE-backed whDest helper)
+// or the leads-to band — NOT precomputed here — so there's a single source of
+// truth for wormhole destinations.
 export interface UndivedHole {
-  id:    string;
-  sigId: string;
-  code:  string;
-  dest:  SystemClass | null;
+  id:      string;
+  sigId:   string;
+  code:    string;
+  leadsTo: string;
 }
 
 // leads-to values that are a class/band/unknown rather than a pinned system —
@@ -40,20 +40,6 @@ function isUnresolvedLeadsTo(leadsTo: string): boolean {
   return CLASS_OR_UNKNOWN.has((leadsTo || '').trim().toUpperCase());
 }
 
-// The destination class to colour a hole by: from the wormhole type first
-// (e.g. U210 -> LS), else the leads-to when it's itself an exact class token,
-// else null (unknown -> neutral).
-function destForHole(code: string, leadsTo: string): SystemClass | null {
-  const byType = WORMHOLE_DESTINATIONS[(code || '').toUpperCase()];
-  if (byType) return byType;
-  const lt = (leadsTo || '').trim().toUpperCase();
-  const asClass = ({
-    C1: 'C1', C2: 'C2', C3: 'C3', C4: 'C4', C5: 'C5', C6: 'C6', C13: 'C13',
-    HS: 'HS', LS: 'LS', NS: 'NS', THERA: 'Thera', POCHVEN: 'Pochven', DRIFTER: 'Drifter',
-  } as Record<string, SystemClass>)[lt];
-  return asClass ?? null;
-}
-
 // The undived holes for one system: wormhole sigs whose leads-to is still
 // unresolved AND which don't already back a connection (a dived hole gets a
 // connection, and — via the backing-sig auto-link — its sig linked to it).
@@ -67,7 +53,7 @@ export function undivedForSystem(sigs: WhSig[], connections: MapConnection[]): U
   for (const s of sigs) {
     if (!isUnresolvedLeadsTo(s.leadsTo)) continue; // pinned to a system — solved
     if (backing.has(s.id)) continue;               // already backs a connection
-    out.push({ id: s.id, sigId: s.sigId, code: s.whType, dest: destForHole(s.whType, s.leadsTo) });
+    out.push({ id: s.id, sigId: s.sigId, code: s.whType, leadsTo: s.leadsTo });
   }
   return out;
 }

--- a/web/src/utils/whDest.ts
+++ b/web/src/utils/whDest.ts
@@ -1,0 +1,61 @@
+import type { SystemClass } from '../types';
+import { CLASS_COLORS, CLASS_LABELS, WORMHOLE_DESTINATIONS } from '../data/wormholes';
+
+// Single source of truth for "where does a wormhole lead / what colour is it".
+// The authoritative data is the SDE-derived catalog served by
+// /api/wormholes/types (loaded once via useWormholeTypes); the small hardcoded
+// WORMHOLE_DESTINATIONS map is only a first-paint / offline fallback. Anything
+// that needs a destination class MUST go through here so the whole app stays
+// consistent (the hardcoded map has drifted from the SDE before — e.g. N432).
+
+// Server's lowercase `dest` -> the SystemClass union used by CLASS_COLORS/LABELS.
+export const DEST_TO_CLASS: Record<string, SystemClass> = {
+  c1: 'C1', c2: 'C2', c3: 'C3', c4: 'C4', c5: 'C5', c6: 'C6', c13: 'C13',
+  hs: 'HS', ls: 'LS', ns: 'NS',
+  thera: 'Thera', pochven: 'Pochven', drifter: 'Drifter',
+};
+
+// Minimal shape of the useWormholeTypes() map that this module reads.
+export type WhTypeDest = Record<string, { dest?: string } | undefined>;
+
+/** A wormhole type code's destination class — SDE first, hardcoded fallback. */
+export function whDestClass(code: string | null | undefined, types: WhTypeDest): SystemClass | null {
+  if (!code) return null;
+  const c = code.toUpperCase();
+  const fromServer = types[c]?.dest;
+  if (fromServer) return DEST_TO_CLASS[fromServer.toLowerCase()] ?? null;
+  return WORMHOLE_DESTINATIONS[c] ?? null;
+}
+
+// J-space "band" leads-to values (an unscanned hole reports a band, not an exact
+// class) with display label + colour — mirrors the LeadsToDropdown options.
+const LEADS_TO_BANDS: Record<string, { label: string; color: string }> = {
+  'C1-C3': { label: 'C1 - C3', color: CLASS_COLORS.C3 },
+  'C4-C5': { label: 'C4 - C5', color: CLASS_COLORS.C5 },
+};
+
+/** Label + colour for a leads-to value (band or exact class); null when empty,
+ *  unknown, or a free-form connected-system name. */
+export function leadsToDisplay(value: string | null | undefined): { label: string; color: string } | null {
+  const v = (value ?? '').trim();
+  if (!v || v.toLowerCase() === 'unknown') return null;
+  const band = LEADS_TO_BANDS[v.toUpperCase()];
+  if (band) return band;
+  if (v in CLASS_LABELS) {
+    const cls = v as SystemClass;
+    return { label: CLASS_LABELS[cls], color: CLASS_COLORS[cls] };
+  }
+  return null;
+}
+
+/** Destination label + colour to display for an undived hole: the wormhole
+ *  type's destination when known (single source), else its leads-to band/class. */
+export function holeDisplay(
+  code: string | null | undefined,
+  leadsTo: string | null | undefined,
+  types: WhTypeDest,
+): { label: string; color: string } | null {
+  const dc = whDestClass(code, types);
+  if (dc) return { label: CLASS_LABELS[dc], color: CLASS_COLORS[dc] };
+  return leadsToDisplay(leadsTo);
+}


### PR DESCRIPTION
Fixes the undived-hole pills showing wrong destinations/colours (screenshots), **and** the recurring "two sources of wormhole data disagree" problem.

## Root cause
There were two sources for a wormhole's destination:
- **`/api/wormholes/types`** — SDE-derived, server-cached, loaded once via `useWormholeTypes`. **Authoritative.** Used by the signature pane and type picker.
- **`WORMHOLE_DESTINATIONS`** — a hardcoded client map that had **drifted** from the SDE (e.g. `N432` was `'LS'` but actually leads to **C5**). Used by the undived pills and statics tags.

So the sig pane showed `N432 → C5` while the pill showed `N432 → LS`, with the wrong colour.

## The single source
We already had it — `/api/wormholes/types` is server-cached and pulled once per page. The fix makes **everything** read it:

- New **`utils/whDest.ts`**: `whDestClass()` / `leadsToDisplay()` / `holeDisplay()` — one resolver, SDE first, hardcoded map only as a first-paint / offline (demo) fallback.
- **Pills**, **node statics**, **system-panel statics**, and the **type picker** all go through it (removed the picker's duplicate `destFor`/`DEST_TO_CLASS`).
- Undived holes now carry their `leadsTo` and resolve destination/colour at render, so a **K162 colours by its leads-to band** (e.g. C1-C3) matching the sig pane.
- Corrected the fallback map itself (`N432 → C5`) so even offline/first-paint is right.

## Tooltip overlap
Folded the "Scanned but not dived wormholes" label into each pill's own `title`, so it no longer overlaps a separate row tooltip.

## Follow-up
The hardcoded `WORMHOLE_DESTINATIONS` is now only a bootstrap fallback; long-term it could be generated from the SDE (or dropped) so it can't drift again. `WH_GROUPS` is now unused and can be removed. `tsc`/eslint/build pass.