### PR TITLE
Support a QA instance (qa.eve-nexum.com) alongside prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ FRONTEND_URL=http://yourdomain.com
 # Public hostname — used by docker-compose.traefik.yml for the Traefik router rule
 DOMAIN=yourdomain.com
 
+# Traefik router/service/middleware name prefix. Leave unset for a single
+# deployment (defaults to eve-nexum). Only set this when running a SECOND
+# instance on the same host/Traefik (e.g. STACK=eve-nexum-qa) so its Traefik
+# names don't collide with the first. See QA-SETUP.md.
+# STACK=eve-nexum
+
 # ── Limits ────────────────────────────────────────────────────────────────────
 # Max maps a single user can create (default: 5)
 MAX_USER_MAPS=5

--- a/QA-SETUP.md
+++ b/QA-SETUP.md
@@ -1,0 +1,83 @@
+# Running a QA environment (qa.eve-nexum.com)
+
+A second, isolated Nexum instance running **alongside prod on the same host**,
+sharing the existing Traefik reverse proxy. QA gets its own database, its own
+sessions, and its own EVE SSO app — nothing crosses over to prod.
+
+## Why it's isolated (no shared state with prod)
+
+- **Database:** the Postgres volume is scoped to the compose project name, so a
+  distinct project name (`nexum-qa`) gives QA a brand-new, separate database.
+- **Sessions:** the session cookie has no explicit domain, so it's host-scoped —
+  `qa.eve-nexum.com` and `eve-nexum.com` logins don't collide.
+- **Discord:** webhooks live in the DB (per-org), so a fresh QA DB posts nowhere
+  until you configure it in the QA admin UI.
+- **Traefik:** router/service/middleware names are prefixed by `${STACK}`, so
+  `STACK=eve-nexum-qa` avoids colliding with prod's `eve-nexum` names.
+
+## One-time setup
+
+1. **DNS** — add an `A` record: `qa.eve-nexum.com` -> the server's IP (same box
+   as prod). Traefik will fetch a Let's Encrypt cert for it automatically on
+   first request.
+
+2. **EVE SSO** — create a *separate* application on
+   https://developers.eveonline.com with:
+   - Callback URL: `https://qa.eve-nexum.com/auth/callback`
+   - The same scopes as the prod app.
+   Note its **Client ID** and **Secret** for the QA `.env` below.
+
+3. **QA env file** — on the server, in a separate checkout/dir for QA, copy
+   `.env.example` to `.env` and set (at minimum) the values that MUST differ
+   from prod:
+
+   ```dotenv
+   # Second-instance identity (must differ from prod)
+   COMPOSE_PROJECT_NAME=nexum-qa
+   STACK=eve-nexum-qa
+   DOMAIN=qa.eve-nexum.com
+   FRONTEND_URL=https://qa.eve-nexum.com
+   EVE_CALLBACK_URL=https://qa.eve-nexum.com/auth/callback
+
+   # QA's own EVE SSO app (step 2)
+   EVE_CLIENT_ID=<qa app client id>
+   EVE_CLIENT_SECRET=<qa app secret>
+
+   # Fresh secrets for QA (do NOT reuse prod's)
+   SESSION_SECRET=<new random>
+   TOKEN_ENCRYPTION_KEY=<new 32-byte key, as prod requires>
+   PG_PASSWORD=<qa db password>
+   ```
+
+   Everything else (CORP_ID / ALLIANCE_ID / ADMIN_CHAR_ID / limits) can mirror
+   prod or be set to QA-specific values as needed. Generate fresh secrets, e.g.
+   `openssl rand -hex 32`.
+
+## Deploy / update QA
+
+From the QA checkout directory (with its own `.env`), always use **both** compose
+files and the QA project name:
+
+```bash
+docker compose -p nexum-qa \
+  -f docker-compose.yml -f docker-compose.traefik.yml \
+  up -d --build
+```
+
+- `-p nexum-qa` keeps QA's containers, network and volumes separate from prod.
+  (You can instead set `COMPOSE_PROJECT_NAME=nexum-qa` in `.env` and drop `-p`.)
+- Same command redeploys after a `git pull` on the QA branch.
+- The SDE import one-shot runs on first `up` and is skipped once populated.
+
+To tear QA down (keeping prod untouched):
+
+```bash
+docker compose -p nexum-qa -f docker-compose.yml -f docker-compose.traefik.yml down
+# add -v to also wipe the QA database volume
+```
+
+## Notes
+
+- Prod is unaffected: with `STACK` unset it still defaults to `eve-nexum`.
+- QA has no data by default — create maps/systems fresh, or seed as needed.
+- The QA EVE app being separate means revoking/rotating it never touches prod.

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -3,6 +3,11 @@
 #
 # Required .env additions:
 #   DOMAIN=nexum.yourdomain.com
