### PR TITLE
perf(map): keyed presence + poll equality gates (Batch B)

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -91,16 +91,19 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   }, [showAccountChars, accountLocations.bySystem, sys.eveSystemId]);
 
   // Other people viewing this map who are currently in this system (presence).
-  // Excludes self — the green you-are-here dot covers that.
-  const presenceViewers = usePresenceStore((s) => s.viewers);
+  // Excludes self — the green you-are-here dot covers that. Subscribe to just
+  // this system's slice of the presence index (stable ref unless a viewer
+  // enters/leaves THIS system), so a viewer moving elsewhere doesn't re-render
+  // this node.
+  const presenceSlice = usePresenceStore(
+    (s) => (sys.eveSystemId == null ? undefined : s.bySystem.get(sys.eveSystemId)),
+  );
   const presenceHere    = useMemo(() => {
-    if (sys.eveSystemId == null) return undefined;
+    if (!presenceSlice || presenceSlice.length === 0) return undefined;
     const myId = user?.characterId;
-    const here = Object.values(presenceViewers).filter(
-      (v) => v.eveSystemId === sys.eveSystemId && v.characterId !== myId,
-    );
+    const here = presenceSlice.filter((v) => v.characterId !== myId);
     return here.length ? here : undefined;
-  }, [presenceViewers, sys.eveSystemId, user?.characterId]);
+  }, [presenceSlice, user?.characterId]);
 
   // Halo around any sov-holder system based on the user's contact bands.
   // Threshold is just "negative or positive" rather than the strict ≤-5

--- a/web/src/hooks/useAccountLocations.ts
+++ b/web/src/hooks/useAccountLocations.ts
@@ -50,15 +50,37 @@ function indexBySystem(list: AccountCharLocation[]): Map<number, AccountCharLoca
 
 function notify(d: AccountLocations) { subscribers.forEach((fn) => fn(d)); }
 
