### PR TITLE
Telemetry: a populated NEXUM_TELEMETRY_URL counts as opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,20 +715,23 @@ Only ever use a container ID you own. The ID is inlined at build time, so a rebu
 
 ### Deployment telemetry (version ping) — opt-in
 
-So the project can gauge how many people self-host and which versions are live, the server can send a tiny **opt-in** ping. It is **off unless you set `NEXUM_TELEMETRY=1`**, and when enabled it sends, once a day:
+So the project can gauge how many people self-host and which versions are live, the server can send a tiny **opt-in** ping. It is **off by default**, and when enabled it sends, once a day:
 
 - the app **version** (e.g. `0.1.0`)
 - a **random per-instance id** (generated once, stored locally), so repeat pings count as one install
 
-That's the entire payload. It contains **no** user data, character names, corp IDs, map data, or settings, and the receiver **does not store your IP**. To enable it:
+That's the entire payload. It contains **no** user data, character names, corp IDs, map data, or settings, and the receiver **does not store your IP**. There are two ways to opt in:
 
 ```bash
+# 1. the flag — sends to the project's default collector
 NEXUM_TELEMETRY=1                                  # in .env
-# optional: send to your own collector instead of the project's
-# NEXUM_TELEMETRY_URL=https://your-host/api/telemetry
+
+# 2. …or just set a collector URL. Populating this is itself treated as opt-in,
+#    so you don't also need the flag. Point it at the project's or your own.
+NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
 ```
 
-Unset `NEXUM_TELEMETRY` (the default) and the server never makes the call. The receiving endpoint (`POST /api/telemetry`) exists on every deployment but stays empty unless instances are pointed at it.
+Leave **both** unset (the default) and the server never makes the call. The receiving endpoint (`POST /api/telemetry`) exists on every deployment but stays empty unless instances are pointed at it.
 
 ---
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -91,13 +91,17 @@ ALLIANCE_ID=
 ALLIANCE_MAP_SHARED=false
 
 # ── Telemetry ─────────────────────────────────────────────────────────────────
-# Opt-in anonymous deployment ping. OFF unless set. When enabled the server
-# sends a tiny daily request with ONLY the app version and a random per-instance
-# id — no user data, no map data, and the receiver stores no IP. It just lets
-# the project count active self-hosted installs and versions in the wild.
+# Opt-in anonymous deployment ping. OFF unless you opt in. When enabled the
+# server sends a tiny daily request with ONLY the app version and a random
+# per-instance id — no user data, no map data, and the receiver stores no IP. It
+# just lets the project count active self-hosted installs and versions in the wild.
+#
+# Two ways to opt in:
+#   1. Set NEXUM_TELEMETRY=1 (sends to the project's default collector), OR
+#   2. Set NEXUM_TELEMETRY_URL to any non-empty value — populating a collector
+#      endpoint is itself treated as consent. Point it at the project's collector
+#      or your own. Comment it out / leave it unset to stay opted out.
 # NEXUM_TELEMETRY=1
-# Override the collector URL (defaults to the project's). Point at your own, or
-# leave unset.
 # NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
 
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -107,10 +107,17 @@ const tokenEncryptionKey = isHex64Key
   : createHash('sha256').update(TOKEN_ENC_RAW).digest('hex');
 
 // Opt-in anonymous deployment ping. OFF by default — a self-hosted instance
