### PR TITLE
Fix backup/restore scripts choking on the dotenv .env

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -41,11 +41,32 @@ if [ ! -f .env ]; then
 fi
 
 # Read PG_USER / PG_DB straight from the deployed .env so this script stays in
-# sync with whatever the running stack is using.
-set -a
-# shellcheck disable=SC1091
-. ./.env
-set +a
+# sync with whatever the running stack is using. We do NOT `source` the file:
+# .env is a dotenv file (parsed by the app via the `dotenv` library), not a
+# shell script, so `source` chokes on any line that isn't a clean shell
+# assignment (e.g. an uncommented `SDE_CHECK_UTC=11:30  # comment`). Read only
+# the keys we need instead — last assignment wins; surrounding quotes and a
+# trailing CR are trimmed.
+read_env() {
+  local val
+  val="$(grep -E "^[[:space:]]*${1}=" .env | tail -n1)" || return 0
+  val="${val#*=}"
+  val="${val%$'\r'}"
+  val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+  val="${val%"${val##*[![:space:]]}"}"   # rtrim
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  printf '%s' "$val"
+}
+
+PG_USER="$(read_env PG_USER)"
+PG_DB="$(read_env PG_DB)"
+# Honour a custom compose project name if the deploy sets one, so
+# `docker compose exec` targets the right postgres container.
+PROJ="$(read_env COMPOSE_PROJECT_NAME)"
+[ -n "$PROJ" ] && export COMPOSE_PROJECT_NAME="$PROJ"
 
 : "${PG_USER:?PG_USER not set in .env}"
 : "${PG_DB:?PG_DB not set in .env}"

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -40,11 +40,28 @@ if [ ! -f .env ]; then
 fi
 
 # Read PG_USER / PG_DB from the deployed .env so this stays in sync with the
-# running stack (same as backup-db.sh).
-set -a
-# shellcheck disable=SC1091
-. ./.env
-set +a
+# running stack (same as backup-db.sh). We do NOT `source` the file — .env is a
+# dotenv file, not a shell script, so `source` breaks on any line that isn't a
+# clean shell assignment. Read only the keys we need; last assignment wins,
+# surrounding quotes and a trailing CR trimmed.
+read_env() {
+  local val
+  val="$(grep -E "^[[:space:]]*${1}=" .env | tail -n1)" || return 0
+  val="${val#*=}"
+  val="${val%$'\r'}"
+  val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+  val="${val%"${val##*[![:space:]]}"}"   # rtrim
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  printf '%s' "$val"
+}
+
+PG_USER="$(read_env PG_USER)"
+PG_DB="$(read_env PG_DB)"
+PROJ="$(read_env COMPOSE_PROJECT_NAME)"
+[ -n "$PROJ" ] && export COMPOSE_PROJECT_NAME="$PROJ"
 
 : "${PG_USER:?PG_USER not set in .env}"
 : "${PG_DB:?PG_DB not set in .env}"


### PR DESCRIPTION
`scripts/backup-db.sh` (and `restore-db.sh`) failed on the live server with:

```
./.env: line 56: SDE_CHECK_UTC:11:30: command not found
```

## Cause
Both scripts did `. ./.env` (source) to read `PG_USER`/`PG_DB`. But `.env` is a **dotenv** file — the app parses it with the `dotenv` library, not the shell. `source` executes every line, so any value that isn't a clean shell assignment aborts the script. Here an uncommented `SDE_CHECK_UTC=11:30  # comment` tripped it, so the backup never ran.

## Fix
Read only the keys the scripts actually need (`PG_USER`, `PG_DB`, and an optional `COMPOSE_PROJECT_NAME` so `docker compose exec` targets the right container) via a `read_env()` helper that greps the value out without executing the file. Tested the parser against a sample `.env` with the offending line; `bash -n` clean on both.

Targets `qa` per the new flow.