+// True when two polls describe the same characters in the same places, so we
+// can keep the previous reference and skip the all-node re-render. Keyed by
+// charId; compares only the fields a node actually renders.
+function sameLocations(a: AccountLocations, b: AccountLocations): boolean {
+  if (a.byChar.size !== b.byChar.size) return false;
+  for (const [k, va] of a.byChar) {
+    const vb = b.byChar.get(k);
+    if (!vb
+        || vb.eveSystemId   !== va.eveSystemId
+        || vb.online        !== va.online
+        || vb.systemName    !== va.systemName
+        || vb.systemClass   !== va.systemClass
+        || vb.characterName !== va.characterName) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<RawResponse>('/api/character/account-locations')
     .then((r) => {
+      inflight = null;
       const byChar = new Map<number, AccountCharLocation>();
       for (const c of r.characters) byChar.set(c.charId, c);
       const data: AccountLocations = { bySystem: indexBySystem(r.characters), byChar };
+      const prev = moduleCache?.data;
+      if (prev && sameLocations(prev, data)) {
+        moduleCache = { data: prev, fetchedAt: Date.now() };
+        return prev;
+      }
       moduleCache = { data, fetchedAt: Date.now() };
-      inflight = null;
       notify(data);
       return data;
     })

--- a/web/src/hooks/useCurrentHourKills.ts
+++ b/web/src/hooks/useCurrentHourKills.ts
@@ -22,13 +22,31 @@ function notify(d: Map<number, SystemKills>) {
   subscribers.forEach(fn => fn(d));
 }
 
+// True when two polls hold identical kill counts, so we keep the previous Map
+// reference and skip the all-node re-render (kills change at most every ~hour,
+// but the poll runs every 5 min — most polls are no-ops).
+function sameKills(a: Map<number, SystemKills>, b: Map<number, SystemKills>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, va] of a) {
+    const vb = b.get(k);
+    if (!vb
+        || vb.shipKills !== va.shipKills
+        || vb.podKills  !== va.podKills
+        || vb.npcKills  !== va.npcKills
+        || vb.jumps     !== va.jumps) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<SystemKills[]>('/api/activity/current-kills')
     .then(rows => {
-      cache = new Map(rows.map(r => [r.systemId, r]));
-      cacheAt = Date.now();
       inflight = null;
+      const next = new Map(rows.map(r => [r.systemId, r]));
+      cacheAt = Date.now();
+      if (sameKills(cache, next)) return cache;
+      cache = next;
       notify(cache);
       return cache;
     })

--- a/web/src/hooks/useFleet.ts
+++ b/web/src/hooks/useFleet.ts
@@ -49,10 +49,27 @@ function notify(d: FleetState) {
   subscribers.forEach((fn) => fn(d));
 }
 
+// True when two polls describe the same fleet in the same places, so we can
+// keep the previous reference and skip the all-node re-render. Members arrive
+// in a stable server-driven order, so a positional compare is enough (a
+// reordering only costs one redundant notify — never a stale render).
+function sameFleet(a: FleetState, b: FleetState): boolean {
+  if (a.inFleet !== b.inFleet || a.members.length !== b.members.length) return false;
+  for (let i = 0; i < a.members.length; i++) {
+    const ma = a.members[i], mb = b.members[i];
+    if (ma.characterId     !== mb.characterId
+        || ma.solarSystemId   !== mb.solarSystemId
+        || ma.characterName   !== mb.characterName
+        || ma.solarSystemName !== mb.solarSystemName) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<RawResponse>('/api/character/fleet')
     .then((r) => {
+      inflight = null;
       const members: FleetMember[] = r.members.map((m) => ({
         characterId:     m.character_id,
         characterName:   m.character_name ?? null,
@@ -60,8 +77,12 @@ function load() {
         solarSystemName: m.solar_system_name ?? null,
       }));
       const data: FleetState = { inFleet: r.inFleet, members, bySystem: indexBySystem(members) };
+      const prev = moduleCache?.data;
+      if (prev && sameFleet(prev, data)) {
+        moduleCache = { data: prev, fetchedAt: Date.now() };
+        return prev;
+      }
       moduleCache = { data, fetchedAt: Date.now() };
-      inflight = null;
       notify(data);
       return data;
     })

--- a/web/src/hooks/useScoutConnections.ts
+++ b/web/src/hooks/useScoutConnections.ts
@@ -30,10 +30,38 @@ function notify(d: ScoutConnection[]) {
   subscribers.forEach(fn => fn(d));
 }
 
+// True when two polls hold the same scout connections, so we keep the previous
+// reference and skip the all-node re-render. remainingHours is included so the
+// ScoutConnectionsPane countdown stays live — meaning this fires mainly in the
+// common no-connections case (empty === empty), which is exactly the fan-out
+// worth eliminating for the majority of maps.
+function sameScout(a: ScoutConnection[], b: ScoutConnection[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i], y = b[i];
+    if (x.id             !== y.id
+        || x.remainingHours !== y.remainingHours
+        || x.expiresAt      !== y.expiresAt
+        || x.inSystemId     !== y.inSystemId
+        || x.outSystemName  !== y.outSystemName) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<ScoutConnection[]>('/api/scout')
-    .then(d => { moduleCache = { data: d, fetchedAt: Date.now() }; inflight = null; notify(d); return d; })
+    .then(d => {
+      inflight = null;
+      const prev = moduleCache?.data;
+      if (prev && sameScout(prev, d)) {
+        moduleCache = { data: prev, fetchedAt: Date.now() };
+        return prev;
+      }
+      moduleCache = { data: d, fetchedAt: Date.now() };
+      notify(d);
+      return d;
+    })
     .catch(() => { inflight = null; return moduleCache?.data ?? []; });
   return inflight;
 }

--- a/web/src/store/presenceStore.ts
+++ b/web/src/store/presenceStore.ts
@@ -10,22 +10,72 @@ export interface PresenceViewer {
 }
 
 interface PresenceState {
-  viewers: Record<number, PresenceViewer>; // keyed by characterId
+  // Source of truth, keyed by characterId.
+  viewers: Record<number, PresenceViewer>;
+  // Derived index: eveSystemId -> viewers currently there. Maintained
+  // incrementally so a single viewer moving only swaps the two affected
+  // systems' arrays; every other system keeps its exact array reference. That
+  // lets each SystemNode subscribe to just `bySystem.get(mySystemId)` and skip
+  // re-rendering when a viewer moves somewhere else on the map.
+  bySystem: Map<number, PresenceViewer[]>;
   snapshot: (list: PresenceViewer[]) => void;
   upsert:   (v: PresenceViewer) => void;
   remove:   (characterId: number) => void;
   reset:    () => void;
 }
 
+// Rebuild the whole index from the viewer map (snapshot / reset paths).
+function indexBySystem(viewers: Record<number, PresenceViewer>): Map<number, PresenceViewer[]> {
+  const idx = new Map<number, PresenceViewer[]>();
+  for (const v of Object.values(viewers)) {
+    if (v.eveSystemId == null) continue;
+    const arr = idx.get(v.eveSystemId);
+    if (arr) arr.push(v);
+    else idx.set(v.eveSystemId, [v]);
+  }
+  return idx;
+}
+
+// Apply one character's change (move / ship swap / removal) to the index while
+// preserving array references for every untouched system. `next` undefined = a
+// removal. Only the (at most two) systems the character left/joined get a fresh
+// array; all others are shared straight through the shallow Map copy.
+function withViewer(
+  bySystem: Map<number, PresenceViewer[]>,
+  prev: PresenceViewer | undefined,
+  next: PresenceViewer | undefined,
+  characterId: number,
+): Map<number, PresenceViewer[]> {
+  const out = new Map(bySystem);
+  const touched = new Set<number>();
+  if (prev?.eveSystemId != null) touched.add(prev.eveSystemId);
+  if (next?.eveSystemId != null) touched.add(next.eveSystemId);
+  for (const sysId of touched) {
+    const arr = (bySystem.get(sysId) ?? []).filter((x) => x.characterId !== characterId);
+    if (next?.eveSystemId === sysId) arr.push(next);
+    if (arr.length) out.set(sysId, arr);
+    else out.delete(sysId);
+  }
+  return out;
+}
+
 export const usePresenceStore = create<PresenceState>((set) => ({
   viewers: {},
-  snapshot: (list) => set({ viewers: Object.fromEntries(list.map((v) => [v.characterId, v])) }),
-  upsert:   (v) => set((s) => ({ viewers: { ...s.viewers, [v.characterId]: v } })),
-  remove:   (characterId) => set((s) => {
-    if (!(characterId in s.viewers)) return s;
+  bySystem: new Map(),
+  snapshot: (list) => {
+    const viewers: Record<number, PresenceViewer> = Object.fromEntries(list.map((v) => [v.characterId, v]));
+    set({ viewers, bySystem: indexBySystem(viewers) });
+  },
+  upsert: (v) => set((s) => ({
+    viewers:  { ...s.viewers, [v.characterId]: v },
+    bySystem: withViewer(s.bySystem, s.viewers[v.characterId], v, v.characterId),
+  })),
+  remove: (characterId) => set((s) => {
+    const prev = s.viewers[characterId];
+    if (!prev) return s;
     const next = { ...s.viewers };
     delete next[characterId];
-    return { viewers: next };
+    return { viewers: next, bySystem: withViewer(s.bySystem, prev, undefined, characterId) };
   }),
-  reset: () => set({ viewers: {} }),
+  reset: () => set({ viewers: {}, bySystem: new Map() }),
 }));


### PR DESCRIPTION
Second of three perf batches from the frontend audit — the two [P1] items. Kills the periodic all-node re-render fan-out from live presence and the shared background polls. No behaviour change.

## Changes

### Presence: keyed per-system subscription
`presenceStore` now maintains an incremental `bySystem` index (`eveSystemId -> viewers`). A viewer moving swaps only the **two** affected systems' arrays; every other system keeps its exact array reference. `SystemNode` subscribes to `bySystem.get(mySystemId)` instead of the whole `viewers` record — so a viewer moving elsewhere on the map no longer re-renders this node. Previously every SSE presence event re-rendered all N nodes, each doing an O(V) `Object.values(...).filter(...)`.

### Poll equality gates
`useAccountLocations` (10s), `useFleet` (20s), `useCurrentHourKills` (5m) and `useScoutConnections` (5m) each notified every subscriber with a **fresh reference on every poll**, re-rendering all N nodes even when the payload was byte-identical (the common case — alts/fleet/kills rarely change between polls). Each `load()` now compares the new payload against the cached one; when unchanged it keeps the previous reference and skips `notify` entirely.

- Comparators cover only the fields nodes/panes actually render.
- Scout includes `remainingHours` so `ScoutConnectionsPane`'s live countdown stays correct — meaning it fires mainly in the common no-connections case (empty === empty), which is the fan-out worth removing for most maps.
- `useNow30s` intentionally left as-is: a live clock must tick every 30s; no gate applicable.

## Verification
- `yarn tsc -b` clean
- `yarn eslint` on all touched files: 0 errors (4 pre-existing `set-state-in-effect` warnings in the untouched `useResource` fallback paths)
- `yarn build` passes

Batch C (per-node `data` memoization in MapCanvas, hover/drag edge rebuilds) to follow.