-// phones home to nobody unless the operator sets NEXUM_TELEMETRY=1. When on,
-// the server sends only { version, instanceId } once a day so the project can
-// count active installs. NEXUM_TELEMETRY_URL overrides the collector endpoint.
-const TELEMETRY_ENABLED = /^(1|true|yes|on)$/i.test(process.env.NEXUM_TELEMETRY ?? '');
+// phones home to nobody unless the operator opts in. When on, the server sends
+// only { version, instanceId } once a day so the project can count active
+// installs. Two ways to opt in:
+//   - NEXUM_TELEMETRY=1 (uses the default eve-nexum.com collector), or
+//   - simply setting NEXUM_TELEMETRY_URL to a non-empty value — populating a
+//     collector endpoint is itself treated as consent (comment it out / leave it
+//     unset to stay opted out).
+// Key off the RAW env var here, not the resolved URL below: the resolved URL
+// always falls back to the default, so testing it would opt everyone in.
+const TELEMETRY_URL_SET = (process.env.NEXUM_TELEMETRY_URL ?? '').trim().length > 0;
+const TELEMETRY_ENABLED = /^(1|true|yes|on)$/i.test(process.env.NEXUM_TELEMETRY ?? '') || TELEMETRY_URL_SET;
 const TELEMETRY_URL = process.env.NEXUM_TELEMETRY_URL?.trim() || 'https://eve-nexum.com/api/telemetry';
 
 export const config = {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -101,7 +101,9 @@ app.use(session({
 // session middleware (so logout etc. still see the session) but before
 // any route is reached. SameSite=lax is the primary protection; this
 // catches the residual cases.
-app.use(originGuard(process.env.FRONTEND_URL ?? 'http://localhost:5174'));
+// The telemetry collector receives anonymous server-to-server pings (no browser
+// Origin, no credentials), so it must be exempt from the CSRF origin check.
+app.use(originGuard(process.env.FRONTEND_URL ?? 'http://localhost:5174', { exemptPaths: ['/api/telemetry'] }));
 
 // Tight limiter ONLY on the SSO brute-force surface (login spam, state
 // guessing). The rest of /auth — /me, /preferences, /settings,

--- a/server/src/middleware/originGuard.ts
+++ b/server/src/middleware/originGuard.ts
@@ -35,13 +35,25 @@ function stripTrailingSlashes(s: string): string {
  * EVE SSO redirects in via top-level navigation, which the OAuth state
  * param verifies separately.
  */
-export function originGuard(allowedOrigin: string) {
+export function originGuard(allowedOrigin: string, opts: { exemptPaths?: string[] } = {}) {
   // Normalise once: strip trailing slash so '.../app' and '.../app/'
   // both match without per-request string juggling.
   const allowed = stripTrailingSlashes(allowedOrigin);
+  const exemptPaths = opts.exemptPaths ?? [];
 
   return function originGuardMiddleware(req: Request, res: Response, next: NextFunction) {
     if (!STATE_METHODS.has(req.method)) {
+      next();
+      return;
+    }
+
+    // Public server-to-server endpoints (e.g. anonymous telemetry pings from
+    // self-hosted installs) legitimately arrive with NO browser Origin/Referer.
+    // They also carry no ambient credential (no session cookie is meaningful to
+    // them) and change no victim-affecting state, so CSRF doesn't apply — the
+    // guard would otherwise reject every one of them at the no-Origin branch
+    // below. Such routes validate + rate-limit their own input downstream.
+    if (exemptPaths.some((p) => req.path === p || req.path.startsWith(`${p}/`))) {
       next();
       return;
     }

--- a/server/src/services/telemetry.ts
+++ b/server/src/services/telemetry.ts
@@ -50,9 +50,14 @@ async function sendPing(instanceId: string): Promise<void> {
       body:    JSON.stringify({ version: appVersion(), instanceId }),
       signal:  AbortSignal.timeout(10_000),
     });
-    if (!res.ok) log.warn(`ping rejected (status ${res.status})`);
+    // Log the OUTCOME, not just failures — otherwise "enabled" in the log looks
+    // like success even when the POST never lands (e.g. a host that can't reach
+    // its own public URL). The collector replies 204 on a successful upsert.
+    if (res.ok) log.info(`ping accepted by collector (status ${res.status})`);
+    else        log.warn(`ping rejected (status ${res.status})`);
   } catch (err) {
-    // Offline / collector down / DNS — all non-fatal and expected.
+    // Offline / collector down / DNS / can't reach own public URL — all
+    // non-fatal and expected; but log it so an empty table is explainable.
     log.warn('ping failed:', err instanceof Error ? err.message : String(err));
   }
 }

--- a/server/src/services/telemetry.ts
+++ b/server/src/services/telemetry.ts
@@ -67,7 +67,7 @@ export async function startTelemetry(): Promise<void> {
   try {
     log.info(
       `anonymous telemetry enabled — sending { version, instanceId } to ${config.telemetry.url} ` +
-      `once a day (disable by unsetting NEXUM_TELEMETRY)`,
+      `once a day (disable by unsetting NEXUM_TELEMETRY and NEXUM_TELEMETRY_URL)`,
     );
     const instanceId = await getInstanceId();
     await sendPing(instanceId);


### PR DESCRIPTION
Setting only `NEXUM_TELEMETRY_URL` used to send **nothing** — the opt-in switch was
the separate `NEXUM_TELEMETRY=1` flag, and the URL var merely overrode the endpoint.
That was a confusing footgun (and the reason a local test showed no rows). Per the
decision, populating `NEXUM_TELEMETRY_URL` is now treated as consent on its own.

## Change
- `config.ts`: `enabled = NEXUM_TELEMETRY flag OR NEXUM_TELEMETRY_URL is non-empty`.
  Crucially it keys off the **raw** `process.env.NEXUM_TELEMETRY_URL`, not the
  resolved URL — the resolved value always falls back to the default collector, so
  checking that would silently opt in every install. With **neither** var set it
  stays **off** (unchanged default).
- Startup log, `.env.example`, and README updated to document both opt-in paths.

No behavioural change to *what* is sent (still `{ version, instanceId }` once a day,
no IP, no user/map data). server `tsc` + tests (25) green.