### PR TITLE
Access-page standings sync: corp/alliance only (skip personal)

### DIFF
--- a/server/src/routes/standings.ts
+++ b/server/src/routes/standings.ts
@@ -84,8 +84,13 @@ standingsRouter.get('/me', async (req, res) => {
 // ESI calls succeeded (200), came back forbidden (403 — missing scope or
 // role), or failed otherwise. Useful both as a debug tool and as a
 // "refresh my standings now" button.
+//
+// Body { scope: 'org' } refreshes ONLY corp + alliance (skips personal) — used
+// by the access-page sync, which must never touch personal contacts. The
+// default ('all') refreshes personal too, for the system-info map tint.
 standingsRouter.post('/refresh', async (req, res) => {
   const userId = req.session.userId!;
+  const orgOnly = (req.body as { scope?: string } | undefined)?.scope === 'org';
 
   const { rows } = await db.query<{
     character_id: number;
@@ -99,13 +104,19 @@ standingsRouter.post('/refresh', async (req, res) => {
   if (!rows.length) { res.status(404).json({ error: 'User not found' }); return; }
   const { character_id, corp_id, alliance_id, access_token } = rows[0];
 
-  // Clear the throttle row(s) so refreshStandingsForUser doesn't skip.
+  // Clear the throttle row(s) so refreshStandingsForUser doesn't skip. An
+  // org-only sync leaves the personal throttle alone (it isn't refreshed).
+  if (!orgOnly) {
+    await db.query(
+      `DELETE FROM standings_refresh WHERE owner_kind = 'character' AND owner_id = $1`,
+      [character_id],
+    );
+  }
   await db.query(
     `DELETE FROM standings_refresh
-     WHERE (owner_kind = 'character' AND owner_id = $1)
-        OR (owner_kind = 'corp'      AND owner_id = $2)
-        OR (owner_kind = 'alliance'  AND owner_id = $3)`,
-    [character_id, corp_id ?? 0, alliance_id ?? 0],
+     WHERE (owner_kind = 'corp'     AND owner_id = $1)
+        OR (owner_kind = 'alliance' AND owner_id = $2)`,
+    [corp_id ?? 0, alliance_id ?? 0],
   );
 
   let token: string;
@@ -123,6 +134,7 @@ standingsRouter.post('/refresh', async (req, res) => {
       corpId:      corp_id,
       allianceId:  alliance_id,
       accessToken: token,
+      scope:       orgOnly ? 'org' : 'all',
     });
   } catch (err) {
     log.error('manual refresh failed:', err);

--- a/server/src/services/standings.ts
+++ b/server/src/services/standings.ts
@@ -102,19 +102,28 @@ async function replaceStandings(
 // alliance contacts in parallel; gracefully no-ops the corp/alliance reads
 // when the character lacks the Contact Manager role. Never throws — every
 // failure is logged so a transient ESI hiccup doesn't break login.
+//
+// scope: 'all' (default) refreshes all three buckets — used on login and by the
+// system-info "refresh standings" button that powers the map tint. scope: 'org'
+// refreshes ONLY corp + alliance and never touches personal contacts — used by
+// the access-page sync, since access control only ever reads corp/alliance
+// standings (so it must not request the personal endpoint at all).
 export async function refreshStandingsForUser(params: {
   userId:      number;
   characterId: number;
   corpId:      number | null;
   allianceId:  number | null;
   accessToken: string;
+  scope?:      'all' | 'org';
 }): Promise<void> {
   const { userId, characterId, corpId, allianceId, accessToken } = params;
+  const scope = params.scope ?? 'all';
 
   const tasks: Promise<void>[] = [];
 
-  // Personal — always available with the read_contacts scope.
-  if (await shouldRefresh('character', characterId)) {
+  // Personal — for the map tint only (never access control). Skipped for
+  // org-scoped syncs.
+  if (scope !== 'org' && await shouldRefresh('character', characterId)) {
     tasks.push((async () => {
       const r = await fetchAllContacts(
         `https://esi.evetech.net/v2/characters/${characterId}/contacts/`,

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -229,8 +229,12 @@ function AccessTab() {
   const syncStandings = async () => {
     setSyncing(true); setSyncResult(null);
     try {
+      // scope:'org' — access control only ever uses corp/alliance standings, so
+      // the access-page sync pulls ONLY the corp + alliance contact lists. It
+      // deliberately does not touch personal contacts (that's the map's tint,
+      // refreshed from the system-info panel instead).
       const r = await api<{ counts: Record<string, number>; succeeded: Record<string, boolean> }>(
-        '/api/standings/refresh', { method: 'POST' },
+        '/api/standings/refresh', { method: 'POST', body: JSON.stringify({ scope: 'org' }) },
       );
       // Report on the bucket the gate actually reads: alliance_standings on an
       // alliance install, else the corp's OWN contacts (which include any


### PR DESCRIPTION
Narrow follow-up to the access-control work (replaces the mistaken #451, which
stripped personal standings from the map too).

**The distinction:** personal standings power the **map tint** (system-info panel)
and must stay. Access control only ever reads **corp/alliance** standings — so the
**access-page** "sync standings" button should pull corp + alliance only and never
touch personal contacts. That personal fetch was the source of the
`personal contacts fetch returned 401 … missing esi-characters.read_contacts.v1 scope`
log line you saw when syncing from the access page.

## Change
- `refreshStandingsForUser` gains `scope: 'all' | 'org'` (default `'all'`). `'org'`
  skips the personal fetch.
- `POST /api/standings/refresh` accepts `{ scope: 'org' }`, leaves the personal
  throttle untouched, and passes the scope through.
- The access-page sync (AdminPage AccessTab) posts `scope:'org'`.
- **Unchanged:** login and the system-info "refresh standings" button keep the
  default `'all'` — the map tint still pulls personal contacts as before. The
  `esi-characters.read_contacts.v1` scope stays.

## Checks
- server `tsc` + `yarn test` (25) green; web `tsc -b` clean. No i18n changes.