+#
+# Running a SECOND instance (e.g. a QA env) on the SAME host/Traefik: give it a
+# distinct compose project name AND a distinct STACK so its Traefik router,
+# service and middleware names don't collide with the first. See QA-SETUP.md.
+#   STACK=eve-nexum-qa  (defaults to eve-nexum when unset — prod is unchanged)
 
 services:
   postgres:
@@ -24,19 +29,22 @@ services:
       - internal
       - traefik-public
     labels:
+      # Router / service / middleware names are prefixed by ${STACK} (default
+      # eve-nexum) so a second instance (STACK=eve-nexum-qa) can share this
+      # Traefik without name collisions.
       - "traefik.enable=true"
       - "traefik.docker.network=traefik-public"
       # HTTPS router
-      - "traefik.http.routers.eve-nexum.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.eve-nexum.entrypoints=websecure"
-      - "traefik.http.routers.eve-nexum.tls=true"
-      - "traefik.http.routers.eve-nexum.tls.certresolver=letsencrypt"
-      - "traefik.http.services.eve-nexum.loadbalancer.server.port=80"
+      - "traefik.http.routers.${STACK:-eve-nexum}.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.${STACK:-eve-nexum}.entrypoints=websecure"
+      - "traefik.http.routers.${STACK:-eve-nexum}.tls=true"
+      - "traefik.http.routers.${STACK:-eve-nexum}.tls.certresolver=letsencrypt"
+      - "traefik.http.services.${STACK:-eve-nexum}.loadbalancer.server.port=80"
       # HTTP → HTTPS redirect
-      - "traefik.http.routers.eve-nexum-http.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.eve-nexum-http.entrypoints=web"
-      - "traefik.http.routers.eve-nexum-http.middlewares=redirect-to-https"
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.${STACK:-eve-nexum}-http.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.${STACK:-eve-nexum}-http.entrypoints=web"
+      - "traefik.http.routers.${STACK:-eve-nexum}-http.middlewares=${STACK:-eve-nexum}-redirect-to-https"
+      - "traefik.http.middlewares.${STACK:-eve-nexum}-redirect-to-https.redirectscheme.scheme=https"
 
 networks:
   internal:


### PR DESCRIPTION
Groundwork to run a QA environment on the **same host** as prod, sharing the existing Traefik, for validating bigger changes (e.g. the perf refactor) off-prod.

## Change
- **`docker-compose.traefik.yml`**: Traefik router/service/middleware names are now prefixed by `${STACK}` (default `eve-nexum`). Prod is byte-for-byte unchanged when `STACK` is unset; a second instance sets `STACK=eve-nexum-qa` so its Traefik names don't collide. Validated via `docker compose config` for both stacks.
- **`.env.example`**: documents the optional `STACK` var.
- **`QA-SETUP.md`**: full runbook — DNS A record, a **separate QA EVE SSO app** (`https://qa.eve-nexum.com/auth/callback`), the QA `.env` (its own `COMPOSE_PROJECT_NAME` for an isolated DB + fresh secrets), and the deploy command (`-p nexum-qa` + both compose files).

## Isolation (already the case, documented)
- **DB**: project-scoped Postgres volume -> separate database.
- **Sessions**: cookie is host-scoped (no explicit domain) -> qa and prod logins don't collide.
- **Discord**: webhooks are per-org in the DB -> a fresh QA DB posts nowhere.

## Your side (can't be done in-repo)
- Add the `qa` DNS A record.
- Create the QA EVE SSO app and put its client id/secret in the QA `.env`.

No app code changes; nothing affects the running prod deployment.