### PR TITLE
refactor: single-source shared time + wormhole-dest helpers

### DIFF
--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -11,6 +11,7 @@ import { useNow30s } from '../../hooks/useNow30s';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { matchConnection } from '../../utils/watchMatch';
 import { watchMarker } from '../../data/watchMarkers';
+import { hoursMins } from '../../i18n/format';
 
 // CSS custom properties (resolved via the edge path's inline `style`) so the
 // colour-vision palettes (--cv-conn-* in App.css) re-map connection colours.
@@ -48,9 +49,7 @@ function computeEolState(eolAt: string | null | undefined, now: number) {
   const elapsed   = now - new Date(eolAt).getTime();
   const remaining = EOL_LIFE_MS - elapsed;
   if (remaining <= 0) return { color: TIME_COLORS.expired, label: '!', cls: 'connection-label__crit', expired: true };
-  const hours = Math.floor(remaining / 3_600_000);
-  const mins  = Math.floor((remaining % 3_600_000) / 60_000);
-  const label = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+  const label = hoursMins(remaining);
   if (remaining < EOL_LESS_1H_MS) {
     return { color: TIME_COLORS.lessThan1h, label, cls: 'connection-label__eol', expired: false };
   }

--- a/web/src/components/ui/DemoMap.tsx
+++ b/web/src/components/ui/DemoMap.tsx
@@ -12,8 +12,8 @@ import type { SystemClass, WormholeEffect } from '../../types';
 import {
   CLASS_COLORS, CLASS_LABELS,
   EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS,
-  WORMHOLE_DESTINATIONS,
 } from '../../data/wormholes';
+import { whDestClass } from '../../utils/whDest';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { AddSystemModal } from './AddSystemModal';
 import { pickHandles } from '../map/edgeUtils';
@@ -154,7 +154,7 @@ function DemoSystemNode({ data, selected }: NodeProps) {
         <div className="system-node__statics">
           <div className="title">{t('systemPanel.statics')}</div>
           {sys.statics.map(s => {
-            const dest = WORMHOLE_DESTINATIONS[s];
+            const dest = whDestClass(s, {});
             return (
               <span key={s} className="system-node__static-tag">
                 {s}
@@ -210,7 +210,7 @@ function DemoInfoPanel({ sys, onRemove }: { sys: DemoSys; onRemove: () => void }
         <div className="demo-info__statics">
           <div className="demo-info__label">{t('systemPanel.statics')}</div>
           {sys.statics.map(s => {
-            const dest = WORMHOLE_DESTINATIONS[s];
+            const dest = whDestClass(s, {});
             return (
               <div key={s} className="demo-info__static-row">
                 <span className="demo-info__static-code">{s}</span>

--- a/web/src/components/ui/KillboardPane.tsx
+++ b/web/src/components/ui/KillboardPane.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from 'i18next';
 import { useKillboard, useLastKill } from '../../hooks/useKillboard';
 import { useStandings } from '../../hooks/useStandings';
 import { useUserSetting } from '../../hooks/useUserSetting';
-import { abbreviateValue } from '../../i18n/format';
+import { abbreviateValue, splitHoursMinutes } from '../../i18n/format';
 import type { ZkbKill } from '../../hooks/useKillboard';
 
 const NPC_TOGGLE_KEY = 'nexum.killboardIncludeNpc';
@@ -20,10 +20,11 @@ const ZKB     = 'https://zkillboard.com';
 // force) rather than a small gang. Tune to taste.
 const GANK_THRESHOLD = 10;
 
+// Killboard uses a finer-grained "time ago" than the shared timeAgo (h+m
+// combined, e.g. "3h 24m ago"), so it stays its own function — but the h/m
+// split now comes from the shared helper.
 function timeAgo(t: TFunction, iso: string): string {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const h = Math.floor(diffMs / 3_600_000);
-  const m = Math.floor((diffMs % 3_600_000) / 60_000);
+  const { hours: h, minutes: m } = splitHoursMinutes(Date.now() - new Date(iso).getTime());
   if (h >= 24) return t('time.daysAgo', { value: Math.floor(h / 24) });
   if (h > 0)   return t('killboard.hoursMinutesAgo', { hours: h, minutes: m });
   return m <= 0 ? t('time.justNow') : t('time.minutesAgo', { value: m });

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowRightIcon, CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react';
 import type { MapSystem, SystemClass } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS } from '../../data/wormholes';
+import { LEADS_TO_BANDS } from '../../utils/whDest';
 import { usePopover } from '../../hooks/usePopover';
 
 interface Props {
@@ -21,10 +22,9 @@ interface DestOption { value: string; label: string; color: string; }
 // worst class so the threat reads green → orange → red. C13 / Thera / Pochven /
 // Drifter stay individual (their descriptions are distinct), as does K-space.
 const J_SPACE: DestOption[] = [
-  // Stored values stay 'C1-C3' / 'C4-C5' (unchanged for existing data + matching);
-  // only the display labels get spaced hyphens.
-  { value: 'C1-C3', label: 'C1 - C3', color: CLASS_COLORS.C3 },
-  { value: 'C4-C5', label: 'C4 - C5', color: CLASS_COLORS.C5 },
+  // Bands (C1-C3 / C4-C5) come from the single source in whDest.ts; stored
+  // values stay 'C1-C3' / 'C4-C5' (unchanged for existing data + matching).
+  ...Object.entries(LEADS_TO_BANDS).map(([value, b]) => ({ value, label: b.label, color: b.color })),
   { value: 'C6',    label: 'C6',    color: CLASS_COLORS.C6 },
   { value: 'C13',     label: CLASS_LABELS.C13,     color: CLASS_COLORS.C13 },
   { value: 'Thera',   label: CLASS_LABELS.Thera,   color: CLASS_COLORS.Thera },

--- a/web/src/components/ui/SharedMapView.tsx
+++ b/web/src/components/ui/SharedMapView.tsx
@@ -7,6 +7,7 @@ import { MapCanvas } from '../map/MapCanvas';
 import { SystemPanel } from './SystemPanel';
 import { ShareModeProvider } from '../../context/ShareModeContext';
 import type { MapSystem, MapConnection, Signature, Structure } from '../../types';
+import { expiresIn } from '../../i18n/format';
 
 interface SharePayload {
   mapName:           string;
@@ -44,12 +45,7 @@ function formatLocal(iso: string): string {
 }
 
 function formatRemaining(t: TFunction, iso: string): string {
-  const ms = new Date(iso).getTime() - Date.now();
-  if (ms <= 0) return t('share.expired');
-  const h = Math.floor(ms / 3_600_000);
-  const m = Math.floor((ms % 3_600_000) / 60_000);
-  if (h > 0) return t('share.expiresInHM', { hours: h, minutes: m });
-  return t('share.expiresInM', { minutes: m });
+  return expiresIn(t, new Date(iso).getTime() - Date.now());
 }
 
 export function SharedMapView({ token }: { token: string }) {

--- a/web/src/i18n/format.ts
+++ b/web/src/i18n/format.ts
@@ -45,14 +45,34 @@ export function duration(t: TFunction, totalSeconds: number): string {
   return t('duration.daysHoursMinutes', { days: d, hours: pad2(h % 24), minutes: pad2(m % 60) });
 }
 
+/**
+ * Split a positive millisecond span into whole hours + leftover minutes. The
+ * `h = floor(ms / 3.6e6), m = floor(rem / 6e4)` idiom was copy-pasted into
+ * expiresIn, the connection-edge EOL label and the killboard "time ago"; this
+ * is the single source. Negative spans clamp to zero.
+ */
+export function splitHoursMinutes(ms: number): { hours: number; minutes: number } {
+  const clamped = ms > 0 ? ms : 0;
+  return {
+    hours:   Math.floor(clamped / 3_600_000),
+    minutes: Math.floor((clamped % 3_600_000) / 60_000),
+  };
+}
+
+/** Compact "2h 14m" / "14m" from a millisecond span. Units are the universal
+ *  h/m abbreviations (as shown on the connection-edge label), so not translated. */
+export function hoursMins(ms: number): string {
+  const { hours, minutes } = splitHoursMinutes(ms);
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
 /** "expires in 2h 14m" / "expires in 14m" / "expired" from a millisecond remainder. */
 export function expiresIn(t: TFunction, ms: number): string {
   if (ms <= 0) return t('share.expired');
-  const h = Math.floor(ms / 3_600_000);
-  const m = Math.floor((ms % 3_600_000) / 60_000);
-  return h > 0
-    ? t('share.expiresInHM', { hours: h, minutes: m })
-    : t('share.expiresInM', { minutes: m });
+  const { hours, minutes } = splitHoursMinutes(ms);
+  return hours > 0
+    ? t('share.expiresInHM', { hours, minutes })
+    : t('share.expiresInM', { minutes });
 }
 
 /** Wormhole mass: "1.44 B kg" / "500 M kg" / "123,456 kg" / em dash for <= 0. */

--- a/web/src/utils/whDest.ts
+++ b/web/src/utils/whDest.ts
@@ -46,8 +46,11 @@ export function isUnresolvedLeadsTo(value: string | null | undefined): boolean {
 }
 
 // J-space "band" leads-to values (an unscanned hole reports a band, not an exact
-// class) with display label + colour — mirrors the LeadsToDropdown options.
-const LEADS_TO_BANDS: Record<string, { label: string; color: string }> = {
+// class) with display label + colour. Single source — the LeadsToDropdown picker
+// builds its band options from this map, and holeDisplay resolves stored band
+// values through it. Insertion order is the picker's display order. Each band is
+// coloured by its worst class so the threat reads green -> orange -> red.
+export const LEADS_TO_BANDS: Record<string, { label: string; color: string }> = {
   'C1-C3': { label: 'C1 - C3', color: CLASS_COLORS.C3 },
   'C4-C5': { label: 'C4 - C5', color: CLASS_COLORS.C5 },
 };


### PR DESCRIPTION
The remaining DRY / dead-code items from the frontend audit. No behaviour change; no new i18n keys.

## Done
- **`hours+mins from ms` math (#7):** added `splitHoursMinutes(ms)` + `hoursMins(ms)` to `i18n/format.ts`. The copy-pasted `h = floor(ms/3.6e6), m = floor(rem/6e4)` idiom now has one home — `expiresIn`, `ConnectionEdge`'s EOL label, and `KillboardPane`'s time-ago all share it.
- **SharedMapView `formatRemaining` (#6):** now delegates to `expiresIn` instead of reimplementing the same "expires in Hh Mm / expired" logic.
- **J-space band table (#8):** `LEADS_TO_BANDS` (C1-C3 / C4-C5) is now exported from `whDest.ts` as the single source; `LeadsToDropdown` builds its band options from it instead of a second hardcoded copy.
- **DemoMap (#10):** static destinations resolve through `whDestClass()` (single source, empty types → hardcoded fallback) instead of reading `WORMHOLE_DESTINATIONS` directly.

## Verified already-resolved / intentionally skipped
- **Frigate-hole set (#5):** already single-sourced — the `WH_GROUPS` copy was removed in batch 1, so `FRIG_WH_TYPES` is the lone Set (the `wormholes.ts` entries are the destination map, a different structure). No change.
- **Picker-popover shell (#9): skipped, documented.** The popover *logic* is already shared via `usePopover`; the remaining JSX genuinely diverges (server-driven groups + `DestBadge` vs connected-systems + bands + K-space), so a generic shell for two UX-sensitive consumers would add more indirection than it removes.
- **`useMapSignatureIndex` rev selector (P3): wontfix.** O(systems) per store write but returns a number (no re-render), and the code already notes it's cheap; a running-sum counter would add bookkeeping risk to the correctness-sensitive sig index for negligible gain.
- **`useCanEdit`/`useCanEditContent`, MapSidebar 60s interval (P3 notes):** left as-is (deliberate siblings / no shared 60s hook worth adding).

`KillboardPane.timeAgo` stays its own function — it's a finer-grained "3h 24m ago" (`killboard.hoursMinutesAgo`), deliberately different from the shared `timeAgo`'s "3h ago"; only the h/m math was shared.

## Verification
- `yarn tsc -b` clean
- `yarn eslint` on all touched files: 0 errors (1 pre-existing `set-state-in-effect` warning in KillboardPane, unrelated)
- `yarn build` passes