### PR TITLE
Tidy the sync/view standings action group (access page)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -9022,16 +9022,32 @@ select.sig-toolbar-btn option {
   border-left: 3px solid #2e5a9a;
   border-radius: 5px;
 }
+/* Sync / view standings action group: a clean button row, its inline result,
+   and the muted helper lines beneath — all grouped so they read as one unit. */
+.admin-access__sync { margin-bottom: 6px; }
 .admin-access__toolbar {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
+.admin-access__sync-status {
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #6fbf8f;
+  margin-left: 4px;
+}
+.admin-access__sync-status--err { color: #e06a6a; }
 .admin-access__hint {
   font-size: calc(12px * var(--font-scale, 1));
   color: #8090a8;
+}
+/* Helper lines beneath the buttons sit tight together as a block. */
+.admin-access__sync .admin-access__hint {
+  display: block;
+  margin: 2px 0 0;
+  max-width: 720px;
+  line-height: 1.5;
 }
 .admin-access__hint--delay { display: block; margin: 3px 0 0; max-width: 720px; line-height: 1.5; }
 .admin-access__result {

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -332,21 +332,25 @@ function AccessTab() {
         )}
       </div>
 
-      <div className="admin-access__toolbar">
-        <button type="button" className="btn btn--ghost btn--sm" disabled={syncing} onClick={syncStandings}>
-          {syncing ? t('admin.access.syncing') : t('admin.access.syncStandings')}
-        </button>
-        <button type="button" className="btn btn--ghost btn--sm" onClick={() => setShowStandings(true)}>
-          {t('admin.access.viewStandings')}
-        </button>
-        <span className="admin-access__hint">{t('admin.access.syncHint')}</span>
+      <div className="admin-access__sync">
+        <div className="admin-access__toolbar">
+          <button type="button" className="btn btn--ghost btn--sm" disabled={syncing} onClick={syncStandings}>
+            {syncing ? t('admin.access.syncing') : t('admin.access.syncStandings')}
+          </button>
+          <button type="button" className="btn btn--ghost btn--sm" onClick={() => setShowStandings(true)}>
+            {t('admin.access.viewStandings')}
+          </button>
+          {syncResult && (
+            <span className={`admin-access__sync-status${syncResult.ok ? '' : ' admin-access__sync-status--err'}`}>
+              {syncResult.text}
+            </span>
+          )}
+        </div>
+        <p className="admin-access__hint">{t('admin.access.syncHint')}</p>
+        <p className="admin-access__hint">{t('admin.access.syncDelay')}</p>
       </div>
 
       {showStandings && <StandingsViewerModal onClose={() => setShowStandings(false)} />}
-      <div className="admin-access__hint admin-access__hint--delay">{t('admin.access.syncDelay')}</div>
-      {syncResult && (
-        <div className={syncResult.ok ? 'admin-access__result' : 'admin-page__error'}>{syncResult.text}</div>
-      )}
 
       <div className="admin-access__add">
         <select


### PR DESCRIPTION
Small UX cleanup of the standings buttons + text beneath them on the access page.

**Before:** the two buttons shared their row with the long "Pull the latest
corp/alliance contacts…" hint trailing to the right, and the sync result appeared
at the very bottom, past the "Heads up: EVE can take ~10 min…" line — so feedback
was disconnected from the action.

**After:**
- Buttons on their own row; the sync result sits **inline beside them** (green on
  success, red on error).
- The two helper lines are grouped tightly **beneath** the buttons as muted text.

Pure layout/CSS — no logic or string changes. web `tsc -b` + `vite build` clean.