### PR TITLE
perf(map): cut node-render fan-out (Batch A)

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -22,8 +22,8 @@ import { useIncursions, findIncursion } from '../../hooks/useIncursions';
 import { useInsurgency, findInsurgency } from '../../hooks/useInsurgency';
 import { useStorms, findStorm } from '../../hooks/useStorms';
 import { useScoutConnections, findScoutConnections } from '../../hooks/useScoutConnections';
-import { useA0Systems } from '../../hooks/useA0Systems';
-import { useShatteredSystems } from '../../hooks/useShatteredSystems';
+import { useA0SystemIds } from '../../hooks/useA0Systems';
+import { useShatteredSystemIds } from '../../hooks/useShatteredSystems';
 import { PREDEFINED_LABELS, parseCustomLabel, labelTextColor } from '../../data/labels';
 import { iconComponent } from '../../utils/phosphorIcons';
 import { useIceBeltSystems, hasIceBelt } from '../../hooks/useIceBeltSystems';
@@ -129,11 +129,10 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const storm           = useMemo(() => findStorm(storms, sys.eveSystemId), [storms, sys.eveSystemId]);
   const scoutAll        = useScoutConnections();
   const scoutMatches    = useMemo(() => findScoutConnections(scoutAll, sys.eveSystemId), [scoutAll, sys.eveSystemId]);
-  const a0Systems       = useA0Systems();
-  const a0Ids           = useMemo(() => new Set(a0Systems.map(s => s.id)), [a0Systems]);
+  // Shared id-Sets (built once, not per node) for O(1) membership.
+  const a0Ids           = useA0SystemIds();
   const isA0            = sys.eveSystemId !== null && a0Ids.has(sys.eveSystemId);
-  const shatteredSystems = useShatteredSystems();
-  const shatteredIds    = useMemo(() => new Set(shatteredSystems.map(s => s.id)), [shatteredSystems]);
+  const shatteredIds    = useShatteredSystemIds();
   const isShattered     = sys.eveSystemId !== null && shatteredIds.has(sys.eveSystemId);
   const iceBeltSystems  = useIceBeltSystems();
   const isIceBelt       = useMemo(() => hasIceBelt(iceBeltSystems, sys.eveSystemId), [iceBeltSystems, sys.eveSystemId]);
@@ -169,7 +168,12 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   // entry (by name, class, effect, or a static wormhole type / frig hole).
   const [watchEntries]  = useWatchlist();
   const watchSigTypes   = useMapStore((s) => s.sigTypesBySystem[sys.id]);
-  const watch           = matchSystem(watchEntries, sys, watchSigTypes);
+  // Memoized: matchSystem scans up to MAX_WATCH (~75) entries; without this it
+  // re-ran on every re-render (e.g. every 10s location poll), for every node.
+  const watch           = useMemo(
+    () => matchSystem(watchEntries, sys, watchSigTypes),
+    [watchEntries, sys, watchSigTypes],
+  );
   const watchDef        = watch ? watchMarker(watch.marker) : null;
   const watchTip        = watch ? (watch.note.trim() || t(`watchMarker.${watch.marker}`)) : undefined;
 
@@ -187,7 +191,10 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   // the app rather than the drift-prone hardcoded map.
   const whTypes         = useWormholeTypes();
   const filterOn        = contentFilterActive(contentFilter);
-  const contentMatch    = filterOn && systemMatchesContent(sysContent, contentFilter, (undivedHoles?.length ?? 0) > 0);
+  const contentMatch    = useMemo(
+    () => filterOn && systemMatchesContent(sysContent, contentFilter, (undivedHoles?.length ?? 0) > 0),
+    [filterOn, sysContent, contentFilter, undivedHoles],
+  );
   const filteredOut     = filterOn && !contentMatch;
 
   // Tooltip label: dedupe by scout system name (Thera / Turnur). Multiple

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -196,27 +196,31 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   const sigTypeLabel = (type: SigType) =>
     type === 'unknown' ? t('sigType.unknown') : SIG_TYPE_LABELS[type];
   const activeMapId     = useMapStore((s) => s.activeMapId);
