### PR TITLE
Fix jump create-race: K-space sig auto-map + 'Failed to load' toasts

### DIFF
--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../api/client';
-import { useMapStore } from '../../store/mapStore';
+import { useMapStore, awaitSystemCreate } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useShareMode } from '../../context/ShareModeContext';
 import { useUserSetting } from '../../hooks/useUserSetting';
@@ -231,9 +231,18 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
     // panel is hidden in share mode (see SystemPanel), so just bail.
     if (isShareMode) return;
 
-    api<Anomaly[]>(`/api/maps/${activeMapId}/systems/${systemId}/anomalies`)
-      .then(setAnoms)
-      .catch(() => toast.error(t('anomalies.loadFailed')));
+    // Wait for a just-jumped-to system's create POST to commit before fetching,
+    // or the GET 404s ("Failed to load anomalies"). Existing systems fetch now.
+    let cancelled = false;
+    const fetchAnoms = () => {
+      if (cancelled) return;
+      api<Anomaly[]>(`/api/maps/${activeMapId}/systems/${systemId}/anomalies`)
+        .then((data) => { if (!cancelled) setAnoms(data); })
+        .catch(() => { if (!cancelled) toast.error(t('anomalies.loadFailed')); });
+    };
+    const pending = awaitSystemCreate(systemId);
+    if (pending) void pending.then(fetchAnoms); else fetchAnoms();
+    return () => { cancelled = true; };
   }, [activeMapId, systemId, isShareMode]);
 
   // Live sync: re-fetch in place when a remote client changes this system's

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../api/client';
-import { useMapStore } from '../../store/mapStore';
+import { useMapStore, awaitSystemCreate } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useShareMode } from '../../context/ShareModeContext';
 import { useUserSetting } from '../../hooks/useUserSetting';
@@ -390,9 +390,19 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       return;
     }
 
-    api<Signature[]>(`/api/maps/${activeMapId}/systems/${systemId}/signatures`)
-      .then(setSigs)
-      .catch(() => toast.error(t('signatures.loadFailed')));
+    // A system just created by a jump may not have committed server-side yet;
+    // wait for its create POST before fetching, or the GET 404s ("Failed to
+    // load signatures"). Existing systems resolve to null and fetch at once.
+    let cancelled = false;
+    const fetchSigs = () => {
+      if (cancelled) return;
+      api<Signature[]>(`/api/maps/${activeMapId}/systems/${systemId}/signatures`)
+        .then((data) => { if (!cancelled) setSigs(data); })
+        .catch(() => { if (!cancelled) toast.error(t('signatures.loadFailed')); });
+    };
+    const pending = awaitSystemCreate(systemId);
+    if (pending) void pending.then(fetchSigs); else fetchSigs();
+    return () => { cancelled = true; };
   }, [activeMapId, systemId, isShareMode]);
 
   // Live sync: when a remote client changes this system's sigs, re-fetch in

--- a/web/src/components/ui/StructuresPane.tsx
+++ b/web/src/components/ui/StructuresPane.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../api/client';
-import { useMapStore } from '../../store/mapStore';
+import { useMapStore, awaitSystemCreate } from '../../store/mapStore';
 import { useShareMode } from '../../context/ShareModeContext';
 import type { Structure, StructureType } from '../../types';
 import { NotesEditor } from './NotesEditor';
@@ -100,9 +100,18 @@ export function StructuresPane({ systemId }: { systemId: string }) {
       return;
     }
 
-    api<Structure[]>(`/api/maps/${activeMapId}/systems/${systemId}/structures`)
-      .then(setStructures)
-      .catch(() => toast.error(t('structures.loadFailed')));
+    // Wait for a just-jumped-to system's create POST to commit before fetching,
+    // or the GET 404s ("Failed to load structures"). Existing systems fetch now.
+    let cancelled = false;
+    const fetchStructures = () => {
+      if (cancelled) return;
+      api<Structure[]>(`/api/maps/${activeMapId}/systems/${systemId}/structures`)
+        .then((data) => { if (!cancelled) setStructures(data); })
+        .catch(() => { if (!cancelled) toast.error(t('structures.loadFailed')); });
+    };
+    const pending = awaitSystemCreate(systemId);
+    if (pending) void pending.then(fetchStructures); else fetchStructures();
+    return () => { cancelled = true; };
   }, [activeMapId, systemId, isShareMode]);
 
   // Live sync: re-fetch in place when a remote client changes this system's

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -29,6 +29,19 @@ const connClassPromises = new Map<string, Promise<string>>();
 export function awaitConnectionType(id: string): Promise<string> | null {
   return connClassPromises.get(id) ?? null;
 }
+
+// Per-system promises that settle once the create POST for a newly-added system
+// has returned. A jump adds the arrival system and its connection (and opens the
+// system panel) in the same tick — all fire-and-forget POSTs/GETs that would
+// otherwise race the system INSERT: the connection FK-violates (server 409) and
+// the panes 404. Dependents await this so nothing hits the server before the
+// system row exists. Resolves (never rejects) so awaiters can't hang; absent
+// once settled, so lookups for an already-created system return null and proceed
+// immediately.
+const systemCreatePromises = new Map<string, Promise<void>>();
+export function awaitSystemCreate(id: string): Promise<void> | null {
+  return systemCreatePromises.get(id) ?? null;
+}
 // Per-node measured dimensions, kept out of reactive state so individual
 // ResizeObserver fires don't trigger re-renders across the whole map.
 // `countHeight` is false for systems with statics — those WH systems can
