### PR TITLE
Stop fetching personal contacts — corp/alliance standings only

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -30,11 +30,13 @@ const SSO_SCOPES = [
   'esi-ui.write_waypoint.v1',
   'esi-characters.read_corporation_roles.v1',
   'esi-location.read_online.v1',
-  // Read player standings (contacts) so the UI can colour-tag structures /
-  // killboard / sov by your standing toward each entity. Corp / alliance reads
-  // only succeed for characters with the Contact Manager role; reads gracefully
-  // no-op otherwise.
-  'esi-characters.read_contacts.v1',
+  // Read CORP / ALLIANCE standings (contacts) so the UI can colour-tag
+  // structures / killboard / sov by the org's standing toward each entity, and
+  // so standings-based access can be gated on the deployment's own contacts. We
+  // deliberately do NOT request esi-characters.read_contacts.v1 — this is a
+  // corp/alliance tool; a single pilot's personal contacts must never drive
+  // org-wide standings. Corp / alliance reads only succeed for characters with
+  // the Contact Manager role; reads gracefully no-op otherwise.
   'esi-corporations.read_contacts.v1',
   'esi-alliances.read_contacts.v1',
   // Fleet member tracking — show fleet-mate locations on the map as purple

--- a/server/src/routes/standings.ts
+++ b/server/src/routes/standings.ts
@@ -12,14 +12,14 @@ standingsRouter.use(requireAuth);
 
 type ContactKind = 'character' | 'corporation' | 'alliance' | 'faction';
 
-// GET /api/standings/me — returns the three standings buckets visible to
-// the logged-in character: their personal contacts, their corp's contacts
-// (if a corp Contact Manager has ever logged in), and their alliance's
-// contacts (likewise). Maps are keyed `"<kind>:<id>"` for fast lookup on
-// the client.
+// GET /api/standings/me — returns the standings buckets visible to the
+// logged-in character: their corp's contacts (if a corp Contact Manager has
+// ever logged in) and their alliance's contacts (likewise). Personal contacts
+// are deliberately not read — this is a corp/alliance tool. Maps are keyed
+// `"<kind>:<id>"` for fast lookup on the client.
 //
 // The frontend's useStandings hook compresses these into a single
-// "effective standing" per target — most negative across the three.
+// "effective standing" per target — most negative across the buckets.
 standingsRouter.get('/me', async (req, res) => {
   const userId = req.session.userId!;
 
@@ -30,12 +30,7 @@ standingsRouter.get('/me', async (req, res) => {
   if (!userRows.length) { res.status(404).json({ error: 'User not found' }); return; }
   const { character_id, corp_id, alliance_id } = userRows[0];
 
-  const [charRows, corpRows, allianceRows, refreshRows] = await Promise.all([
-    db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
-      `SELECT contact_kind, contact_id, standing
-       FROM character_standings WHERE character_id = $1`,
-      [character_id],
-    ),
+  const [corpRows, allianceRows, refreshRows] = await Promise.all([
     corp_id !== null
       ? db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
           `SELECT contact_kind, contact_id, standing
@@ -52,10 +47,9 @@ standingsRouter.get('/me', async (req, res) => {
       : Promise.resolve({ rows: [] as Array<{ contact_kind: ContactKind; contact_id: number; standing: number }> }),
     db.query<{ owner_kind: string; last_fetched_at: string }>(
       `SELECT owner_kind, last_fetched_at FROM standings_refresh
-       WHERE (owner_kind = 'character' AND owner_id = $1)
-          OR (owner_kind = 'corp'      AND owner_id = $2)
-          OR (owner_kind = 'alliance'  AND owner_id = $3)`,
-      [character_id, corp_id ?? 0, alliance_id ?? 0],
+       WHERE (owner_kind = 'corp'     AND owner_id = $1)
+          OR (owner_kind = 'alliance' AND owner_id = $2)`,
+      [corp_id ?? 0, alliance_id ?? 0],
     ),
   ]);
 
@@ -72,7 +66,6 @@ standingsRouter.get('/me', async (req, res) => {
     characterId: character_id,
     corpId:      corp_id,
     allianceId:  alliance_id,
-    character:   toMap(charRows.rows),
     corp:        toMap(corpRows.rows),
     alliance:    toMap(allianceRows.rows),
     refreshedAt,
@@ -102,10 +95,9 @@ standingsRouter.post('/refresh', async (req, res) => {
   // Clear the throttle row(s) so refreshStandingsForUser doesn't skip.
   await db.query(
     `DELETE FROM standings_refresh
-     WHERE (owner_kind = 'character' AND owner_id = $1)
-        OR (owner_kind = 'corp'      AND owner_id = $2)
-        OR (owner_kind = 'alliance'  AND owner_id = $3)`,
-    [character_id, corp_id ?? 0, alliance_id ?? 0],
+     WHERE (owner_kind = 'corp'     AND owner_id = $1)
+        OR (owner_kind = 'alliance' AND owner_id = $2)`,
+    [corp_id ?? 0, alliance_id ?? 0],
   );
 
   let token: string;
@@ -131,8 +123,7 @@ standingsRouter.post('/refresh', async (req, res) => {
   }
 
   // Read back what was actually stored so the client can see the result.
-  const [charCnt, corpCnt, allianceCnt, refreshRows] = await Promise.all([
-    db.query<{ count: number }>(`SELECT COUNT(*)::int AS count FROM character_standings WHERE character_id = $1`, [character_id]),
+  const [corpCnt, allianceCnt, refreshRows] = await Promise.all([
     corp_id !== null
       ? db.query<{ count: number }>(`SELECT COUNT(*)::int AS count FROM corp_standings WHERE corp_id = $1`, [corp_id])
       : Promise.resolve({ rows: [{ count: 0 }] }),
@@ -141,10 +132,9 @@ standingsRouter.post('/refresh', async (req, res) => {
       : Promise.resolve({ rows: [{ count: 0 }] }),
     db.query<{ owner_kind: string; last_fetched_at: string }>(
       `SELECT owner_kind, last_fetched_at FROM standings_refresh
-       WHERE (owner_kind = 'character' AND owner_id = $1)
-          OR (owner_kind = 'corp'      AND owner_id = $2)
-          OR (owner_kind = 'alliance'  AND owner_id = $3)`,
-      [character_id, corp_id ?? 0, alliance_id ?? 0],
+       WHERE (owner_kind = 'corp'     AND owner_id = $1)
+          OR (owner_kind = 'alliance' AND owner_id = $2)`,
+      [corp_id ?? 0, alliance_id ?? 0],
     ),
   ]);
 
@@ -154,7 +144,6 @@ standingsRouter.post('/refresh', async (req, res) => {
   res.json({
     ok: true,
     counts: {
-      character: charCnt.rows[0]?.count ?? 0,
       corp:      corpCnt.rows[0]?.count ?? 0,
       alliance:  allianceCnt.rows[0]?.count ?? 0,
     },
@@ -163,9 +152,8 @@ standingsRouter.post('/refresh', async (req, res) => {
     // ESI call returned 403 (missing scope or role). Helps the client tell
     // "you have no contacts" from "your token doesn't carry the scope".
     succeeded: {
-      character: 'character' in refreshedAt,
-      corp:      'corp'      in refreshedAt,
-      alliance:  'alliance'  in refreshedAt,
+      corp:      'corp'     in refreshedAt,
+      alliance:  'alliance' in refreshedAt,
     },
   });
 });

--- a/server/src/services/standings.ts
+++ b/server/src/services/standings.ts
@@ -58,8 +58,8 @@ async function markRefreshed(ownerKind: string, ownerId: number) {
 }
 
 async function replaceStandings(
-  table: 'character_standings' | 'corp_standings' | 'alliance_standings',
-  ownerCol: 'character_id' | 'corp_id' | 'alliance_id',
+  table: 'corp_standings' | 'alliance_standings',
+  ownerCol: 'corp_id' | 'alliance_id',
   ownerId: number,
   contacts: EsiContact[],
   actorUserId: number | null,
@@ -73,21 +73,12 @@ async function replaceStandings(
       const kinds   = contacts.map((c) => c.contact_type);
       const ids     = contacts.map((c) => c.contact_id);
       const values  = contacts.map((c) => c.standing);
-      if (table === 'character_standings') {
-        await client.query(
-          `INSERT INTO ${table} (${ownerCol}, contact_kind, contact_id, standing)
-           SELECT $1, k, i, v
-           FROM UNNEST($2::text[], $3::int[], $4::real[]) AS t(k, i, v)`,
-          [ownerId, kinds, ids, values],
-        );
-      } else {
-        await client.query(
-          `INSERT INTO ${table} (${ownerCol}, contact_kind, contact_id, standing, updated_by_user_id)
-           SELECT $1, k, i, v, $5
-           FROM UNNEST($2::text[], $3::int[], $4::real[]) AS t(k, i, v)`,
-          [ownerId, kinds, ids, values, actorUserId],
-        );
-      }
+      await client.query(
+        `INSERT INTO ${table} (${ownerCol}, contact_kind, contact_id, standing, updated_by_user_id)
+         SELECT $1, k, i, v, $5
+         FROM UNNEST($2::text[], $3::int[], $4::real[]) AS t(k, i, v)`,
+        [ownerId, kinds, ids, values, actorUserId],
+      );
     }
     await client.query('COMMIT');
   } catch (err) {
@@ -98,10 +89,12 @@ async function replaceStandings(
   }
 }
 
-// Fire-and-forget standings refresh on login. Pulls personal, corp, and
-// alliance contacts in parallel; gracefully no-ops the corp/alliance reads
-// when the character lacks the Contact Manager role. Never throws — every
-// failure is logged so a transient ESI hiccup doesn't break login.
+// Fire-and-forget standings refresh on login. Pulls CORP and ALLIANCE contacts
+// in parallel; gracefully no-ops each read when the character lacks the Contact
+// Manager / executor role. Personal (character) contacts are deliberately NOT
+// fetched — this is a corp/alliance tool and we don't request the personal
+// read_contacts scope. Never throws — every failure is logged so a transient
+// ESI hiccup doesn't break login.
 export async function refreshStandingsForUser(params: {
   userId:      number;
   characterId: number;
@@ -112,23 +105,6 @@ export async function refreshStandingsForUser(params: {
   const { userId, characterId, corpId, allianceId, accessToken } = params;
 
   const tasks: Promise<void>[] = [];
-
-  // Personal — always available with the read_contacts scope.
-  if (await shouldRefresh('character', characterId)) {
-    tasks.push((async () => {
-      const r = await fetchAllContacts(
-        `https://esi.evetech.net/v2/characters/${characterId}/contacts/`,
-        accessToken,
-      );
-      if (Array.isArray(r)) {
-        log.info(`character ${characterId}: fetched ${r.length} personal contacts`);
-        await replaceStandings('character_standings', 'character_id', characterId, r, userId);
-        await markRefreshed('character', characterId);
-      } else {
-        log.info(`character ${characterId}: personal contacts fetch returned ${r.status} (${r.error}) — likely missing esi-characters.read_contacts.v1 scope`);
-      }
-    })().catch((err) => log.error('character standings fetch errored:', err)));
-  }
 
   // Corp — requires the Contact Manager role; 403 is the common case.
   if (corpId !== null && await shouldRefresh('corp', corpId)) {

--- a/web/src/components/ui/SystemPanel.tsx
+++ b/web/src/components/ui/SystemPanel.tsx
@@ -781,10 +781,9 @@ function StandingsRefreshButton({ standings }: { standings: ReturnType<typeof us
   async function onClick() {
     const r = await standings.refresh();
     if (!r) { setStatus('err'); }
-    else if (r.succeeded?.character || r.succeeded?.corp || r.succeeded?.alliance) {
+    else if (r.succeeded?.corp || r.succeeded?.alliance) {
       toast.success(
         t('systemPanel.standingsRefreshed', {
-          personal: r.counts?.character ?? 0,
           corp: r.counts?.corp ?? 0,
           alliance: r.counts?.alliance ?? 0,
         })
@@ -811,10 +810,10 @@ function StandingsRefreshButton({ standings }: { standings: ReturnType<typeof us
   );
 }
 
-// Inline standings strip next to a sov holder row. Renders up to three
-// compact pills — Personal / Corp / Alliance — only for buckets that
-// actually have a contact for this entity. Colour-coded against in-game
-// blue (≥5) / red (≤-5) thresholds with a softer tier inside that range.
+// Inline standings strip next to a sov holder row. Renders up to two
+// compact pills — Corp / Alliance — only for buckets that actually have a
+// contact for this entity. Colour-coded against in-game blue (≥5) / red
+// (≤-5) thresholds with a softer tier inside that range.
 function StandingsBadges({
   standings,
   kind,
@@ -847,7 +846,6 @@ function StandingsBadges({
   // Buckets the user isn't a member of (no corp / no alliance) just show
   // "—" with the "none" colour tier.
   const entries: Array<{ label: string; value: number | null; hasBucket: boolean }> = [
-    { label: 'P', value: lookup.character, hasBucket: true },
     { label: 'C', value: lookup.corp,      hasBucket: !!standings.self?.corpId     },
     { label: 'A', value: lookup.alliance,  hasBucket: !!standings.self?.allianceId },
   ];
@@ -880,7 +878,6 @@ function StandingsBadges({
 
 function labelFor(t: TFunction, short: string): string {
   switch (short) {
-    case 'P': return t('systemPanel.personal');
     case 'C': return t('systemPanel.corp');
     case 'A': return t('systemPanel.alliance');
     default:  return short;

--- a/web/src/hooks/useStandings.ts
+++ b/web/src/hooks/useStandings.ts
@@ -5,10 +5,9 @@ import { useShareMode } from '../context/ShareModeContext';
 export type ContactKind = 'character' | 'corporation' | 'alliance' | 'faction';
 
 export interface StandingsLookup {
-  character: number | null;
   corp:      number | null;
   alliance:  number | null;
-  effective: number;   // most negative non-null across the three, 0 if none
+  effective: number;   // most negative non-null across the buckets, 0 if none
   isHostile:  boolean; // effective < -5 — red "terrible" band (-10 territory)
   isFriendly: boolean; // effective >  5 — dark-blue "excellent" band (+10 territory)
   isNeutral:  boolean; // not hostile and not friendly
@@ -18,7 +17,6 @@ interface StandingsResponse {
   characterId: number;
   corpId:      number | null;
   allianceId:  number | null;
-  character:   Record<string, number>;
   corp:        Record<string, number>;
   alliance:    Record<string, number>;
 }
@@ -55,8 +53,8 @@ async function load() {
 // refresh result so callers can show "X new contacts" or similar.
 async function refreshFromEsi(): Promise<{
   ok: boolean;
-  counts?:    { character: number; corp: number; alliance: number };
-  succeeded?: { character: boolean; corp: boolean; alliance: boolean };
+  counts?:    { corp: number; alliance: number };
+  succeeded?: { corp: boolean; alliance: boolean };
 } | null> {
   if (refreshing) return null;
   refreshing = true;
@@ -64,8 +62,8 @@ async function refreshFromEsi(): Promise<{
   try {
     const result = await api<{
       ok: boolean;
-      counts:    { character: number; corp: number; alliance: number };
-      succeeded: { character: boolean; corp: boolean; alliance: boolean };
+      counts:    { corp: number; alliance: number };
+      succeeded: { corp: boolean; alliance: boolean };
     }>('/api/standings/refresh', { method: 'POST' });
     // Force a re-pull of the GET endpoint so the cache reflects the
     // freshly-written DB rows.
@@ -82,7 +80,7 @@ async function refreshFromEsi(): Promise<{
 }
 
 const EMPTY: StandingsLookup = {
-  character: null, corp: null, alliance: null,
+  corp: null, alliance: null,
   effective: 0, isHostile: false, isFriendly: false, isNeutral: true,
 };
 
@@ -109,14 +107,13 @@ export function useStandings() {
   const getStanding = useCallback((kind: ContactKind, id: number): StandingsLookup => {
     if (!cache) return EMPTY;
     const key = `${kind}:${id}`;
-    const character = cache.character[key] ?? null;
     const corp      = cache.corp[key]      ?? null;
     const alliance  = cache.alliance[key]  ?? null;
 
-    const values = [character, corp, alliance].filter((v): v is number => v !== null);
+    const values = [corp, alliance].filter((v): v is number => v !== null);
     const effective = values.length ? Math.min(...values) : 0;
     return {
-      character, corp, alliance, effective,
+      corp, alliance, effective,
       isHostile:  effective < -5,
       isFriendly: effective >  5,
       isNeutral:  effective >= -5 && effective <= 5,

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -894,7 +894,7 @@
     "faction": "Fraktion",
     "personal": "Persönlich",
     "refreshStandings": "Standings jetzt von ESI aktualisieren (umgeht die 6h-TTL)",
-    "standingsRefreshed": "Standings aktualisiert — {{personal}} persönlich · {{corp}} Corp · {{alliance}} Allianz-Kontakte",
+    "standingsRefreshed": "Standings aktualisiert — {{corp}} Corp · {{alliance}} Allianz-Kontakte",
     "noContactsRefreshed": "Es konnten keine Kontakte aktualisiert werden. Dem Token fehlt möglicherweise der read_contacts-Scope — melde dich ab und wieder an.",
     "standingsNotLoaded": "Standings noch nicht geladen. Wenn dies bestehen bleibt, melde dich ab und wieder an, um die read_contacts-Scopes zu gewähren.",
     "standingNotInBucket": "{{label}}: du bist in keiner",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -947,7 +947,7 @@
     "faction": "Faction",
     "personal": "Personal",
     "refreshStandings": "Refresh standings from ESI now (bypasses the 6h TTL)",
-    "standingsRefreshed": "Standings refreshed — {{personal}} personal · {{corp}} corp · {{alliance}} alliance contacts",
+    "standingsRefreshed": "Standings refreshed — {{corp}} corp · {{alliance}} alliance contacts",
     "noContactsRefreshed": "No contacts could be refreshed. Token may be missing the read_contacts scope — log out and back in.",
     "standingsNotLoaded": "Standings not loaded yet. If this stays here, log out and back in to grant the read_contacts scopes.",
     "standingNotInBucket": "{{label}}: you are not in one",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -894,7 +894,7 @@
     "faction": "Facción",
     "personal": "Personal",
     "refreshStandings": "Actualizar standings desde la ESI ahora (omite el TTL de 6 h)",
-    "standingsRefreshed": "Standings actualizados — {{personal}} personales · {{corp}} corp · {{alliance}} contactos de alianza",
+    "standingsRefreshed": "Standings actualizados — {{corp}} corp · {{alliance}} contactos de alianza",
     "noContactsRefreshed": "No se pudo actualizar ningún contacto. Puede que al token le falte el scope read_contacts — cierra sesión y vuelve a entrar.",
     "standingsNotLoaded": "Standings aún no cargados. Si esto persiste, cierra sesión y vuelve a entrar para conceder los scopes read_contacts.",
     "standingNotInBucket": "{{label}}: no estás en ninguno",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -894,7 +894,7 @@
     "faction": "Faction",
     "personal": "Personnel",
     "refreshStandings": "Actualiser les standings depuis l'ESI maintenant (contourne le TTL de 6 h)",
-    "standingsRefreshed": "Standings actualisés — {{personal}} perso · {{corp}} corp · {{alliance}} contacts d'alliance",
+    "standingsRefreshed": "Standings actualisés — {{corp}} corp · {{alliance}} contacts d'alliance",
     "noContactsRefreshed": "Aucun contact n'a pu être actualisé. Le token n'a peut-être pas le scope read_contacts — déconnectez-vous et reconnectez-vous.",
     "standingsNotLoaded": "Standings pas encore chargés. Si cela persiste, déconnectez-vous et reconnectez-vous pour accorder les scopes read_contacts.",
     "standingNotInBucket": "{{label}} : vous n'êtes dans aucun",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -894,7 +894,7 @@
     "faction": "ファクション",
     "personal": "個人",
     "refreshStandings": "今すぐ ESI からスタンディングを更新（6時間 TTL を回避）",
-    "standingsRefreshed": "スタンディングを更新しました — 個人 {{personal}} · コーポ {{corp}} · アライアンス連絡先 {{alliance}}",
+    "standingsRefreshed": "スタンディングを更新しました — コーポ {{corp}} · アライアンス連絡先 {{alliance}}",
     "noContactsRefreshed": "連絡先を更新できませんでした。トークンに read_contacts スコープがない可能性があります — ログアウトして再ログインしてください。",
     "standingsNotLoaded": "スタンディングがまだ読み込まれていません。これが続く場合は、ログアウトして再ログインし read_contacts スコープを付与してください。",
     "standingNotInBucket": "{{label}}: どれにも属していません",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -894,7 +894,7 @@
     "faction": "팩션",
     "personal": "개인",
     "refreshStandings": "지금 ESI에서 스탠딩 새로 고침 (6시간 TTL 무시)",
-    "standingsRefreshed": "스탠딩 새로 고침됨 — 개인 {{personal}} · 군단 {{corp}} · 연합 연락처 {{alliance}}",
+    "standingsRefreshed": "스탠딩 새로 고침됨 — 군단 {{corp}} · 연합 연락처 {{alliance}}",
     "noContactsRefreshed": "연락처를 새로 고칠 수 없습니다. 토큰에 read_contacts 스코프가 없을 수 있습니다 — 로그아웃 후 다시 로그인하세요.",
     "standingsNotLoaded": "스탠딩이 아직 로드되지 않았습니다. 계속 이 상태라면, 로그아웃 후 다시 로그인하여 read_contacts 스코프를 부여하세요.",
     "standingNotInBucket": "{{label}}: 어느 쪽에도 속하지 않음",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -894,7 +894,7 @@
     "faction": "Facção",
     "personal": "Pessoal",
     "refreshStandings": "Atualizar standings da ESI agora (ignora o TTL de 6 h)",
-    "standingsRefreshed": "Standings atualizados — {{personal}} pessoais · {{corp}} corp · {{alliance}} contactos de aliança",
+    "standingsRefreshed": "Standings atualizados — {{corp}} corp · {{alliance}} contactos de aliança",
     "noContactsRefreshed": "Não foi possível atualizar nenhum contacto. O token pode não ter o scope read_contacts — termina a sessão e volta a entrar.",
     "standingsNotLoaded": "Standings ainda não carregados. Se isto persistir, termina a sessão e volta a entrar para conceder os scopes read_contacts.",
     "standingNotInBucket": "{{label}}: não estás em nenhum",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -920,7 +920,7 @@
     "faction": "Фракция",
     "personal": "Личные",
     "refreshStandings": "Обновить стендинги из ESI сейчас (минуя 6-часовой TTL)",
-    "standingsRefreshed": "Стендинги обновлены — {{personal}} личных · {{corp}} корп · {{alliance}} альянсовых контактов",
+    "standingsRefreshed": "Стендинги обновлены — {{corp}} корп · {{alliance}} альянсовых контактов",
     "noContactsRefreshed": "Не удалось обновить ни один контакт. Возможно, у токена нет области read_contacts — выйдите и войдите снова.",
     "standingsNotLoaded": "Стендинги ещё не загружены. Если это не исчезнет, выйдите и войдите снова, чтобы выдать области read_contacts.",
     "standingNotInBucket": "{{label}}: вы не в одной из них",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -894,7 +894,7 @@
     "faction": "势力",
     "personal": "个人",
     "refreshStandings": "立即从 ESI 刷新声望（绕过 6 小时 TTL）",
-    "standingsRefreshed": "声望已刷新 — {{personal}} 个人 · {{corp}} 军团 · {{alliance}} 联盟联系人",
+    "standingsRefreshed": "声望已刷新 — {{corp}} 军团 · {{alliance}} 联盟联系人",
     "noContactsRefreshed": "无法刷新任何联系人。令牌可能缺少 read_contacts 权限 — 请登出后重新登录。",
     "standingsNotLoaded": "声望尚未加载。如果一直如此，请登出后重新登录以授予 read_contacts 权限。",
     "standingNotInBucket": "{{label}}：你不属于任何一类",


### PR DESCRIPTION
Fixes the log noise you saw:
`[standings] character …: personal contacts fetch returned 401 … missing esi-characters.read_contacts.v1 scope`

nexum is a corp/alliance tool, so a single pilot's personal contacts should never
feed org-wide standings — neither the display nor the standings-based access gate
(which already only read corp/alliance). We now request and read ONLY
`esi-corporations.read_contacts.v1` + `esi-alliances.read_contacts.v1`.

## Changes
- **auth.ts** — dropped `esi-characters.read_contacts.v1` from the SSO scope set. New logins no longer ask for personal contacts; no forced re-auth for existing users.
- **standings service** — removed the personal contacts fetch; `replaceStandings` is corp/alliance only.
- **standings routes** — `GET /me` + `POST /refresh` no longer touch `character_standings` or return a `character` bucket/count.
- **frontend** — `useStandings` drops the character source (effective standing = min of corp + alliance); the SystemPanel standings strip now shows **C / A** pills only; refresh toast drops the personal count.
- **i18n** — `standingsRefreshed` updated across all 9 locales.

## Not changed
- `character_standings` table is left in place but unused — dropping a table on the live DB is riskier than an empty one. Say the word and I'll add a migration to drop it + its stale rows.

## Checks
- server `tsc` + `yarn test` (25) green; web `tsc -b` clean; all 9 locale JSONs valid.