-  const map             = useMapStore((s) => s.map);
+  // Narrow slices instead of the whole `map`: the pane only reads systems +
+  // connections, so it no longer re-renders on unrelated map mutations (rename,
+  // saved routes, updatedAt bumps, share-flag changes, ...).
+  const mapSystems      = useMapStore((s) => s.map.systems);
+  const mapConnections  = useMapStore((s) => s.map.connections);
   const currentSystemId = useMapStore((s) => s.currentSystemId);
   const setSystemSigTypes = useMapStore((s) => s.setSystemSigTypes);
   const setSystemWhSigs = useMapStore((s) => s.setSystemWhSigs);
   const canEdit         = useCanEditContent();
 
   const systemStatics = useMemo(
-    () => map.systems.find((sys) => sys.id === systemId)?.statics ?? [],
-    [map.systems, systemId],
+    () => mapSystems.find((sys) => sys.id === systemId)?.statics ?? [],
+    [mapSystems, systemId],
   );
 
   const connectedSystems = useMemo(() => {
-    const conns = map.connections.filter(
+    const conns = mapConnections.filter(
       (c) => c.sourceId === systemId || c.targetId === systemId,
     );
     return conns.flatMap((c) => {
       const otherId = c.sourceId === systemId ? c.targetId : c.sourceId;
-      const sys = map.systems.find((m) => m.id === otherId);
+      const sys = mapSystems.find((m) => m.id === otherId);
       return sys ? [{ id: sys.id, name: sys.name, systemClass: sys.systemClass }] : [];
     });
-  }, [map.connections, map.systems, systemId]);
+  }, [mapConnections, mapSystems, systemId]);
 
   const [sigs, setSigs]               = useState<Signature[]>([]);
   const [selected, setSelected]       = useState<Set<string>>(new Set());
@@ -418,7 +422,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       updates.whType?.toUpperCase() === 'K162' &&
       existing?.whType?.toUpperCase() !== 'K162'
     ) {
-      const sysName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown system';
+      const sysName = mapSystems.find((s) => s.id === systemId)?.name ?? 'unknown system';
       alertInboundK162(sysName);
     }
 
@@ -460,13 +464,13 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       const leads = sig.whLeadsTo?.toUpperCase();
       if (!leads) continue;
       let source: string | null = null;
-      for (const conn of map.connections) {
+      for (const conn of mapConnections) {
         if (conn.connectionType !== 'standard') continue;
         const otherId =
           conn.sourceId === systemId ? conn.targetId :
           conn.targetId === systemId ? conn.sourceId : null;
         if (!otherId) continue;
-        const other = map.systems.find((s) => s.id === otherId);
+        const other = mapSystems.find((s) => s.id === otherId);
         if (!other) continue;
         const oc = other.systemClass.toUpperCase();
         const on = (other.name ?? '').toUpperCase();
@@ -477,7 +481,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       if (source) updateSig(sig.id, { notes: source });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sigs, map.connections, map.systems, systemId, canEdit, isShareMode]);
+  }, [sigs, mapConnections, mapSystems, systemId, canEdit, isShareMode]);
 
   // Quarantine orphaned wormhole links. A live wormhole always shows as a sig
   // on BOTH ends, so if this system has been scanned (has sigs) yet carries no