@@ -901,7 +914,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
         if (activeMapId) {
           const url  = `/api/maps/${activeMapId}/systems`;
           const body = JSON.stringify({ ...added });
-          api<{ system?: { security?: number | null; eveSystemId?: number | null } }>(url, { method: 'POST', body })
+          const createP = api<{ system?: { security?: number | null; eveSystemId?: number | null } }>(url, { method: 'POST', body })
             .then((resp) => {
               // Backfill server-derived fields (SDE security, resolved eve id)
               // onto the optimistic node — addSystem can't know these, and the
@@ -924,6 +937,11 @@ export const useMapStore = create<MapStore>()((set, get) => {
               }));
             })
             .catch(() => enqueue(`addSystem:${added.name}`, url, 'POST', body));
+          // Publish the settle signal so the jump's connection POST and the
+          // system panel's sig/structure/anomaly GETs wait for the row to exist
+          // instead of racing it. Never rejects; self-cleans after settling.
+          systemCreatePromises.set(id, createP);
+          void createP.finally(() => systemCreatePromises.delete(id));
         }
       }
 
@@ -1067,7 +1085,18 @@ export const useMapStore = create<MapStore>()((set, get) => {
           const sourceEveId = systemsNow.find((s) => s.id === conn.sourceId)?.eveSystemId ?? null;
           const targetEveId = systemsNow.find((s) => s.id === conn.targetId)?.eveSystemId ?? null;
           const body = JSON.stringify({ ...conn, sourceEveId, targetEveId });
-          const classifyP = api<{ ok: boolean; connectionType?: string }>(url, { method: 'POST', body })
+          // On a jump the endpoint system(s) are being created this same tick;
+          // wait for their create POST to land before POSTing the connection, or
+          // its FK to map_systems violates (server 409) and the classification
+          // resolves 'unknown' — which makes the jump-confirm skip auto-filling
+          // the hole's leads-to. Endpoints that already exist resolve to null and
+          // don't wait.
+          const endpointsReady = Promise.all([
+            awaitSystemCreate(conn.sourceId),
+            awaitSystemCreate(conn.targetId),
+          ]);
+          const classifyP = endpointsReady
+            .then(() => api<{ ok: boolean; connectionType?: string }>(url, { method: 'POST', body }))
             .then((r) => {
               // Server may auto-classify an in-game gate (stargate-adjacent
               // systems). Reflect it locally so the chain/edge updates without


### PR DESCRIPTION
## Live issue
On jumps into a **freshly-added system** (K-space exits — a J-space chain is already scanned, so J→J jumps land on existing rows and never race), the reporting user saw:
- the source hole's leads-to **not auto-mapping** even though the static/K162 was known, and
- three **"Failed to load signatures / structures / anomalies"** toasts on the jump.

Intermittent ("only certain sigs", "the second LS hole didn't work").

## Root cause — a create-race
`applyJump` fires three things fire-and-forget in the same tick and they race the system INSERT:

1. **Connection POST vs system INSERT.** `map_connections.{source,target}_id` are `NOT NULL REFERENCES map_systems(id)`. If the connection POST reaches the DB before the system row commits → FK violation → server returns **409** → the client's `awaitConnectionType` resolves `'unknown'` → `maybeConfirmWhJump` bails (since `1d457d1` it only proceeds for a confirmed `'standard'`) → **the hole's leads-to is never filled.**
2. **Pane GETs vs system INSERT.** The Signature/Structure/Anomaly panes GET `/systems/:id/{...}` for the new system before its row exists → 404 ×3 → the toasts.

The tell that confirmed it: the "which one did you jump?" prompt is gated behind the `'standard'` check, so it appeared for the hole whose connection classified in time (U210) but not the one that resolved `'unknown'` and bailed first (K162).

## Fix — serialize dependents behind the system create
- `addSystem` publishes a per-system settle promise via a new `awaitSystemCreate(id)` (mirrors the existing `awaitConnectionType`). Resolves (never rejects) so awaiters can't hang; absent once settled.
- `addConnection` awaits **both** endpoints' create before POSTing the connection — no more FK-race, so the classification resolves the real `'standard'` and the jump-confirm auto-fills.
- The three panes await the same promise before fetching — no more 404 toasts.
- Existing systems resolve to `null` and proceed immediately, so **J→J and re-jumps keep the fast path** (no added latency).

This also hardens the manual add-then-connect flow against the same FK race for free.

## Verification
- `yarn tsc -b` clean
- `yarn eslint` on touched files: 0 errors (pre-existing `setState-in-effect` / `t`-dep warnings only)
- `yarn build` passes

⚠️ This is a create-race, so it can't be exercised deterministically in a unit test here — worth a QA smoke on a live-ish map: jump from a scanned J-space system out into a **new** K-space system and confirm (a) no "Failed to load" toasts and (b) the source hole's leads-to auto-fills / prompts.