### PR TITLE
Promote qa → release: perf batches A/B/C, DRY consolidations, QA env + backup fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ FRONTEND_URL=http://yourdomain.com
 # Public hostname — used by docker-compose.traefik.yml for the Traefik router rule
 DOMAIN=yourdomain.com
 
+# Traefik router/service/middleware name prefix. Leave unset for a single
+# deployment (defaults to eve-nexum). Only set this when running a SECOND
+# instance on the same host/Traefik (e.g. STACK=eve-nexum-qa) so its Traefik
+# names don't collide with the first. See QA-SETUP.md.
+# STACK=eve-nexum
+
 # ── Limits ────────────────────────────────────────────────────────────────────
 # Max maps a single user can create (default: 5)
 MAX_USER_MAPS=5

--- a/QA-SETUP.md
+++ b/QA-SETUP.md
@@ -1,0 +1,83 @@
+# Running a QA environment (qa.eve-nexum.com)
+
+A second, isolated Nexum instance running **alongside prod on the same host**,
+sharing the existing Traefik reverse proxy. QA gets its own database, its own
+sessions, and its own EVE SSO app — nothing crosses over to prod.
+
+## Why it's isolated (no shared state with prod)
+
+- **Database:** the Postgres volume is scoped to the compose project name, so a
+  distinct project name (`nexum-qa`) gives QA a brand-new, separate database.
+- **Sessions:** the session cookie has no explicit domain, so it's host-scoped —
+  `qa.eve-nexum.com` and `eve-nexum.com` logins don't collide.
+- **Discord:** webhooks live in the DB (per-org), so a fresh QA DB posts nowhere
+  until you configure it in the QA admin UI.
+- **Traefik:** router/service/middleware names are prefixed by `${STACK}`, so
+  `STACK=eve-nexum-qa` avoids colliding with prod's `eve-nexum` names.
+
+## One-time setup
+
+1. **DNS** — add an `A` record: `qa.eve-nexum.com` -> the server's IP (same box
+   as prod). Traefik will fetch a Let's Encrypt cert for it automatically on
+   first request.
+
+2. **EVE SSO** — create a *separate* application on
+   https://developers.eveonline.com with:
+   - Callback URL: `https://qa.eve-nexum.com/auth/callback`
+   - The same scopes as the prod app.
+   Note its **Client ID** and **Secret** for the QA `.env` below.
+
+3. **QA env file** — on the server, in a separate checkout/dir for QA, copy
+   `.env.example` to `.env` and set (at minimum) the values that MUST differ
+   from prod:
+
+   ```dotenv
+   # Second-instance identity (must differ from prod)
+   COMPOSE_PROJECT_NAME=nexum-qa
+   STACK=eve-nexum-qa
+   DOMAIN=qa.eve-nexum.com
+   FRONTEND_URL=https://qa.eve-nexum.com
+   EVE_CALLBACK_URL=https://qa.eve-nexum.com/auth/callback
+
+   # QA's own EVE SSO app (step 2)
+   EVE_CLIENT_ID=<qa app client id>
+   EVE_CLIENT_SECRET=<qa app secret>
+
+   # Fresh secrets for QA (do NOT reuse prod's)
+   SESSION_SECRET=<new random>
+   TOKEN_ENCRYPTION_KEY=<new 32-byte key, as prod requires>
+   PG_PASSWORD=<qa db password>
+   ```
+
+   Everything else (CORP_ID / ALLIANCE_ID / ADMIN_CHAR_ID / limits) can mirror
+   prod or be set to QA-specific values as needed. Generate fresh secrets, e.g.
+   `openssl rand -hex 32`.
+
+## Deploy / update QA
+
+From the QA checkout directory (with its own `.env`), always use **both** compose
+files and the QA project name:
+
+```bash
+docker compose -p nexum-qa \
+  -f docker-compose.yml -f docker-compose.traefik.yml \
+  up -d --build
+```
+
+- `-p nexum-qa` keeps QA's containers, network and volumes separate from prod.
+  (You can instead set `COMPOSE_PROJECT_NAME=nexum-qa` in `.env` and drop `-p`.)
+- Same command redeploys after a `git pull` on the QA branch.
+- The SDE import one-shot runs on first `up` and is skipped once populated.
+
+To tear QA down (keeping prod untouched):
+
+```bash
+docker compose -p nexum-qa -f docker-compose.yml -f docker-compose.traefik.yml down
+# add -v to also wipe the QA database volume
+```
+
+## Notes
+
+- Prod is unaffected: with `STACK` unset it still defaults to `eve-nexum`.
+- QA has no data by default — create maps/systems fresh, or seed as needed.
+- The QA EVE app being separate means revoking/rotating it never touches prod.

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -3,6 +3,11 @@
 #
 # Required .env additions:
 #   DOMAIN=nexum.yourdomain.com
+#
+# Running a SECOND instance (e.g. a QA env) on the SAME host/Traefik: give it a
+# distinct compose project name AND a distinct STACK so its Traefik router,
+# service and middleware names don't collide with the first. See QA-SETUP.md.
+#   STACK=eve-nexum-qa  (defaults to eve-nexum when unset — prod is unchanged)
 
 services:
   postgres:
@@ -24,19 +29,22 @@ services:
       - internal
       - traefik-public
     labels:
+      # Router / service / middleware names are prefixed by ${STACK} (default
+      # eve-nexum) so a second instance (STACK=eve-nexum-qa) can share this
+      # Traefik without name collisions.
       - "traefik.enable=true"
       - "traefik.docker.network=traefik-public"
       # HTTPS router
-      - "traefik.http.routers.eve-nexum.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.eve-nexum.entrypoints=websecure"
-      - "traefik.http.routers.eve-nexum.tls=true"
-      - "traefik.http.routers.eve-nexum.tls.certresolver=letsencrypt"
-      - "traefik.http.services.eve-nexum.loadbalancer.server.port=80"
+      - "traefik.http.routers.${STACK:-eve-nexum}.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.${STACK:-eve-nexum}.entrypoints=websecure"
+      - "traefik.http.routers.${STACK:-eve-nexum}.tls=true"
+      - "traefik.http.routers.${STACK:-eve-nexum}.tls.certresolver=letsencrypt"
+      - "traefik.http.services.${STACK:-eve-nexum}.loadbalancer.server.port=80"
       # HTTP → HTTPS redirect
-      - "traefik.http.routers.eve-nexum-http.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.eve-nexum-http.entrypoints=web"
-      - "traefik.http.routers.eve-nexum-http.middlewares=redirect-to-https"
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.${STACK:-eve-nexum}-http.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.${STACK:-eve-nexum}-http.entrypoints=web"
+      - "traefik.http.routers.${STACK:-eve-nexum}-http.middlewares=${STACK:-eve-nexum}-redirect-to-https"
+      - "traefik.http.middlewares.${STACK:-eve-nexum}-redirect-to-https.redirectscheme.scheme=https"
 
 networks:
   internal:

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -41,11 +41,32 @@ if [ ! -f .env ]; then
 fi
 
 # Read PG_USER / PG_DB straight from the deployed .env so this script stays in