@@ -621,8 +625,8 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
       // Warn if the character is in a different system than the one being edited
       if (currentSystemId && currentSystemId !== systemId) {
-        const currentName  = map.systems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
-        const selectedName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown';
+        const currentName  = mapSystems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
+        const selectedName = mapSystems.find((s) => s.id === systemId)?.name ?? 'unknown';
         setPendingAction({
           message: t('signatures.pasteDifferentSystem', { current: currentName, selected: selectedName }),
           fn: () => processPaste(parsed, overwrite, delaySec),
@@ -637,7 +641,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
     window.addEventListener('paste', handlePaste);
     return () => window.removeEventListener('paste', handlePaste);
-  }, [activeMapId, systemId, currentSystemId, map.systems, processPaste, overwriteOnPaste, overwriteDelay, t]);
+  }, [activeMapId, systemId, currentSystemId, mapSystems, processPaste, overwriteOnPaste, overwriteDelay, t]);
 
   const addSig = async () => {
     if (!activeMapId) return;

--- a/web/src/hooks/useA0Systems.ts
+++ b/web/src/hooks/useA0Systems.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { createStaticResource } from './createStaticResource';
 
 export interface A0System {
@@ -7,5 +8,26 @@ export interface A0System {
 }
 
 // The A0 list is static cluster data — load once per page, never refresh.
-const { useResource } = createStaticResource<A0System[]>('/api/systems/a0', []);
+const { useResource, load } = createStaticResource<A0System[]>('/api/systems/a0', []);
 export const useA0Systems = useResource;
+
+// Shared Set of A0 eve-ids for O(1) membership checks, derived ONCE globally
+// from the loaded list rather than rebuilt in every map node. The Set is
+// populated in an effect (via the resource's own load()), never reassigned
+// during render — the react-hooks purity rule forbids mutating module state
+// while rendering. A stable empty Set is used until the data loads.
+const EMPTY_IDS: ReadonlySet<number> = new Set();
+let idSetCache: Set<number> | null = null;
+
+export function useA0SystemIds(): ReadonlySet<number> {
+  const [ids, setIds] = useState<ReadonlySet<number>>(idSetCache ?? EMPTY_IDS);
+  useEffect(() => {
+    let cancelled = false;
+    load().then((list) => {
+      if (!idSetCache) idSetCache = new Set(list.map((s) => s.id));
+      if (!cancelled) setIds(idSetCache);
+    });
+    return () => { cancelled = true; };
+  }, []);
+  return ids;
+}

--- a/web/src/hooks/useShatteredSystems.ts
+++ b/web/src/hooks/useShatteredSystems.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { createStaticResource } from './createStaticResource';
 
 export interface ShatteredSystem {
@@ -7,5 +8,26 @@ export interface ShatteredSystem {
 }
 
 // The shattered list is static cluster data — load once per page, never refresh.
-const { useResource } = createStaticResource<ShatteredSystem[]>('/api/systems/shattered', []);
+const { useResource, load } = createStaticResource<ShatteredSystem[]>('/api/systems/shattered', []);
 export const useShatteredSystems = useResource;
+
+// Shared Set of shattered eve-ids for O(1) membership, derived ONCE globally
+// from the loaded list rather than rebuilt in every map node. The Set is
+// populated in an effect (via the resource's own load()), never reassigned
+// during render — the react-hooks purity rule forbids mutating module state
+// while rendering. A stable empty Set is used until the data loads.
+const EMPTY_IDS: ReadonlySet<number> = new Set();
+let idSetCache: Set<number> | null = null;
+
+export function useShatteredSystemIds(): ReadonlySet<number> {
+  const [ids, setIds] = useState<ReadonlySet<number>>(idSetCache ?? EMPTY_IDS);
+  useEffect(() => {
+    let cancelled = false;
+    load().then((list) => {
+      if (!idSetCache) idSetCache = new Set(list.map((s) => s.id));
+      if (!cancelled) setIds(idSetCache);
+    });
+    return () => { cancelled = true; };
+  }, []);
+  return ids;
+}

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -86,6 +86,27 @@ function recomputeUniformMax(): { w: number; h: number } {
   // the height would lock at 0 and the inline minHeight would never apply.
   return { w: snapUpToGrid(w), h: snapUpToGrid(anyHeightEligible ? h : hAll) };
 }
+
+// Coalesce the uniform-max recompute. On map load all N nodes report their size
+// in the same frame; recomputing (an O(N) scan) + writing the store per report
+// was O(N^2) and re-rendered every node up to N times as the max ratcheted.
+// Instead each report just schedules one recompute per frame that reads the
+// final nodeSizes and writes the store at most once.
+let uniformRaf: ReturnType<typeof requestAnimationFrame> | null = null;
+function scheduleUniformRecompute(): void {
+  if (uniformRaf !== null) return;
+  const run = () => {
+    uniformRaf = null;
+    const { w, h } = recomputeUniformMax();
+    const st = useMapStore.getState();
+    if (st.uniformWidth !== w || st.uniformHeight !== h) {
+      useMapStore.setState({ uniformWidth: w, uniformHeight: h });
+    }
+  };
+  // requestAnimationFrame is absent under SSR/tests — fall back to running now.
+  if (typeof requestAnimationFrame === 'undefined') { run(); return; }
+  uniformRaf = requestAnimationFrame(run);
+}
 // Debounce map name saves — keyed by mapId so two tabs renaming two different
 // maps don't clobber each other through a shared timer slot.
 const nameTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -785,11 +806,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
           && Math.abs(prev.h - height) < 1
           && prev.countHeight === countHeight) return;
       nodeSizes.set(id, { w: width, h: height, countHeight });
-      const { w, h } = recomputeUniformMax();
-      const cur = get();
-      if (cur.uniformWidth !== w || cur.uniformHeight !== h) {
-        set({ uniformWidth: w, uniformHeight: h });
-      }
+      scheduleUniformRecompute();
 
       // Consume a pending placement fix now we know this node's real size.
       // Only ever moves the node FARTHER from the source (restores the gap when
@@ -824,11 +841,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
       // before the real measure consumes it. The fix is cleared in
       // reportNodeSize (on apply) or removeSystem (on real removal).
       if (!nodeSizes.delete(id)) return;
-      const { w, h } = recomputeUniformMax();
-      const cur = get();
-      if (cur.uniformWidth !== w || cur.uniformHeight !== h) {
-        set({ uniformWidth: w, uniformHeight: h });
-      }
+      scheduleUniformRecompute();
     },
 
     // Drop every cached natural size and reset the broadcast uniform


### PR DESCRIPTION
First of three perf batches from the frontend audit. All four items target map-node re-render fan-out; no behaviour change.

## Changes
- **SystemNode memoization (#5):** wrap `matchSystem` (watchlist) and `systemMatchesContent` (content filter) in `useMemo`. Both scanned per node on every re-render (e.g. the 10s location poll) despite stable inputs.
- **Shared id-Sets (#6):** `useA0SystemIds` / `useShatteredSystemIds` build one Set globally instead of each node doing `new Set(list.map(...))`. Populated in an effect via the resource loader — no module mutation during render (react-hooks purity).
- **Coalesced uniform-max recompute (#3):** `reportNodeSize`/`forgetNodeSize` now schedule one rAF per frame instead of recompute + store-write per report. On map load all N nodes report in one frame; old path was O(N^2) and re-rendered every node as the max ratcheted. Now O(N), at most one store write per frame. Placement-fix logic unchanged (reads `nodeSizes` directly).
- **Narrowed SignaturePane subscription (#10):** subscribe to `map.systems` + `map.connections` rather than the whole `map`, so the pane stops re-rendering on unrelated map mutations (rename, saved routes, updatedAt bumps, share-flag changes).

## Verification
- `yarn tsc -b` clean
- `yarn eslint` on all touched files: 0 errors (2 pre-existing warnings in SignaturePane, unrelated to this change)
- `yarn build` passes

Batch B (keyed subscriptions for presenceStore + polled hooks) and Batch C (per-node data memoization, hover/drag edge rebuilds) to follow.