### PR TITLE
Access: re-validate live sessions after a standings sync

### DIFF
--- a/server/src/routes/standings.ts
+++ b/server/src/routes/standings.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { db } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { refreshStandingsForUser } from '../services/standings.js';
+import { revalidateActiveSessions } from '../services/accessRevalidate.js';
 import { decryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -163,6 +164,16 @@ standingsRouter.post('/refresh', async (req, res) => {
   const refreshedAt: Record<string, string> = {};
   for (const r of refreshRows.rows) refreshedAt[r.owner_kind] = r.last_fetched_at;
 
+  // Access-page (org) sync: the freshly-pulled corp/alliance standings can mean a
+  // currently-logged-in user is no longer permitted (e.g. an auto-admitted corp's
+  // standing dropped below the threshold). Re-check live sessions and evict the
+  // no-longer-permitted now, instead of waiting for the periodic sweep. No-op in
+  // solo mode; never evicts the bootstrap admin. Skipped for the map-tint refresh
+  // (scope 'all'), which any user can trigger and which isn't an access action.
+  const revalidation = orgOnly
+    ? await revalidateActiveSessions()
+    : { usersEvicted: 0, sessionsKilled: 0 };
+
   res.json({
     ok: true,
     counts: {
@@ -179,5 +190,6 @@ standingsRouter.post('/refresh', async (req, res) => {
       corp:      'corp'      in refreshedAt,
       alliance:  'alliance'  in refreshedAt,
     },
+    sessionsKilled: revalidation.sessionsKilled,
   });
 });

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -235,7 +235,7 @@ function AccessTab() {
       // the access-page sync pulls ONLY the corp + alliance contact lists. It
       // deliberately does not touch personal contacts (that's the map's tint,
       // refreshed from the system-info panel instead).
-      const r = await api<{ counts: Record<string, number>; succeeded: Record<string, boolean> }>(
+      const r = await api<{ counts: Record<string, number>; succeeded: Record<string, boolean>; sessionsKilled?: number }>(
         '/api/standings/refresh', { method: 'POST', body: JSON.stringify({ scope: 'org' }) },
       );
       // Report on the bucket the gate actually reads: alliance_standings on an
@@ -246,6 +246,11 @@ function AccessTab() {
       setSyncResult(r.succeeded[bucket]
         ? { ok: true,  text: t('admin.access.syncOk', { count: r.counts[bucket] ?? 0 }) }
         : { ok: false, text: t('admin.access.syncNoRole') });
+      // The sync re-checks live sessions against the freshly-pulled standings and
+      // evicts anyone no longer permitted — surface that, same as the settings flow.
+      if (r.sessionsKilled && r.sessionsKilled > 0) {
+        toast.info(t('admin.access.standingsSessionsEnded', { count: r.sessionsKilled }));
+      }
     } catch (e) {
       setSyncResult({ ok: false, text: grantErrorMessage(e, t, t('admin.access.syncFailed')) });
     } finally { setSyncing(false); }


### PR DESCRIPTION
Final access-control gap: the login gate runs only at sign-in, and the various
narrowing actions (grant removal, settings change, periodic sweep) already
re-validate live sessions — but a **manual standings sync** did not. So if an
admin synced and a currently-logged-in, auto-admitted user's standing had dropped
below the threshold, that user lingered until the next periodic sweep.

## Change
- `POST /api/standings/refresh`: after an **org-scoped** (access-page) sync, call
  the existing `revalidateActiveSessions()` and return `sessionsKilled`. It
  re-checks every live session against `isLoginPermitted() OR standingsPermitLogin()`
  and evicts the no-longer-permitted.
  - Skipped for `scope:'all'` (the system-info map-tint refresh) — any user can
    trigger that and it isn't an access action.
  - No-op in solo mode; never evicts the bootstrap admin (both already handled
    inside `revalidateActiveSessions`).
- `AccessTab`: shows a `standingsSessionsEnded` toast when sessions were evicted —
  the same feedback the settings-change flow already uses. No new strings.

## Checks
- server `tsc` + `yarn test` (25) green; web `tsc -b` clean. i18n key reused
  (present in all 9 locales).