### PR TITLE
Access-control Phase 3: standings auto-admit ("friends") toggle

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -801,6 +801,16 @@ export async function migrate() {
       UNIQUE (kind, eve_id)
     );
     CREATE INDEX IF NOT EXISTS idx_access_grants_lookup ON access_grants (kind, eve_id);
+
+    -- Deployment-level key/value settings (distinct from per-user ui_settings).
+    -- Phase 3 uses standings_login_enabled ('true'|'false') and
+    -- standings_login_threshold ('5'|'10') for the standings auto-admit toggle.
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key             TEXT        PRIMARY KEY,
+      value           TEXT        NOT NULL,
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_by_user INTEGER     REFERENCES users(id) ON DELETE SET NULL
+    );
   `);
 
   await encryptLegacyTokens();

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -16,6 +16,10 @@ import {
   isLoginPermitted, standingPermitsTarget, grantKindAllowedForInstall,
   requiresPositiveStanding, type GrantKind,
 } from '../services/accessGrants.js';
+import {
+  getStandingsLoginSettings, setSetting,
+  STANDINGS_LOGIN_ENABLED, STANDINGS_LOGIN_THRESHOLD,
+} from '../services/appSettings.js';
 
 const log = createLogger('admin');
 
@@ -477,6 +481,30 @@ adminRouter.delete('/access-grants/:id', async (req, res) => {
     if (!stillOk) killed += await invalidateSessionsForUser(u.id);
   }
   res.json({ ok: true, sessionsKilled: killed });
+});
+
+// ── Standings auto-admit ("friends") settings — Phase 3 ──────────────────────
+
+// GET /api/admin/access-settings — current standings auto-admit toggle + level.
+adminRouter.get('/access-settings', async (_req, res) => {
+  const s = await getStandingsLoginSettings();
+  res.json({ standingsLoginEnabled: s.enabled, standingsLoginThreshold: s.threshold });
+});
+
+// PATCH /api/admin/access-settings — update the standings auto-admit settings.
+adminRouter.patch('/access-settings', async (req, res) => {
+  const { enabled, threshold } = req.body as { enabled?: unknown; threshold?: unknown };
+  if (enabled !== undefined) {
+    if (typeof enabled !== 'boolean') { res.status(400).json({ error: 'enabled must be a boolean' }); return; }
+    await setSetting(STANDINGS_LOGIN_ENABLED, enabled ? 'true' : 'false', req.session.userId ?? null);
+  }
+  if (threshold !== undefined) {
+    if (threshold !== 5 && threshold !== 10) { res.status(400).json({ error: 'threshold must be 5 or 10' }); return; }
+    await setSetting(STANDINGS_LOGIN_THRESHOLD, String(threshold), req.session.userId ?? null);
+  }
+  await audit(req, null, null, 'access_settings_update', null, JSON.stringify({ enabled, threshold }));
+  const s = await getStandingsLoginSettings();
+  res.json({ standingsLoginEnabled: s.enabled, standingsLoginThreshold: s.threshold });
 });
 
 // GET /api/admin/maps — every corp map in the system with owner + stats.

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -6,7 +6,7 @@ import { encryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
 import { esiFetch } from '../utils/esi.js';
 import { refreshStandingsForUser } from '../services/standings.js';
-import { isLoginPermitted } from '../services/accessGrants.js';
+import { isLoginPermitted, standingsPermitLogin } from '../services/accessGrants.js';
 import { seedDemoMap } from '../services/demoMap.js';
 
 const log = createLogger('auth');
@@ -180,9 +180,11 @@ authRouter.get('/callback', async (req, res) => {
         // and extended live from the admin area, so a friendly corp can be
         // admitted without editing .env. See access-control-design.md.
         if (config.restrictedMode) {
-          const permitted = await isLoginPermitted({
-            characterId: characterId, corpId: userCorpId, allianceId: userAllianceId,
-          });
+          const ids = { characterId, corpId: userCorpId, allianceId: userAllianceId };
+          // Admitted by an explicit allow-list grant, OR (Phase 3) by the
+          // standings auto-admit when it's enabled and the pilot is stood at or
+          // above the configured friendly threshold.
+          const permitted = await isLoginPermitted(ids) || await standingsPermitLogin(ids);
           if (!permitted) {
             res.redirect(failUrl('not_in_corp'));
             return;

--- a/server/src/services/accessGrants.test.ts
+++ b/server/src/services/accessGrants.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock config + db so we can drive the install-type / positive-standing decision
 // logic without a database. hoisted so the mock factories (which run before the
 // module import below) can close over them.
-const { mockConfig, queryMock } = vi.hoisted(() => ({
+const { mockConfig, queryMock, mockSettings } = vi.hoisted(() => ({
   mockConfig: {
     corpMode: true,
     allianceMode: false,
@@ -11,14 +11,18 @@ const { mockConfig, queryMock } = vi.hoisted(() => ({
     allianceIds: [1354830081] as number[],
   },
   queryMock: vi.fn(),
+  mockSettings: { enabled: false, threshold: 10 as 5 | 10 },
 }));
 
 vi.mock('../config.js', () => ({ config: mockConfig }));
 vi.mock('../db.js', () => ({ db: { query: queryMock } }));
+vi.mock('./appSettings.js', () => ({
+  getStandingsLoginSettings: async () => ({ enabled: mockSettings.enabled, threshold: mockSettings.threshold }),
+}));
 
 // vi.mock calls above are hoisted by vitest, so this static import already sees
 // the mocked config/db.
-import { isLoginPermitted, standingPermitsTarget, grantKindAllowedForInstall, requiresPositiveStanding } from './accessGrants.js';
+import { isLoginPermitted, standingPermitsTarget, grantKindAllowedForInstall, requiresPositiveStanding, standingsPermitLogin } from './accessGrants.js';
 
 const rows = (ok: boolean) => ({ rows: [{ ok }] });
 
@@ -28,6 +32,8 @@ beforeEach(() => {
   mockConfig.allianceMode = false;
   mockConfig.corpIds = [98120330];
   mockConfig.allianceIds = [1354830081];
+  mockSettings.enabled = false;
+  mockSettings.threshold = 10;
 });
 
 describe('grantKindAllowedForInstall', () => {
@@ -107,6 +113,52 @@ describe('standingPermitsTarget', () => {
   it('fail-closed: an empty result set denies', async () => {
     queryMock.mockResolvedValue({ rows: [] });
     expect(await standingPermitsTarget('corp', 999)).toBe(false);
+  });
+});
+
+describe('standingsPermitLogin', () => {
+  const pilot = { characterId: 1841929906, corpId: 98370861, allianceId: 99000001 };
+
+  it('returns false (without querying) when the toggle is off', async () => {
+    mockSettings.enabled = false;
+    expect(await standingsPermitLogin(pilot)).toBe(false);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('alliance install: reads alliance_standings with the threshold + all three contact kinds', async () => {
+    mockConfig.allianceMode = true;
+    mockSettings.enabled = true;
+    mockSettings.threshold = 10;
+    queryMock.mockResolvedValue({ rows: [{ ok: true }] });
+    expect(await standingsPermitLogin(pilot)).toBe(true);
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('alliance_standings');
+    expect(sql).not.toContain('corp_standings');
+    expect(params[0]).toEqual(mockConfig.allianceIds);
+    expect(params[1]).toBe(10);                 // threshold
+    expect(params[2]).toBe(pilot.allianceId);   // alliance match
+    expect(params[3]).toBe(pilot.corpId);       // corp match
+    expect(params[4]).toBe(pilot.characterId);  // character match
+  });
+
+  it('corp install: reads corp_standings only (alliance ignored), corp+char match', async () => {
+    mockSettings.enabled = true;
+    mockSettings.threshold = 5;
+    queryMock.mockResolvedValue({ rows: [{ ok: false }] });
+    expect(await standingsPermitLogin(pilot)).toBe(false);
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('corp_standings');
+    expect(sql).not.toContain('alliance_standings');
+    expect(params[0]).toEqual(mockConfig.corpIds);
+    expect(params[1]).toBe(5);
+    expect(params[2]).toBe(pilot.corpId);
+    expect(params[3]).toBe(pilot.characterId);
+  });
+
+  it('fail-closed: an empty result set denies', async () => {
+    mockSettings.enabled = true;
+    queryMock.mockResolvedValue({ rows: [] });
+    expect(await standingsPermitLogin(pilot)).toBe(false);
   });
 });
 

--- a/server/src/services/accessGrants.ts
+++ b/server/src/services/accessGrants.ts
@@ -4,6 +4,7 @@
 // positive-standing prerequisite from access-control-design.md section 4.0.
 import { db } from '../db.js';
 import { config } from '../config.js';
+import { getStandingsLoginSettings } from './appSettings.js';
 
 export type GrantKind = 'corp' | 'alliance' | 'character';
 
@@ -76,6 +77,52 @@ export async function standingPermitsTarget(kind: GrantKind, eveId: number): Pro
 export function grantKindAllowedForInstall(kind: GrantKind): boolean {
   if (kind === 'alliance') return config.allianceMode;
   return true;
+}
+
+// Standings auto-admit ("friends") — Phase 3. Admin-toggleable, OFF by default.
+// When on, a pilot may log in if the DEPLOYMENT holds them at standing >= the
+// admin-chosen threshold (5 or 10), even without an explicit access_grants row.
+// Install-type decides the source (per design):
+//   - Alliance install: the deployment ALLIANCE's contacts only; match the
+//     pilot's alliance, then corp, then character. Corp standings are ignored.
+//   - Corp install: the deployment CORP's contacts only; match the pilot's corp,
+//     then character. Alliance standings are ignored entirely.
+// POSITIVE-ONLY: signed `standing >= threshold` (threshold is 5 or 10), never
+// magnitude/abs. Fail-closed: disabled, or no matching contact, returns false.
+export async function standingsPermitLogin(p: {
+  characterId: number;
+  corpId:      number | null;
+  allianceId:  number | null;
+}): Promise<boolean> {
+  const { enabled, threshold } = await getStandingsLoginSettings();
+  if (!enabled) return false;
+
+  if (config.allianceMode) {
+    const { rows } = await db.query<{ ok: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM alliance_standings
+          WHERE alliance_id = ANY($1::bigint[])
+            AND standing >= $2
+            AND ( (contact_kind = 'alliance'    AND contact_id = $3)
+               OR (contact_kind = 'corporation' AND contact_id = $4)
+               OR (contact_kind = 'character'   AND contact_id = $5) )
+       ) AS ok`,
+      [config.allianceIds, threshold, p.allianceId, p.corpId, p.characterId],
+    );
+    return rows[0]?.ok ?? false;
+  }
+
+  const { rows } = await db.query<{ ok: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM corp_standings
+        WHERE corp_id = ANY($1::bigint[])
+          AND standing >= $2
+          AND ( (contact_kind = 'corporation' AND contact_id = $3)
+             OR (contact_kind = 'character'   AND contact_id = $4) )
+     ) AS ok`,
+    [config.corpIds, threshold, p.corpId, p.characterId],
+  );
+  return rows[0]?.ok ?? false;
 }
 
 // The positive-standing prerequisite (design 4.0) applies to GROUP targets

--- a/server/src/services/appSettings.ts
+++ b/server/src/services/appSettings.ts
@@ -1,0 +1,43 @@
+// Deployment-level key/value settings (app_settings table). Distinct from the
+// per-user ui_settings blob — these are instance-wide and admin-managed.
+import { db } from '../db.js';
+
+export async function getSetting(key: string): Promise<string | null> {
+  const { rows } = await db.query<{ value: string }>(
+    `SELECT value FROM app_settings WHERE key = $1`,
+    [key],
+  );
+  return rows[0]?.value ?? null;
+}
+
+export async function setSetting(key: string, value: string, userId: number | null): Promise<void> {
+  await db.query(
+    `INSERT INTO app_settings (key, value, updated_at, updated_by_user)
+     VALUES ($1, $2, NOW(), $3)
+     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW(), updated_by_user = EXCLUDED.updated_by_user`,
+    [key, value, userId],
+  );
+}
+
+// ── Standings auto-admit ("friends") settings — Phase 3 ──────────────────────
+export const STANDINGS_LOGIN_ENABLED   = 'standings_login_enabled';
+export const STANDINGS_LOGIN_THRESHOLD = 'standings_login_threshold';
+
+// Only the two in-game friendly levels are valid thresholds (design 4.0). Off by
+// default; a threshold of 10 (stricter) is the default when none is stored.
+export type StandingsThreshold = 5 | 10;
+export interface StandingsLoginSettings {
+  enabled:   boolean;
+  threshold: StandingsThreshold;
+}
+
+export async function getStandingsLoginSettings(): Promise<StandingsLoginSettings> {
+  const [enabledRaw, thresholdRaw] = await Promise.all([
+    getSetting(STANDINGS_LOGIN_ENABLED),
+    getSetting(STANDINGS_LOGIN_THRESHOLD),
+  ]);
+  return {
+    enabled:   enabledRaw === 'true',
+    threshold: thresholdRaw === '5' ? 5 : 10,
+  };
+}


### PR DESCRIPTION
Phase 3 of the access-control redesign — the standings auto-admit, which automates what you currently do by hand (bless a corp/alliance in-game, then let them in). **Admin-toggleable, OFF by default**, so existing deployments are unchanged.

## Backend
- **`app_settings`** key/value table (deployment-level settings) + `appSettings` service (`getStandingsLoginSettings()`, `standings_login_enabled` / `standings_login_threshold`).
- **`standingsPermitLogin()`** — install-type aware: alliance install reads `alliance_standings` matching the pilot's alliance→corp→character; corp install reads `corp_standings` matching corp→character (alliance ignored). **Positive-only** signed `standing >= threshold` (5 or 10), never abs. **Fail-closed** when disabled or no matching contact.
- **Login gate:** `permitted = isLoginPermitted() OR standingsPermitLogin()`.
- **`GET/PATCH /api/admin/access-settings`** (threshold constrained to 5/10, audited).

## Frontend
- Access tab: **"Auto-admit friends by standing"** toggle + (when on) a **+10 only / +5 and above** minimum-level choice, saved via the settings endpoint.
- i18n across all 9 locales (parity checked), README updated.

## Verification
- server `tsc` clean, **19 tests pass** (+4 for `standingsPermitLogin`: off, alliance/corp source + params, fail-closed).
- web `tsc -b` + `yarn build` clean; eslint 0 errors.

## Notes
- Requires the deployment's corp/alliance contacts to be **synced** (the existing Sync-standings button) — a director-role character has to have done it, else the gate admits nobody (fail-closed, by design).
- Off by default; turning it off reverts to the explicit allow-list.

This completes the three-phase access-control redesign (Phase 1 #447, Phase 2 #448, Phase 3 here).