-# sync with whatever the running stack is using.
-set -a
-# shellcheck disable=SC1091
-. ./.env
-set +a
+# sync with whatever the running stack is using. We do NOT `source` the file:
+# .env is a dotenv file (parsed by the app via the `dotenv` library), not a
+# shell script, so `source` chokes on any line that isn't a clean shell
+# assignment (e.g. an uncommented `SDE_CHECK_UTC=11:30  # comment`). Read only
+# the keys we need instead — last assignment wins; surrounding quotes and a
+# trailing CR are trimmed.
+read_env() {
+  local val
+  val="$(grep -E "^[[:space:]]*${1}=" .env | tail -n1)" || return 0
+  val="${val#*=}"
+  val="${val%$'\r'}"
+  val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+  val="${val%"${val##*[![:space:]]}"}"   # rtrim
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  printf '%s' "$val"
+}
+
+PG_USER="$(read_env PG_USER)"
+PG_DB="$(read_env PG_DB)"
+# Honour a custom compose project name if the deploy sets one, so
+# `docker compose exec` targets the right postgres container.
+PROJ="$(read_env COMPOSE_PROJECT_NAME)"
+[ -n "$PROJ" ] && export COMPOSE_PROJECT_NAME="$PROJ"
 
 : "${PG_USER:?PG_USER not set in .env}"
 : "${PG_DB:?PG_DB not set in .env}"

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -40,11 +40,28 @@ if [ ! -f .env ]; then
 fi
 
 # Read PG_USER / PG_DB from the deployed .env so this stays in sync with the
-# running stack (same as backup-db.sh).
-set -a
-# shellcheck disable=SC1091
-. ./.env
-set +a
+# running stack (same as backup-db.sh). We do NOT `source` the file — .env is a
+# dotenv file, not a shell script, so `source` breaks on any line that isn't a
+# clean shell assignment. Read only the keys we need; last assignment wins,
+# surrounding quotes and a trailing CR trimmed.
+read_env() {
+  local val
+  val="$(grep -E "^[[:space:]]*${1}=" .env | tail -n1)" || return 0
+  val="${val#*=}"
+  val="${val%$'\r'}"
+  val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+  val="${val%"${val##*[![:space:]]}"}"   # rtrim
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  printf '%s' "$val"
+}
+
+PG_USER="$(read_env PG_USER)"
+PG_DB="$(read_env PG_DB)"
+PROJ="$(read_env COMPOSE_PROJECT_NAME)"
+[ -n "$PROJ" ] && export COMPOSE_PROJECT_NAME="$PROJ"
 
 : "${PG_USER:?PG_USER not set in .env}"
 : "${PG_DB:?PG_DB not set in .env}"

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -11,6 +11,7 @@ import { useNow30s } from '../../hooks/useNow30s';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { matchConnection } from '../../utils/watchMatch';
 import { watchMarker } from '../../data/watchMarkers';
+import { hoursMins } from '../../i18n/format';
 
 // CSS custom properties (resolved via the edge path's inline `style`) so the
 // colour-vision palettes (--cv-conn-* in App.css) re-map connection colours.
@@ -48,9 +49,7 @@ function computeEolState(eolAt: string | null | undefined, now: number) {
   const elapsed   = now - new Date(eolAt).getTime();
   const remaining = EOL_LIFE_MS - elapsed;
   if (remaining <= 0) return { color: TIME_COLORS.expired, label: '!', cls: 'connection-label__crit', expired: true };
-  const hours = Math.floor(remaining / 3_600_000);
-  const mins  = Math.floor((remaining % 3_600_000) / 60_000);
-  const label = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+  const label = hoursMins(remaining);
   if (remaining < EOL_LESS_1H_MS) {
     return { color: TIME_COLORS.lessThan1h, label, cls: 'connection-label__eol', expired: false };
   }

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -266,6 +266,16 @@ export function MapCanvas() {
   // only ever ran once before being overwritten.
   const [nodes, setNodes] = useNodesState<Node>([]);
 
+  // Per-id cache of the last-built node plus the inputs it was built from. The
+  // store keeps the SAME `sys` reference for systems that didn't change, so on
+  // any single-system edit we can reuse the exact node object for every other
+  // system — keeping its `data` reference stable so SystemNode's memo holds and
+  // only the one changed node re-renders (instead of all N).
+  const nodeCache = useRef<Map<string, {
+    sys: MapSystem; selected: boolean; easyConnect: boolean;
+    canEdit: boolean; dimmed: boolean; routeHighlighted: boolean; node: Node;
+  }>>(new Map());
+
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => {
       changes.forEach((c) => {
@@ -452,10 +462,31 @@ export function MapCanvas() {
 
   useEffect(() => {
     const hl = routeHighlight ? new Set(routeHighlight.systemIds) : null;
-    setNodes(systems.map((s) => {
-      const inRoute = !!hl && hl.has(s.id);
-      return systemToNode(s, selectedSystemId, easyConnect, canEdit, !!hl && !inRoute, inRoute);
-    }));
+    const prevCache = nodeCache.current;
+    const nextCache = new Map<string, {
+      sys: MapSystem; selected: boolean; easyConnect: boolean;
+      canEdit: boolean; dimmed: boolean; routeHighlighted: boolean; node: Node;
+    }>();
+    const nextNodes = systems.map((s) => {
+      const inRoute  = !!hl && hl.has(s.id);
+      const dimmed   = !!hl && !inRoute;
+      const selected = s.id === selectedSystemId;
+      // Reuse the previous node object outright when nothing this node renders
+      // from has changed — same `sys` ref (unchanged system) and same derived
+      // flags. Reference-identical node -> React Flow skips it entirely.
+      const prev = prevCache.get(s.id);
+      if (prev && prev.sys === s && prev.selected === selected
+          && prev.easyConnect === easyConnect && prev.canEdit === canEdit
+          && prev.dimmed === dimmed && prev.routeHighlighted === inRoute) {
+        nextCache.set(s.id, prev);
+        return prev.node;
+      }
+      const node = systemToNode(s, selectedSystemId, easyConnect, canEdit, dimmed, inRoute);
+      nextCache.set(s.id, { sys: s, selected, easyConnect, canEdit, dimmed, routeHighlighted: inRoute, node });
+      return node;
+    });
+    nodeCache.current = nextCache;
+    setNodes(nextNodes);
   }, [systems, selectedSystemId, easyConnect, setNodes, canEdit, routeHighlight]);
 
   useEffect(() => {
@@ -614,9 +645,30 @@ export function MapCanvas() {
   const onNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node) => setHoveredNodeId(node.id), []);
   const onNodeMouseLeave = useCallback(() => setHoveredNodeId(null), []);
 
-  // Edges driven directly from store — no local duplicate state, except for
-  // the live drag-handle overrides above.
-  const edges = useMemo(
+  // Precomputed at drag-start so each drag frame doesn't re-scan every
+  // connection and rebuild a position Map of every system: connections touching
+  // a moved node never change during a drag, and neither do the non-moved
+  // systems' positions.
+  const dragConns   = useRef<typeof connections>([]);
+  const dragBasePos = useRef<Map<string, { x: number; y: number }>>(new Map());
+  const onNodeDragStart = useCallback(
+    (_: React.MouseEvent, _node: Node, movedNodes: Node[]) => {
+      if (!canEdit) return;
+      const movedIds = new Set(movedNodes.map((n) => n.id));
+      dragConns.current = connections.filter(
+        (c) => movedIds.has(c.sourceId) || movedIds.has(c.targetId),
+      );
+      dragBasePos.current = new Map(systems.map((s) => [s.id, s.position]));
+    },
+    [canEdit, connections, systems],
+  );
+
+  // Base edges — everything EXCEPT the mouse-hover highlight. Kept off the
+  // hover state so moving the mouse across nodes doesn't rebuild all E edge
+  // objects (which would re-render every ConnectionEdge). `highlighted` here
+  // reflects only the route-chain highlight; the transient hover highlight is
+  // layered on below, touching just the edges under the cursor.
+  const baseEdges = useMemo(
     () => {
       // Group connections by unordered system pair so multiples between the
       // same two systems can be fanned apart (parallelIndex / parallelCount)
@@ -634,12 +686,7 @@ export function MapCanvas() {
         const ov = dragHandles.get(c.id);
         const key = c.sourceId < c.targetId ? `${c.sourceId}|${c.targetId}` : `${c.targetId}|${c.sourceId}`;
         const group = pairGroups.get(key)!;
-        // Hover-only: a *selected* system would keep its links lit permanently
-        // (e.g. your located system on a 2-node map), which reads as a stuck
-        // hover effect — so highlight only follows the mouse.
         const inRoute = !!routeConns && routeConns.has(c.id);
-        const highlighted =
-          inRoute || (hoveredNodeId != null && (c.sourceId === hoveredNodeId || c.targetId === hoveredNodeId));
         const dimmed = !!routeConns && !inRoute;
         return {
           id: c.id,
@@ -649,17 +696,32 @@ export function MapCanvas() {
           targetHandle: ov?.targetHandle ?? c.targetHandle ?? undefined,
           type: 'connection',
           // Lift highlighted edges above the rest so the traced link sits on top.
-          zIndex: highlighted ? 10 : 0,
+          zIndex: inRoute ? 10 : 0,
           data: {
-            ...c, edgeStyle, connectionThickness, highlighted, dimmed,
+            ...c, edgeStyle, connectionThickness, highlighted: inRoute, dimmed,
             parallelIndex: group.indexOf(c.id), parallelCount: group.length,
           } as unknown as Record<string, unknown>,
           selected: c.id === selectedConnectionId,
         };
       });
     },
-    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, hoveredNodeId, routeHighlight],
+    [connections, selectedConnectionId, edgeStyle, connectionThickness, dragHandles, routeHighlight],
   );
+
+  // Layer the hover highlight on top of the base edges. Only edges touching the
+  // hovered node are rebuilt; every other edge keeps its exact object reference
+  // so ConnectionEdge's memo holds. Hover-only: a *selected* system would keep
+  // its links lit permanently (reads as a stuck hover), so highlight follows
+  // the mouse. When nothing is hovered this returns baseEdges unchanged.
+  const edges = useMemo(() => {
+    if (hoveredNodeId == null) return baseEdges;
+    return baseEdges.map((e) => {
+      if (e.source !== hoveredNodeId && e.target !== hoveredNodeId) return e;
+      const data = e.data as { highlighted?: boolean };
+      if (data.highlighted) return e; // already lit by the route chain
+      return { ...e, zIndex: 10, data: { ...e.data, highlighted: true } };
+    });
+  }, [baseEdges, hoveredNodeId]);
 
   const onEdgesChange = useCallback(
     (changes: EdgeChange[]) => {
@@ -696,17 +758,16 @@ export function MapCanvas() {
   const onNodeDrag = useCallback(
     (_: React.MouseEvent, _node: Node, movedNodes: Node[]) => {
       if (!canEdit) return;
-      const movedIds = new Set(movedNodes.map((n) => n.id));
-      // Live positions: store positions overridden by the in-flight drag.
-      const posMap = new Map(systems.map((s) => [s.id, s.position]));
-      movedNodes.forEach((n) => posMap.set(n.id, n.position));
+      // Only the moved nodes' live positions override the drag-start snapshot;
+      // every other endpoint is read straight from dragBasePos.
+      const moved = new Map(movedNodes.map((n) => [n.id, n.position]));
+      const posOf = (id: string) => moved.get(id) ?? dragBasePos.current.get(id);
 
       setDragHandles((prev) => {
         let next = prev;
-        for (const conn of connections) {
-          if (!movedIds.has(conn.sourceId) && !movedIds.has(conn.targetId)) continue;
-          const src = posMap.get(conn.sourceId);
-          const tgt = posMap.get(conn.targetId);
+        for (const conn of dragConns.current) {
+          const src = posOf(conn.sourceId);
+          const tgt = posOf(conn.targetId);
           if (!src || !tgt) continue;
           const { sourceHandle, targetHandle } = pickHandles(src, tgt);
           const cur = next.get(conn.id);
@@ -720,7 +781,7 @@ export function MapCanvas() {
         return next;
       });
     },
-    [canEdit, systems, connections],
+    [canEdit],
   );
 
   const onNodeDragStop = useCallback(
@@ -728,16 +789,14 @@ export function MapCanvas() {
       if (!canEdit) return;
       movedNodes.forEach((n) => moveSystem(n.id, n.position));
 
-      const movedIds = new Set(movedNodes.map((n) => n.id));
-      // Build position map from store, then override with the just-dragged positions
-      // (store hasn't updated yet when this fires)
-      const posMap = new Map(systems.map((s) => [s.id, s.position]));
-      movedNodes.forEach((n) => posMap.set(n.id, n.position));
+      // Reuse the drag-start snapshot (store hasn't committed the move yet),
+      // overriding only the just-dragged positions.
+      const moved = new Map(movedNodes.map((n) => [n.id, n.position]));
+      const posOf = (id: string) => moved.get(id) ?? dragBasePos.current.get(id);
 
-      for (const conn of connections) {
-        if (!movedIds.has(conn.sourceId) && !movedIds.has(conn.targetId)) continue;
-        const src = posMap.get(conn.sourceId);
-        const tgt = posMap.get(conn.targetId);
+      for (const conn of dragConns.current) {
+        const src = posOf(conn.sourceId);
+        const tgt = posOf(conn.targetId);
         if (!src || !tgt) continue;
         const { sourceHandle, targetHandle } = pickHandles(src, tgt);
         if (conn.sourceHandle !== sourceHandle || conn.targetHandle !== targetHandle) {
@@ -748,7 +807,7 @@ export function MapCanvas() {
       // drop the overrides (no flicker — the store write above is synchronous).
       setDragHandles((prev) => (prev.size ? new Map() : prev));
     },
-    [moveSystem, systems, connections, updateConnection, canEdit],
+    [moveSystem, updateConnection, canEdit],
   );
 
   const nodeCtxFired = useRef(false);
@@ -1238,6 +1297,7 @@ export function MapCanvas() {
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        onNodeDragStart={onNodeDragStart}
         onNodeDrag={onNodeDrag}
         onNodeDragStop={onNodeDragStop}
         onNodeMouseEnter={onNodeMouseEnter}

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -22,8 +22,8 @@ import { useIncursions, findIncursion } from '../../hooks/useIncursions';
 import { useInsurgency, findInsurgency } from '../../hooks/useInsurgency';
 import { useStorms, findStorm } from '../../hooks/useStorms';
 import { useScoutConnections, findScoutConnections } from '../../hooks/useScoutConnections';
-import { useA0Systems } from '../../hooks/useA0Systems';
-import { useShatteredSystems } from '../../hooks/useShatteredSystems';
+import { useA0SystemIds } from '../../hooks/useA0Systems';
+import { useShatteredSystemIds } from '../../hooks/useShatteredSystems';
 import { PREDEFINED_LABELS, parseCustomLabel, labelTextColor } from '../../data/labels';
 import { iconComponent } from '../../utils/phosphorIcons';
 import { useIceBeltSystems, hasIceBelt } from '../../hooks/useIceBeltSystems';
@@ -129,11 +129,10 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const storm           = useMemo(() => findStorm(storms, sys.eveSystemId), [storms, sys.eveSystemId]);
   const scoutAll        = useScoutConnections();
   const scoutMatches    = useMemo(() => findScoutConnections(scoutAll, sys.eveSystemId), [scoutAll, sys.eveSystemId]);
-  const a0Systems       = useA0Systems();
-  const a0Ids           = useMemo(() => new Set(a0Systems.map(s => s.id)), [a0Systems]);
+  // Shared id-Sets (built once, not per node) for O(1) membership.
+  const a0Ids           = useA0SystemIds();
   const isA0            = sys.eveSystemId !== null && a0Ids.has(sys.eveSystemId);
-  const shatteredSystems = useShatteredSystems();
-  const shatteredIds    = useMemo(() => new Set(shatteredSystems.map(s => s.id)), [shatteredSystems]);
+  const shatteredIds    = useShatteredSystemIds();
   const isShattered     = sys.eveSystemId !== null && shatteredIds.has(sys.eveSystemId);
   const iceBeltSystems  = useIceBeltSystems();
   const isIceBelt       = useMemo(() => hasIceBelt(iceBeltSystems, sys.eveSystemId), [iceBeltSystems, sys.eveSystemId]);
@@ -169,7 +168,12 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   // entry (by name, class, effect, or a static wormhole type / frig hole).
   const [watchEntries]  = useWatchlist();
   const watchSigTypes   = useMapStore((s) => s.sigTypesBySystem[sys.id]);
-  const watch           = matchSystem(watchEntries, sys, watchSigTypes);
+  // Memoized: matchSystem scans up to MAX_WATCH (~75) entries; without this it
+  // re-ran on every re-render (e.g. every 10s location poll), for every node.
+  const watch           = useMemo(
+    () => matchSystem(watchEntries, sys, watchSigTypes),
+    [watchEntries, sys, watchSigTypes],
+  );
   const watchDef        = watch ? watchMarker(watch.marker) : null;
   const watchTip        = watch ? (watch.note.trim() || t(`watchMarker.${watch.marker}`)) : undefined;
 
@@ -187,7 +191,10 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   // the app rather than the drift-prone hardcoded map.
   const whTypes         = useWormholeTypes();
   const filterOn        = contentFilterActive(contentFilter);
-  const contentMatch    = filterOn && systemMatchesContent(sysContent, contentFilter, (undivedHoles?.length ?? 0) > 0);
+  const contentMatch    = useMemo(
+    () => filterOn && systemMatchesContent(sysContent, contentFilter, (undivedHoles?.length ?? 0) > 0),
+    [filterOn, sysContent, contentFilter, undivedHoles],
+  );
   const filteredOut     = filterOn && !contentMatch;
 
   // Tooltip label: dedupe by scout system name (Thera / Turnur). Multiple

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -91,16 +91,19 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   }, [showAccountChars, accountLocations.bySystem, sys.eveSystemId]);
 
   // Other people viewing this map who are currently in this system (presence).
-  // Excludes self — the green you-are-here dot covers that.
-  const presenceViewers = usePresenceStore((s) => s.viewers);
+  // Excludes self — the green you-are-here dot covers that. Subscribe to just
+  // this system's slice of the presence index (stable ref unless a viewer
+  // enters/leaves THIS system), so a viewer moving elsewhere doesn't re-render
+  // this node.
+  const presenceSlice = usePresenceStore(
+    (s) => (sys.eveSystemId == null ? undefined : s.bySystem.get(sys.eveSystemId)),
+  );
   const presenceHere    = useMemo(() => {
-    if (sys.eveSystemId == null) return undefined;
+    if (!presenceSlice || presenceSlice.length === 0) return undefined;
     const myId = user?.characterId;
-    const here = Object.values(presenceViewers).filter(
-      (v) => v.eveSystemId === sys.eveSystemId && v.characterId !== myId,
-    );
+    const here = presenceSlice.filter((v) => v.characterId !== myId);
     return here.length ? here : undefined;
-  }, [presenceViewers, sys.eveSystemId, user?.characterId]);
+  }, [presenceSlice, user?.characterId]);
 
   // Halo around any sov-holder system based on the user's contact bands.
   // Threshold is just "negative or positive" rather than the strict ≤-5

--- a/web/src/components/ui/DemoMap.tsx
+++ b/web/src/components/ui/DemoMap.tsx
@@ -12,8 +12,8 @@ import type { SystemClass, WormholeEffect } from '../../types';
 import {
   CLASS_COLORS, CLASS_LABELS,
   EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS,
-  WORMHOLE_DESTINATIONS,
 } from '../../data/wormholes';
+import { whDestClass } from '../../utils/whDest';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { AddSystemModal } from './AddSystemModal';
 import { pickHandles } from '../map/edgeUtils';
@@ -154,7 +154,7 @@ function DemoSystemNode({ data, selected }: NodeProps) {
         <div className="system-node__statics">
           <div className="title">{t('systemPanel.statics')}</div>
           {sys.statics.map(s => {
-            const dest = WORMHOLE_DESTINATIONS[s];
+            const dest = whDestClass(s, {});
             return (
               <span key={s} className="system-node__static-tag">
                 {s}
@@ -210,7 +210,7 @@ function DemoInfoPanel({ sys, onRemove }: { sys: DemoSys; onRemove: () => void }
         <div className="demo-info__statics">
           <div className="demo-info__label">{t('systemPanel.statics')}</div>
           {sys.statics.map(s => {
-            const dest = WORMHOLE_DESTINATIONS[s];
+            const dest = whDestClass(s, {});
             return (
               <div key={s} className="demo-info__static-row">
                 <span className="demo-info__static-code">{s}</span>

--- a/web/src/components/ui/KillboardPane.tsx
+++ b/web/src/components/ui/KillboardPane.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from 'i18next';
 import { useKillboard, useLastKill } from '../../hooks/useKillboard';
 import { useStandings } from '../../hooks/useStandings';
 import { useUserSetting } from '../../hooks/useUserSetting';
-import { abbreviateValue } from '../../i18n/format';
+import { abbreviateValue, splitHoursMinutes } from '../../i18n/format';
 import type { ZkbKill } from '../../hooks/useKillboard';
 
 const NPC_TOGGLE_KEY = 'nexum.killboardIncludeNpc';
@@ -20,10 +20,11 @@ const ZKB     = 'https://zkillboard.com';
 // force) rather than a small gang. Tune to taste.
 const GANK_THRESHOLD = 10;
 
+// Killboard uses a finer-grained "time ago" than the shared timeAgo (h+m
+// combined, e.g. "3h 24m ago"), so it stays its own function — but the h/m
+// split now comes from the shared helper.
 function timeAgo(t: TFunction, iso: string): string {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const h = Math.floor(diffMs / 3_600_000);
-  const m = Math.floor((diffMs % 3_600_000) / 60_000);
+  const { hours: h, minutes: m } = splitHoursMinutes(Date.now() - new Date(iso).getTime());
   if (h >= 24) return t('time.daysAgo', { value: Math.floor(h / 24) });
   if (h > 0)   return t('killboard.hoursMinutesAgo', { hours: h, minutes: m });
   return m <= 0 ? t('time.justNow') : t('time.minutesAgo', { value: m });

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowRightIcon, CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react';
 import type { MapSystem, SystemClass } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS } from '../../data/wormholes';
+import { LEADS_TO_BANDS } from '../../utils/whDest';
 import { usePopover } from '../../hooks/usePopover';
 
 interface Props {
@@ -21,10 +22,9 @@ interface DestOption { value: string; label: string; color: string; }
 // worst class so the threat reads green → orange → red. C13 / Thera / Pochven /
 // Drifter stay individual (their descriptions are distinct), as does K-space.
 const J_SPACE: DestOption[] = [
-  // Stored values stay 'C1-C3' / 'C4-C5' (unchanged for existing data + matching);
-  // only the display labels get spaced hyphens.
-  { value: 'C1-C3', label: 'C1 - C3', color: CLASS_COLORS.C3 },
-  { value: 'C4-C5', label: 'C4 - C5', color: CLASS_COLORS.C5 },
+  // Bands (C1-C3 / C4-C5) come from the single source in whDest.ts; stored
+  // values stay 'C1-C3' / 'C4-C5' (unchanged for existing data + matching).
+  ...Object.entries(LEADS_TO_BANDS).map(([value, b]) => ({ value, label: b.label, color: b.color })),
   { value: 'C6',    label: 'C6',    color: CLASS_COLORS.C6 },
   { value: 'C13',     label: CLASS_LABELS.C13,     color: CLASS_COLORS.C13 },
   { value: 'Thera',   label: CLASS_LABELS.Thera,   color: CLASS_COLORS.Thera },

--- a/web/src/components/ui/SharedMapView.tsx
+++ b/web/src/components/ui/SharedMapView.tsx
@@ -7,6 +7,7 @@ import { MapCanvas } from '../map/MapCanvas';
 import { SystemPanel } from './SystemPanel';
 import { ShareModeProvider } from '../../context/ShareModeContext';
 import type { MapSystem, MapConnection, Signature, Structure } from '../../types';
+import { expiresIn } from '../../i18n/format';
 
 interface SharePayload {
   mapName:           string;
@@ -44,12 +45,7 @@ function formatLocal(iso: string): string {
 }
 
 function formatRemaining(t: TFunction, iso: string): string {
-  const ms = new Date(iso).getTime() - Date.now();
-  if (ms <= 0) return t('share.expired');
-  const h = Math.floor(ms / 3_600_000);
-  const m = Math.floor((ms % 3_600_000) / 60_000);
-  if (h > 0) return t('share.expiresInHM', { hours: h, minutes: m });
-  return t('share.expiresInM', { minutes: m });
+  return expiresIn(t, new Date(iso).getTime() - Date.now());
 }
 
 export function SharedMapView({ token }: { token: string }) {

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -196,27 +196,31 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   const sigTypeLabel = (type: SigType) =>
     type === 'unknown' ? t('sigType.unknown') : SIG_TYPE_LABELS[type];
   const activeMapId     = useMapStore((s) => s.activeMapId);
-  const map             = useMapStore((s) => s.map);
+  // Narrow slices instead of the whole `map`: the pane only reads systems +
+  // connections, so it no longer re-renders on unrelated map mutations (rename,
+  // saved routes, updatedAt bumps, share-flag changes, ...).
+  const mapSystems      = useMapStore((s) => s.map.systems);
+  const mapConnections  = useMapStore((s) => s.map.connections);
   const currentSystemId = useMapStore((s) => s.currentSystemId);
   const setSystemSigTypes = useMapStore((s) => s.setSystemSigTypes);
   const setSystemWhSigs = useMapStore((s) => s.setSystemWhSigs);
   const canEdit         = useCanEditContent();
 
   const systemStatics = useMemo(
-    () => map.systems.find((sys) => sys.id === systemId)?.statics ?? [],
-    [map.systems, systemId],
+    () => mapSystems.find((sys) => sys.id === systemId)?.statics ?? [],
+    [mapSystems, systemId],
   );
 
   const connectedSystems = useMemo(() => {
-    const conns = map.connections.filter(
+    const conns = mapConnections.filter(
       (c) => c.sourceId === systemId || c.targetId === systemId,
     );
     return conns.flatMap((c) => {
       const otherId = c.sourceId === systemId ? c.targetId : c.sourceId;
-      const sys = map.systems.find((m) => m.id === otherId);
+      const sys = mapSystems.find((m) => m.id === otherId);
       return sys ? [{ id: sys.id, name: sys.name, systemClass: sys.systemClass }] : [];
     });
-  }, [map.connections, map.systems, systemId]);
+  }, [mapConnections, mapSystems, systemId]);
 
   const [sigs, setSigs]               = useState<Signature[]>([]);
   const [selected, setSelected]       = useState<Set<string>>(new Set());
@@ -418,7 +422,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       updates.whType?.toUpperCase() === 'K162' &&
       existing?.whType?.toUpperCase() !== 'K162'
     ) {
-      const sysName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown system';
+      const sysName = mapSystems.find((s) => s.id === systemId)?.name ?? 'unknown system';
       alertInboundK162(sysName);
     }
 
@@ -460,13 +464,13 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       const leads = sig.whLeadsTo?.toUpperCase();
       if (!leads) continue;
       let source: string | null = null;
-      for (const conn of map.connections) {
+      for (const conn of mapConnections) {
         if (conn.connectionType !== 'standard') continue;
         const otherId =
           conn.sourceId === systemId ? conn.targetId :
           conn.targetId === systemId ? conn.sourceId : null;
         if (!otherId) continue;
-        const other = map.systems.find((s) => s.id === otherId);
+        const other = mapSystems.find((s) => s.id === otherId);
         if (!other) continue;
         const oc = other.systemClass.toUpperCase();
         const on = (other.name ?? '').toUpperCase();
@@ -477,7 +481,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       if (source) updateSig(sig.id, { notes: source });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sigs, map.connections, map.systems, systemId, canEdit, isShareMode]);
+  }, [sigs, mapConnections, mapSystems, systemId, canEdit, isShareMode]);
 
   // Quarantine orphaned wormhole links. A live wormhole always shows as a sig
   // on BOTH ends, so if this system has been scanned (has sigs) yet carries no
@@ -621,8 +625,8 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
       // Warn if the character is in a different system than the one being edited
       if (currentSystemId && currentSystemId !== systemId) {
-        const currentName  = map.systems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
-        const selectedName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown';
+        const currentName  = mapSystems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
+        const selectedName = mapSystems.find((s) => s.id === systemId)?.name ?? 'unknown';
         setPendingAction({
           message: t('signatures.pasteDifferentSystem', { current: currentName, selected: selectedName }),
           fn: () => processPaste(parsed, overwrite, delaySec),
@@ -637,7 +641,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
     window.addEventListener('paste', handlePaste);
     return () => window.removeEventListener('paste', handlePaste);
-  }, [activeMapId, systemId, currentSystemId, map.systems, processPaste, overwriteOnPaste, overwriteDelay, t]);
+  }, [activeMapId, systemId, currentSystemId, mapSystems, processPaste, overwriteOnPaste, overwriteDelay, t]);
 
   const addSig = async () => {
     if (!activeMapId) return;

--- a/web/src/hooks/useA0Systems.ts
+++ b/web/src/hooks/useA0Systems.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { createStaticResource } from './createStaticResource';
 
 export interface A0System {
@@ -7,5 +8,26 @@ export interface A0System {
 }
 
 // The A0 list is static cluster data — load once per page, never refresh.
-const { useResource } = createStaticResource<A0System[]>('/api/systems/a0', []);
+const { useResource, load } = createStaticResource<A0System[]>('/api/systems/a0', []);
 export const useA0Systems = useResource;
+
+// Shared Set of A0 eve-ids for O(1) membership checks, derived ONCE globally
+// from the loaded list rather than rebuilt in every map node. The Set is
+// populated in an effect (via the resource's own load()), never reassigned
+// during render — the react-hooks purity rule forbids mutating module state
+// while rendering. A stable empty Set is used until the data loads.
+const EMPTY_IDS: ReadonlySet<number> = new Set();
+let idSetCache: Set<number> | null = null;
+
+export function useA0SystemIds(): ReadonlySet<number> {
+  const [ids, setIds] = useState<ReadonlySet<number>>(idSetCache ?? EMPTY_IDS);
+  useEffect(() => {
+    let cancelled = false;
+    load().then((list) => {
+      if (!idSetCache) idSetCache = new Set(list.map((s) => s.id));
+      if (!cancelled) setIds(idSetCache);
+    });
+    return () => { cancelled = true; };
+  }, []);
+  return ids;
+}

--- a/web/src/hooks/useAccountLocations.ts
+++ b/web/src/hooks/useAccountLocations.ts
@@ -50,15 +50,37 @@ function indexBySystem(list: AccountCharLocation[]): Map<number, AccountCharLoca
 
 function notify(d: AccountLocations) { subscribers.forEach((fn) => fn(d)); }
 
+// True when two polls describe the same characters in the same places, so we
+// can keep the previous reference and skip the all-node re-render. Keyed by
+// charId; compares only the fields a node actually renders.
+function sameLocations(a: AccountLocations, b: AccountLocations): boolean {
+  if (a.byChar.size !== b.byChar.size) return false;
+  for (const [k, va] of a.byChar) {
+    const vb = b.byChar.get(k);
+    if (!vb
+        || vb.eveSystemId   !== va.eveSystemId
+        || vb.online        !== va.online
+        || vb.systemName    !== va.systemName
+        || vb.systemClass   !== va.systemClass
+        || vb.characterName !== va.characterName) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<RawResponse>('/api/character/account-locations')
     .then((r) => {
+      inflight = null;
       const byChar = new Map<number, AccountCharLocation>();
       for (const c of r.characters) byChar.set(c.charId, c);
       const data: AccountLocations = { bySystem: indexBySystem(r.characters), byChar };
+      const prev = moduleCache?.data;
+      if (prev && sameLocations(prev, data)) {
+        moduleCache = { data: prev, fetchedAt: Date.now() };
+        return prev;
+      }
       moduleCache = { data, fetchedAt: Date.now() };
-      inflight = null;
       notify(data);
       return data;
     })

--- a/web/src/hooks/useCurrentHourKills.ts
+++ b/web/src/hooks/useCurrentHourKills.ts
@@ -22,13 +22,31 @@ function notify(d: Map<number, SystemKills>) {
   subscribers.forEach(fn => fn(d));
 }
 
+// True when two polls hold identical kill counts, so we keep the previous Map
+// reference and skip the all-node re-render (kills change at most every ~hour,
+// but the poll runs every 5 min — most polls are no-ops).
+function sameKills(a: Map<number, SystemKills>, b: Map<number, SystemKills>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, va] of a) {
+    const vb = b.get(k);
+    if (!vb
+        || vb.shipKills !== va.shipKills
+        || vb.podKills  !== va.podKills
+        || vb.npcKills  !== va.npcKills
+        || vb.jumps     !== va.jumps) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<SystemKills[]>('/api/activity/current-kills')
     .then(rows => {
-      cache = new Map(rows.map(r => [r.systemId, r]));
-      cacheAt = Date.now();
       inflight = null;
+      const next = new Map(rows.map(r => [r.systemId, r]));
+      cacheAt = Date.now();
+      if (sameKills(cache, next)) return cache;
+      cache = next;
       notify(cache);
       return cache;
     })

--- a/web/src/hooks/useFleet.ts
+++ b/web/src/hooks/useFleet.ts
@@ -49,10 +49,27 @@ function notify(d: FleetState) {
   subscribers.forEach((fn) => fn(d));
 }
 
+// True when two polls describe the same fleet in the same places, so we can
+// keep the previous reference and skip the all-node re-render. Members arrive
+// in a stable server-driven order, so a positional compare is enough (a
+// reordering only costs one redundant notify — never a stale render).
+function sameFleet(a: FleetState, b: FleetState): boolean {
+  if (a.inFleet !== b.inFleet || a.members.length !== b.members.length) return false;
+  for (let i = 0; i < a.members.length; i++) {
+    const ma = a.members[i], mb = b.members[i];
+    if (ma.characterId     !== mb.characterId
+        || ma.solarSystemId   !== mb.solarSystemId
+        || ma.characterName   !== mb.characterName
+        || ma.solarSystemName !== mb.solarSystemName) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<RawResponse>('/api/character/fleet')
     .then((r) => {
+      inflight = null;
       const members: FleetMember[] = r.members.map((m) => ({
         characterId:     m.character_id,
         characterName:   m.character_name ?? null,
@@ -60,8 +77,12 @@ function load() {
         solarSystemName: m.solar_system_name ?? null,
       }));
       const data: FleetState = { inFleet: r.inFleet, members, bySystem: indexBySystem(members) };
+      const prev = moduleCache?.data;
+      if (prev && sameFleet(prev, data)) {
+        moduleCache = { data: prev, fetchedAt: Date.now() };
+        return prev;
+      }
       moduleCache = { data, fetchedAt: Date.now() };
-      inflight = null;
       notify(data);
       return data;
     })

--- a/web/src/hooks/useScoutConnections.ts
+++ b/web/src/hooks/useScoutConnections.ts
@@ -30,10 +30,38 @@ function notify(d: ScoutConnection[]) {
   subscribers.forEach(fn => fn(d));
 }
 
+// True when two polls hold the same scout connections, so we keep the previous
+// reference and skip the all-node re-render. remainingHours is included so the
+// ScoutConnectionsPane countdown stays live — meaning this fires mainly in the
+// common no-connections case (empty === empty), which is exactly the fan-out
+// worth eliminating for the majority of maps.
+function sameScout(a: ScoutConnection[], b: ScoutConnection[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i], y = b[i];
+    if (x.id             !== y.id
+        || x.remainingHours !== y.remainingHours
+        || x.expiresAt      !== y.expiresAt
+        || x.inSystemId     !== y.inSystemId
+        || x.outSystemName  !== y.outSystemName) return false;
+  }
+  return true;
+}
+
 function load() {
   if (inflight) return inflight;
   inflight = api<ScoutConnection[]>('/api/scout')
-    .then(d => { moduleCache = { data: d, fetchedAt: Date.now() }; inflight = null; notify(d); return d; })
+    .then(d => {
+      inflight = null;
+      const prev = moduleCache?.data;
+      if (prev && sameScout(prev, d)) {
+        moduleCache = { data: prev, fetchedAt: Date.now() };
+        return prev;
+      }
+      moduleCache = { data: d, fetchedAt: Date.now() };
+      notify(d);
+      return d;
+    })
     .catch(() => { inflight = null; return moduleCache?.data ?? []; });
   return inflight;
 }

--- a/web/src/hooks/useShatteredSystems.ts
+++ b/web/src/hooks/useShatteredSystems.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { createStaticResource } from './createStaticResource';
 
 export interface ShatteredSystem {
@@ -7,5 +8,26 @@ export interface ShatteredSystem {
 }
 
 // The shattered list is static cluster data — load once per page, never refresh.
-const { useResource } = createStaticResource<ShatteredSystem[]>('/api/systems/shattered', []);
+const { useResource, load } = createStaticResource<ShatteredSystem[]>('/api/systems/shattered', []);
 export const useShatteredSystems = useResource;
+
+// Shared Set of shattered eve-ids for O(1) membership, derived ONCE globally
+// from the loaded list rather than rebuilt in every map node. The Set is
+// populated in an effect (via the resource's own load()), never reassigned
+// during render — the react-hooks purity rule forbids mutating module state
+// while rendering. A stable empty Set is used until the data loads.
+const EMPTY_IDS: ReadonlySet<number> = new Set();
+let idSetCache: Set<number> | null = null;
+
+export function useShatteredSystemIds(): ReadonlySet<number> {
+  const [ids, setIds] = useState<ReadonlySet<number>>(idSetCache ?? EMPTY_IDS);
+  useEffect(() => {
+    let cancelled = false;
+    load().then((list) => {
+      if (!idSetCache) idSetCache = new Set(list.map((s) => s.id));
+      if (!cancelled) setIds(idSetCache);
+    });
+    return () => { cancelled = true; };
+  }, []);
+  return ids;
+}

--- a/web/src/i18n/format.ts
+++ b/web/src/i18n/format.ts
@@ -45,14 +45,34 @@ export function duration(t: TFunction, totalSeconds: number): string {
   return t('duration.daysHoursMinutes', { days: d, hours: pad2(h % 24), minutes: pad2(m % 60) });
 }
 
+/**
+ * Split a positive millisecond span into whole hours + leftover minutes. The
+ * `h = floor(ms / 3.6e6), m = floor(rem / 6e4)` idiom was copy-pasted into
+ * expiresIn, the connection-edge EOL label and the killboard "time ago"; this
+ * is the single source. Negative spans clamp to zero.
+ */
+export function splitHoursMinutes(ms: number): { hours: number; minutes: number } {
+  const clamped = ms > 0 ? ms : 0;
+  return {
+    hours:   Math.floor(clamped / 3_600_000),
+    minutes: Math.floor((clamped % 3_600_000) / 60_000),
+  };
+}
+
+/** Compact "2h 14m" / "14m" from a millisecond span. Units are the universal
+ *  h/m abbreviations (as shown on the connection-edge label), so not translated. */
+export function hoursMins(ms: number): string {
+  const { hours, minutes } = splitHoursMinutes(ms);
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
 /** "expires in 2h 14m" / "expires in 14m" / "expired" from a millisecond remainder. */
 export function expiresIn(t: TFunction, ms: number): string {
   if (ms <= 0) return t('share.expired');
-  const h = Math.floor(ms / 3_600_000);
-  const m = Math.floor((ms % 3_600_000) / 60_000);
-  return h > 0
-    ? t('share.expiresInHM', { hours: h, minutes: m })
-    : t('share.expiresInM', { minutes: m });
+  const { hours, minutes } = splitHoursMinutes(ms);
+  return hours > 0
+    ? t('share.expiresInHM', { hours, minutes })
+    : t('share.expiresInM', { minutes });
 }
 
 /** Wormhole mass: "1.44 B kg" / "500 M kg" / "123,456 kg" / em dash for <= 0. */

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -86,6 +86,27 @@ function recomputeUniformMax(): { w: number; h: number } {
   // the height would lock at 0 and the inline minHeight would never apply.
   return { w: snapUpToGrid(w), h: snapUpToGrid(anyHeightEligible ? h : hAll) };
 }
+
+// Coalesce the uniform-max recompute. On map load all N nodes report their size
+// in the same frame; recomputing (an O(N) scan) + writing the store per report
+// was O(N^2) and re-rendered every node up to N times as the max ratcheted.
+// Instead each report just schedules one recompute per frame that reads the
+// final nodeSizes and writes the store at most once.
+let uniformRaf: ReturnType<typeof requestAnimationFrame> | null = null;
+function scheduleUniformRecompute(): void {
+  if (uniformRaf !== null) return;
+  const run = () => {
+    uniformRaf = null;
+    const { w, h } = recomputeUniformMax();
+    const st = useMapStore.getState();
+    if (st.uniformWidth !== w || st.uniformHeight !== h) {
+      useMapStore.setState({ uniformWidth: w, uniformHeight: h });
+    }
+  };
+  // requestAnimationFrame is absent under SSR/tests — fall back to running now.
+  if (typeof requestAnimationFrame === 'undefined') { run(); return; }
+  uniformRaf = requestAnimationFrame(run);
+}
 // Debounce map name saves — keyed by mapId so two tabs renaming two different
 // maps don't clobber each other through a shared timer slot.
 const nameTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -785,11 +806,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
           && Math.abs(prev.h - height) < 1
           && prev.countHeight === countHeight) return;
       nodeSizes.set(id, { w: width, h: height, countHeight });
-      const { w, h } = recomputeUniformMax();
-      const cur = get();
-      if (cur.uniformWidth !== w || cur.uniformHeight !== h) {
-        set({ uniformWidth: w, uniformHeight: h });
-      }
+      scheduleUniformRecompute();
 
       // Consume a pending placement fix now we know this node's real size.
       // Only ever moves the node FARTHER from the source (restores the gap when
@@ -824,11 +841,7 @@ export const useMapStore = create<MapStore>()((set, get) => {
       // before the real measure consumes it. The fix is cleared in
       // reportNodeSize (on apply) or removeSystem (on real removal).
       if (!nodeSizes.delete(id)) return;
-      const { w, h } = recomputeUniformMax();
-      const cur = get();
-      if (cur.uniformWidth !== w || cur.uniformHeight !== h) {
-        set({ uniformWidth: w, uniformHeight: h });
-      }
+      scheduleUniformRecompute();
     },
 
     // Drop every cached natural size and reset the broadcast uniform

--- a/web/src/store/presenceStore.ts
+++ b/web/src/store/presenceStore.ts
@@ -10,22 +10,72 @@ export interface PresenceViewer {
 }
 
 interface PresenceState {
-  viewers: Record<number, PresenceViewer>; // keyed by characterId
+  // Source of truth, keyed by characterId.
+  viewers: Record<number, PresenceViewer>;
+  // Derived index: eveSystemId -> viewers currently there. Maintained
+  // incrementally so a single viewer moving only swaps the two affected
+  // systems' arrays; every other system keeps its exact array reference. That
+  // lets each SystemNode subscribe to just `bySystem.get(mySystemId)` and skip
+  // re-rendering when a viewer moves somewhere else on the map.
+  bySystem: Map<number, PresenceViewer[]>;
   snapshot: (list: PresenceViewer[]) => void;
   upsert:   (v: PresenceViewer) => void;
   remove:   (characterId: number) => void;
   reset:    () => void;
 }
 
+// Rebuild the whole index from the viewer map (snapshot / reset paths).
+function indexBySystem(viewers: Record<number, PresenceViewer>): Map<number, PresenceViewer[]> {
+  const idx = new Map<number, PresenceViewer[]>();
+  for (const v of Object.values(viewers)) {
+    if (v.eveSystemId == null) continue;
+    const arr = idx.get(v.eveSystemId);
+    if (arr) arr.push(v);
+    else idx.set(v.eveSystemId, [v]);
+  }
+  return idx;
+}
+
+// Apply one character's change (move / ship swap / removal) to the index while
+// preserving array references for every untouched system. `next` undefined = a
+// removal. Only the (at most two) systems the character left/joined get a fresh
+// array; all others are shared straight through the shallow Map copy.
+function withViewer(
+  bySystem: Map<number, PresenceViewer[]>,
+  prev: PresenceViewer | undefined,
+  next: PresenceViewer | undefined,
+  characterId: number,
+): Map<number, PresenceViewer[]> {
+  const out = new Map(bySystem);
+  const touched = new Set<number>();
+  if (prev?.eveSystemId != null) touched.add(prev.eveSystemId);
+  if (next?.eveSystemId != null) touched.add(next.eveSystemId);
+  for (const sysId of touched) {
+    const arr = (bySystem.get(sysId) ?? []).filter((x) => x.characterId !== characterId);
+    if (next?.eveSystemId === sysId) arr.push(next);
+    if (arr.length) out.set(sysId, arr);
+    else out.delete(sysId);
+  }
+  return out;
+}
+
 export const usePresenceStore = create<PresenceState>((set) => ({
   viewers: {},
-  snapshot: (list) => set({ viewers: Object.fromEntries(list.map((v) => [v.characterId, v])) }),
-  upsert:   (v) => set((s) => ({ viewers: { ...s.viewers, [v.characterId]: v } })),
-  remove:   (characterId) => set((s) => {
-    if (!(characterId in s.viewers)) return s;
+  bySystem: new Map(),
+  snapshot: (list) => {
+    const viewers: Record<number, PresenceViewer> = Object.fromEntries(list.map((v) => [v.characterId, v]));
+    set({ viewers, bySystem: indexBySystem(viewers) });
+  },
+  upsert: (v) => set((s) => ({
+    viewers:  { ...s.viewers, [v.characterId]: v },
+    bySystem: withViewer(s.bySystem, s.viewers[v.characterId], v, v.characterId),
+  })),
+  remove: (characterId) => set((s) => {
+    const prev = s.viewers[characterId];
+    if (!prev) return s;
     const next = { ...s.viewers };
     delete next[characterId];
-    return { viewers: next };
+    return { viewers: next, bySystem: withViewer(s.bySystem, prev, undefined, characterId) };
   }),
-  reset: () => set({ viewers: {} }),
+  reset: () => set({ viewers: {}, bySystem: new Map() }),
 }));

--- a/web/src/utils/whDest.ts
+++ b/web/src/utils/whDest.ts
@@ -46,8 +46,11 @@ export function isUnresolvedLeadsTo(value: string | null | undefined): boolean {
 }
 
 // J-space "band" leads-to values (an unscanned hole reports a band, not an exact
-// class) with display label + colour — mirrors the LeadsToDropdown options.
-const LEADS_TO_BANDS: Record<string, { label: string; color: string }> = {
+// class) with display label + colour. Single source — the LeadsToDropdown picker
+// builds its band options from this map, and holeDisplay resolves stored band
+// values through it. Insertion order is the picker's display order. Each band is
+// coloured by its worst class so the threat reads green -> orange -> red.
+export const LEADS_TO_BANDS: Record<string, { label: string; color: string }> = {
   'C1-C3': { label: 'C1 - C3', color: CLASS_COLORS.C3 },
   'C4-C5': { label: 'C4 - C5', color: CLASS_COLORS.C5 },
 };


### PR DESCRIPTION
Promotes the staged qa work to release. All six PRs below were reviewed and merged into qa; release already has the v2.9.4 jump-race hotfix, so this is purely qa's additional work flowing up.

## Frontend performance (map re-render fan-out)
- **#440 — Batch A:** memoized `matchSystem`/`systemMatchesContent` in SystemNode; shared id-Sets from `useA0Systems`/`useShatteredSystems`; rAF-coalesced uniform-max recompute (O(N²)→O(N)); narrowed SignaturePane to `map.systems`/`map.connections` slices.
- **#441 — Batch B:** keyed per-system presence subscription (a viewer moving only re-renders the two affected nodes); equality gates on the polled hooks (`useAccountLocations`, `useFleet`, `useCurrentHourKills`, `useScoutConnections`) so identical polls stop re-rendering every node.
- **#442 — Batch C:** stabilized MapCanvas node `data` refs (per-id reuse), split the edges memo so hover only rebuilds touched edges, and precompute drag connections/positions at drag-start.

## DRY / dead-code
- **#443:** single-sourced the `hours+mins` math (`splitHoursMinutes`/`hoursMins` in `i18n/format.ts`), SharedMapView → `expiresIn`, J-space band table from `whDest.ts`, DemoMap → `whDestClass()`.

## Infra / ops
- **#438 — QA environment:** parameterized the Traefik service/router names with `${STACK:-eve-nexum}` (defaults to `eve-nexum`, so **production is unaffected**), `.env.example` additions, and the `QA-SETUP.md` runbook.
- **#439 — backup/restore fix:** `backup-db.sh` / `restore-db.sh` stopped sourcing `.env` as shell (`. ./.env` was executing the dotenv file and crashing the cron); replaced with a grep-based `read_env()` parser.

## Notes for review
- No behaviour change in the perf/DRY work — all verified with `tsc -b` + eslint + `yarn build` on qa.
- ⚠️ `docker-compose.traefik.yml` changes production deploy config. The parameterization defaults to the existing `eve-nexum` names, but confirm the live `.env` before the next deploy (deploy still needs both compose files).
- i18n: no new user-facing keys were added.