### PR TITLE
Access hardening: DB-integration tests, admin-eviction fix, stale-corp-membership refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,32 @@ jobs:
   server:
     name: server (typecheck + test)
     runs-on: ubuntu-latest
+    # Throwaway Postgres for the DB-integration suites (*.integration.test.ts).
+    # The DB name ends in _test, which the test harness requires before it will
+    # run (a guard against ever pointing TRUNCATE-heavy tests at a real DB).
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: nexum
+          POSTGRES_PASSWORD: nexum
+          POSTGRES_DB: eve_nexum_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U nexum -d eve_nexum_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     defaults:
       run:
         working-directory: server
+    env:
+      PG_HOST: localhost
+      PG_PORT: 5432
+      PG_DB: eve_nexum_test
+      PG_USER: nexum
+      PG_PASSWORD: nexum
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/access-control-design.md
+++ b/access-control-design.md
@@ -309,14 +309,33 @@ it so operators are not misled:
 
 ## 7. Test plan (authz cannot rely on tsc/CodeQL)
 
-Harness: vitest is now set up server-side (`server` `yarn test`, wired into CI).
-First suite `src/services/accessGrants.test.ts` (13 tests, mocked config+db) covers
-the decision logic: install-type gating (grantKindAllowedForInstall), the
-positive-standing table/contact_kind selection (incl. corp-install alliance targets) +
-fail-closed (standingPermitsTarget), and admit/deny + param passthrough
-(isLoginPermitted). NEXT layer (not yet done): DB-integration tests that run the
-real SQL against a throwaway test database, plus admin endpoint tests (env-immutable
-refusal, revocation session-kill).
+Harness: vitest is set up server-side (`server` `yarn test`, wired into CI).
+
+Layer 1 — mocked unit tests (`*.test.ts`, mocked config+db): the decision logic —
+install-type gating (grantKindAllowedForInstall), positive-standing table/
+contact_kind selection incl. corp-install alliance targets + fail-closed
+(standingPermitsTarget), admit/deny + param passthrough (isLoginPermitted).
+
+Layer 2 — DB-integration tests (`*.integration.test.ts`, mocked config + REAL sql
+vs a throwaway `eve_nexum_test` database; DONE 2026-07-16). Harness in
+`src/test/integrationDb.ts` runs the real migrate() then seeds/truncates; suites
+skip (describe.skipIf) when no test DB is reachable and run in CI via a Postgres
+service. Coverage:
+  - accessGrants: isLoginPermitted (corp/alliance/character grant match, null-corp
+    no-match), standingPermitsTarget (corp + alliance install, positive-only,
+    corp-install alliance contact, fail-closed), standingsPermitLogin (toggle off,
+    thresholds 5/10, corp-admits-alliance, negative denied).
+  - revalidateActiveSessions: still-permitted kept / no-longer-permitted evicted,
+    all-sessions-of-a-user killed, bootstrap-admin exemption, blocked-user eviction,
+    solo no-op, expired sessions ignored, standings-auto-admit kept.
+  - admin endpoints (supertest + fake session): unauth 401, non-admin 403, positive
+    standing 201, standing-not-positive 403 (nothing written), character exempt,
+    env-immutable delete 400, revocation session-kill.
+
+This layer immediately caught a real bug: revalidateActiveSessions compared the
+BIGINT character_id (a STRING from node-pg) with the numeric adminCharId via ===,
+so the bootstrap-admin exemption never matched and the admin could be evicted.
+Fixed by Number()-coercing before the compare.
 
 
 - Seed: CORP_ID/ALLIANCE_ID reproduce as `source='env'` grants; re-running boot

--- a/access-control-design.md
+++ b/access-control-design.md
@@ -370,4 +370,10 @@ Fixed by Number()-coercing before the compare.
   (owner/account model), or strictly per-character? Recommend per-character.
 - Do we want a deployment-wide "share also grants login" default (auto) vs the
   per-share prompt? Recommend prompt, remember-per-session.
-- Re-validation cadence for stale corp membership.
+- ~~Re-validation cadence for stale corp membership.~~ RESOLVED (2026-07-16): the
+  periodic sweep (`revalidateActiveSessions({ refreshAffiliation: true })`, cadence
+  `ACCESS_REVALIDATE_MINUTES`) batch-refreshes each live user's corp/alliance from
+  ESI (`POST /characters/affiliation/`) before the gate check, so a pilot who left
+  an admitted corp is evicted without needing to re-login. Fail-safe: any ESI error
+  falls back to the stored ids (an outage never mass-evicts). Admin-triggered sweeps
+  leave `refreshAffiliation` off to stay fast.

--- a/server/package.json
+++ b/server/package.json
@@ -44,7 +44,9 @@
     "@types/express-session": "^1.19.0",
     "@types/node": "^20.14.0",
     "@types/pg": "^8.11.6",
+    "@types/supertest": "^7.2.1",
     "@types/unzipper": "^0.10.11",
+    "supertest": "^7.2.2",
     "tsx": "^4.15.6",
     "typescript": "^5.4.5",
     "vitest": "^4.1.10"

--- a/server/src/routes/adminAccess.integration.test.ts
+++ b/server/src/routes/adminAccess.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mock config (real db). A Proxy over the real config with live-mutable overrides.
+// sessionUserId drives the fake auth middleware below.
+const state = vi.hoisted(() => ({ over: {} as Record<string, unknown>, sessionUserId: 0 }));
+vi.mock('../config.js', async (importActual) => {
+  const base = (await importActual<typeof import('../config.js')>()).config as Record<string, unknown>;
+  return { config: new Proxy({}, { get: (_t, k: string) => (k in state.over ? state.over[k] : base[k]) }) };
+});
+
+import { ensureIntegrationDb, truncateAll, seedUser, seedSession, liveSessionCount } from '../test/integrationDb.js';
+import { db } from '../db.js';
+import { adminRouter } from './admin.js';
+
+const dbReady = await ensureIntegrationDb();
+
+// A bare app that mounts the real adminRouter (requireAdmin included) behind a
+// fake session. requireAdmin re-checks the role against the real DB, so seeding
+// an admin user is what actually authorises the request.
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as express.Request & { session: Record<string, unknown> }).session = { userId: state.sessionUserId, characterId: 777 };
+    next();
+  });
+  app.use('/api/admin', adminRouter);
+  return app;
+}
+
+const corpStanding = (contactId: number, standing: number) =>
+  db.query(`INSERT INTO corp_standings (corp_id, contact_kind, contact_id, standing, updated_at) VALUES (1000, 'corporation', $1, $2, NOW())`, [contactId, standing]);
+
+describe.skipIf(!dbReady)('admin access-grants endpoints (integration)', () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    await truncateAll();
+    state.over = { corpMode: true, allianceMode: false, corpIds: [1000], allianceIds: [2000], restrictedMode: true, adminCharId: 777 };
+    const adminId = await seedUser({ characterId: 777, corpId: 1000, role: 'admin' });
+    state.sessionUserId = adminId;
+    app = makeApp();
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    state.sessionUserId = 0; // falsy → requireAdmin returns 401
+    const res = await request(app).post('/api/admin/access-grants').send({ kind: 'corp', eveId: 500 });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a non-admin session', async () => {
+    const plebId = await seedUser({ characterId: 12, corpId: 1000, role: 'readonly' });
+    state.sessionUserId = plebId;
+    const res = await request(app).post('/api/admin/access-grants').send({ kind: 'corp', eveId: 500 });
+    expect(res.status).toBe(403);
+  });
+
+  it('adds a corp grant held at positive standing (201)', async () => {
+    await corpStanding(500, 10);
+    const res = await request(app).post('/api/admin/access-grants').send({ kind: 'corp', eveId: 500 });
+    expect(res.status).toBe(201);
+    const { rows } = await db.query(`SELECT source FROM access_grants WHERE kind='corp' AND eve_id=500`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe('admin');
+  });
+
+  it('refuses a corp grant with no positive standing (403 standing_not_positive)', async () => {
+    const res = await request(app).post('/api/admin/access-grants').send({ kind: 'corp', eveId: 500 });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('standing_not_positive');
+    const { rows } = await db.query(`SELECT 1 FROM access_grants WHERE kind='corp' AND eve_id=500`);
+    expect(rows).toHaveLength(0); // nothing written
+  });
+
+  it('adds a character grant with no standing check (201, exempt)', async () => {
+    const res = await request(app).post('/api/admin/access-grants').send({ kind: 'character', eveId: 42 });
+    expect(res.status).toBe(201);
+  });
+
+  it('refuses to delete an env-seeded grant (400 env_immutable)', async () => {
+    const { rows } = await db.query<{ id: string }>(`INSERT INTO access_grants (kind, eve_id, source) VALUES ('corp', 500, 'env') RETURNING id`);
+    const res = await request(app).delete(`/api/admin/access-grants/${rows[0].id}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('env_immutable');
+    const check = await db.query(`SELECT 1 FROM access_grants WHERE id=$1`, [rows[0].id]);
+    expect(check.rows).toHaveLength(1); // still there
+  });
+
+  it('deleting an admin grant evicts the sessions it solely admitted', async () => {
+    const { rows } = await db.query<{ id: string }>(`INSERT INTO access_grants (kind, eve_id, source) VALUES ('corp', 555, 'admin') RETURNING id`);
+    const u = await seedUser({ characterId: 5, corpId: 555 }); // admitted only by this grant
+    await seedSession(u);
+    const res = await request(app).delete(`/api/admin/access-grants/${rows[0].id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.sessionsKilled).toBe(1);
+    expect(await liveSessionCount(u)).toBe(0);
+  });
+});

--- a/server/src/services/accessGrants.integration.test.ts
+++ b/server/src/services/accessGrants.integration.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock ONLY config (to drive install-type) — the db is real. A Proxy over the
+// real config lets each test flip corpMode/allianceMode/ids live (services read
+// config.* at call time) while everything else keeps its real value.
+const state = vi.hoisted(() => ({ over: {} as Record<string, unknown> }));
+vi.mock('../config.js', async (importActual) => {
+  const base = (await importActual<typeof import('../config.js')>()).config as Record<string, unknown>;
+  return { config: new Proxy({}, { get: (_t, k: string) => (k in state.over ? state.over[k] : base[k]) }) };
+});
+
+import { ensureIntegrationDb, truncateAll } from '../test/integrationDb.js';
+import { db } from '../db.js';
+import { setSetting } from './appSettings.js';
+import { isLoginPermitted, standingPermitsTarget, standingsPermitLogin } from './accessGrants.js';
+
+const dbReady = await ensureIntegrationDb();
+
+const grant = (kind: string, eveId: number, source = 'admin') =>
+  db.query(
+    `INSERT INTO access_grants (id, kind, eve_id, source, created_at)
+     VALUES (gen_random_uuid(), $1, $2, $3, NOW())`,
+    [kind, eveId, source],
+  );
+
+const corpStanding = (contactKind: string, contactId: number, standing: number, corpId = 1000) =>
+  db.query(
+    `INSERT INTO corp_standings (corp_id, contact_kind, contact_id, standing, updated_at)
+     VALUES ($1, $2, $3, $4, NOW())`,
+    [corpId, contactKind, contactId, standing],
+  );
+
+const allianceStanding = (contactKind: string, contactId: number, standing: number, allianceId = 2000) =>
+  db.query(
+    `INSERT INTO alliance_standings (alliance_id, contact_kind, contact_id, standing, updated_at)
+     VALUES ($1, $2, $3, $4, NOW())`,
+    [allianceId, contactKind, contactId, standing],
+  );
+
+describe.skipIf(!dbReady)('accessGrants (integration — real SQL)', () => {
+  beforeEach(async () => {
+    await truncateAll();
+    // Default: a corp installation.
+    state.over = { corpMode: true, allianceMode: false, corpIds: [1000], allianceIds: [2000], restrictedMode: true, adminCharId: null };
+  });
+
+  describe('isLoginPermitted', () => {
+    it('admits a character whose corp has a grant', async () => {
+      await grant('corp', 500);
+      expect(await isLoginPermitted({ characterId: 9, corpId: 500, allianceId: null })).toBe(true);
+    });
+
+    it('rejects when no grant matches', async () => {
+      await grant('corp', 500);
+      expect(await isLoginPermitted({ characterId: 9, corpId: 999, allianceId: null })).toBe(false);
+    });
+
+    it('matches on alliance-kind and character-kind grants', async () => {
+      await grant('alliance', 3000);
+      await grant('character', 42);
+      expect(await isLoginPermitted({ characterId: 1, corpId: 1, allianceId: 3000 })).toBe(true);
+      expect(await isLoginPermitted({ characterId: 42, corpId: 1, allianceId: 1 })).toBe(true);
+    });
+
+    it('does not match a corp grant against a null corp id', async () => {
+      await grant('corp', 500);
+      expect(await isLoginPermitted({ characterId: 9, corpId: null, allianceId: null })).toBe(false);
+    });
+  });
+
+  describe('standingPermitsTarget — corp installation', () => {
+    it('positive corp standing permits; zero and negative deny', async () => {
+      await corpStanding('corporation', 700, 5);
+      await corpStanding('corporation', 701, 0);
+      await corpStanding('corporation', 702, -10);
+      expect(await standingPermitsTarget('corp', 700)).toBe(true);
+      expect(await standingPermitsTarget('corp', 701)).toBe(false);
+      expect(await standingPermitsTarget('corp', 702)).toBe(false);
+    });
+
+    it('fails closed when there is no standing row', async () => {
+      expect(await standingPermitsTarget('corp', 999)).toBe(false);
+    });
+
+    it('an alliance target checks the corp\'s own alliance contact', async () => {
+      await allianceStanding('corporation', 800, 10); // in alliance_standings — must be ignored
+      await corpStanding('alliance', 3000, 7);
+      expect(await standingPermitsTarget('alliance', 3000)).toBe(true);
+      expect(await standingPermitsTarget('alliance', 3001)).toBe(false);
+    });
+
+    it('never admits a negative standing via any magnitude/abs path', async () => {
+      await corpStanding('corporation', 703, -10);
+      expect(await standingPermitsTarget('corp', 703)).toBe(false);
+    });
+  });
+
+  describe('standingPermitsTarget — alliance installation', () => {
+    beforeEach(() => { state.over = { ...state.over, corpMode: false, allianceMode: true }; });
+
+    it('reads alliance_standings and ignores corp_standings', async () => {
+      await allianceStanding('corporation', 800, 5);
+      await corpStanding('corporation', 801, 10); // must be ignored on an alliance install
+      expect(await standingPermitsTarget('corp', 800)).toBe(true);
+      expect(await standingPermitsTarget('corp', 801)).toBe(false);
+    });
+  });
+
+  describe('standingsPermitLogin (auto-admit)', () => {
+    it('returns false when the toggle is off (no app_settings rows)', async () => {
+      expect(await standingsPermitLogin({ characterId: 1, corpId: 1000, allianceId: 2000 })).toBe(false);
+    });
+
+    it('corp install: admits at/above threshold, denies below; alliance of pilot also matches', async () => {
+      await setSetting('standings_login_enabled', 'true', null);
+      await setSetting('standings_login_threshold', '5', null);
+      await corpStanding('corporation', 600, 5);   // friendly corp at exactly 5
+      await corpStanding('corporation', 601, 0);   // neutral
+      await corpStanding('alliance', 3000, 10);    // corp holds a friendly alliance
+      // pilot in the friendly corp
+      expect(await standingsPermitLogin({ characterId: 1, corpId: 600, allianceId: 9 })).toBe(true);
+      // pilot in the neutral corp
+      expect(await standingsPermitLogin({ characterId: 1, corpId: 601, allianceId: 9 })).toBe(false);
+      // pilot whose ALLIANCE the corp stands friendly (corp-admits-alliance)
+      expect(await standingsPermitLogin({ characterId: 1, corpId: 999, allianceId: 3000 })).toBe(true);
+    });
+
+    it('threshold 10 denies a +5 pilot that threshold 5 would admit', async () => {
+      await corpStanding('corporation', 600, 5);
+      await setSetting('standings_login_enabled', 'true', null);
+      await setSetting('standings_login_threshold', '10', null);
+      expect(await standingsPermitLogin({ characterId: 1, corpId: 600, allianceId: null })).toBe(false);
+      await setSetting('standings_login_threshold', '5', null);
+      expect(await standingsPermitLogin({ characterId: 1, corpId: 600, allianceId: null })).toBe(true);
+    });
+
+    it('a negative-standing pilot is denied at both thresholds', async () => {
+      await corpStanding('corporation', 610, -10);
+      await setSetting('standings_login_enabled', 'true', null);
+      for (const th of ['5', '10']) {
+        await setSetting('standings_login_threshold', th, null);
+        expect(await standingsPermitLogin({ characterId: 1, corpId: 610, allianceId: null })).toBe(false);
+      }
+    });
+  });
+});

--- a/server/src/services/accessRevalidate.integration.test.ts
+++ b/server/src/services/accessRevalidate.integration.test.ts
@@ -8,6 +8,13 @@ vi.mock('../config.js', async (importActual) => {
   return { config: new Proxy({}, { get: (_t, k: string) => (k in state.over ? state.over[k] : base[k]) }) };
 });
 
+// Mock ESI so the affiliation refresh is deterministic. `esi.rows` is the
+// /characters/affiliation/ payload; `esi.ok=false` simulates an ESI outage.
+const esi = vi.hoisted(() => ({ ok: true, status: 200, rows: [] as Array<{ character_id: number; corporation_id: number; alliance_id?: number }> }));
+vi.mock('../utils/esi.js', () => ({
+  esiFetch: vi.fn(async () => ({ ok: esi.ok, status: esi.status, json: async () => esi.rows } as unknown as Response)),
+}));
+
 import { ensureIntegrationDb, truncateAll, seedUser, seedSession, liveSessionCount } from '../test/integrationDb.js';
 import { db } from '../db.js';
 import { setSetting } from './appSettings.js';
@@ -22,6 +29,7 @@ describe.skipIf(!dbReady)('revalidateActiveSessions (integration — real SQL)',
   beforeEach(async () => {
     await truncateAll();
     state.over = { corpMode: true, allianceMode: false, corpIds: [1000], allianceIds: [2000], restrictedMode: true, adminCharId: 777 };
+    esi.ok = true; esi.status = 200; esi.rows = [];
   });
 
   it('keeps a still-permitted user, evicts one no longer permitted', async () => {
@@ -82,6 +90,63 @@ describe.skipIf(!dbReady)('revalidateActiveSessions (integration — real SQL)',
     expect(res.sessionsKilled).toBe(0);
     // The expired row is left untouched (the scan never reached this user).
     expect(await liveSessionCount(u)).toBe(1);
+  });
+
+  describe('affiliation refresh (refreshAffiliation: true)', () => {
+    it('evicts a pilot who left an admitted corp (fresh corp, not stored)', async () => {
+      await grantCorp(500);
+      const u = await seedUser({ characterId: 1, corpId: 500 }); // stored corp is admitted...
+      await seedSession(u);
+      esi.rows = [{ character_id: 1, corporation_id: 999 }]; // ...but ESI says they left to 999
+
+      const res = await revalidateActiveSessions({ refreshAffiliation: true });
+
+      expect(res.sessionsKilled).toBe(1);
+      expect(await liveSessionCount(u)).toBe(0);
+      // The stale corp_id is updated + a corp_change is audited.
+      const { rows } = await db.query<{ corp_id: number }>(`SELECT corp_id FROM users WHERE id = $1`, [u]);
+      expect(rows[0].corp_id).toBe(999);
+      const audit = await db.query(`SELECT 1 FROM admin_audit WHERE action='corp_change' AND target_user_id=$1`, [u]);
+      expect(audit.rows).toHaveLength(1);
+    });
+
+    it('keeps a pilot who moved INTO an admitted corp (stored corp was not admitted)', async () => {
+      await grantCorp(500);
+      const u = await seedUser({ characterId: 2, corpId: 999 }); // stored corp not admitted...
+      await seedSession(u);
+      esi.rows = [{ character_id: 2, corporation_id: 500 }]; // ...but now in the admitted corp
+
+      const res = await revalidateActiveSessions({ refreshAffiliation: true });
+
+      expect(res.sessionsKilled).toBe(0);
+      expect(await liveSessionCount(u)).toBe(1);
+      const { rows } = await db.query<{ corp_id: number }>(`SELECT corp_id FROM users WHERE id = $1`, [u]);
+      expect(rows[0].corp_id).toBe(500);
+    });
+
+    it('falls back to stored ids on an ESI outage (no mass eviction)', async () => {
+      await grantCorp(500);
+      const u = await seedUser({ characterId: 3, corpId: 500 }); // permitted by stored
+      await seedSession(u);
+      esi.ok = false; esi.status = 503; // ESI down
+
+      const res = await revalidateActiveSessions({ refreshAffiliation: true });
+
+      expect(res.sessionsKilled).toBe(0);
+      expect(await liveSessionCount(u)).toBe(1);
+    });
+
+    it('updates a changed alliance_id even when the corp is unchanged', async () => {
+      await grantCorp(500);
+      const u = await seedUser({ characterId: 4, corpId: 500, allianceId: null });
+      await seedSession(u);
+      esi.rows = [{ character_id: 4, corporation_id: 500, alliance_id: 3000 }];
+
+      await revalidateActiveSessions({ refreshAffiliation: true });
+
+      const { rows } = await db.query<{ alliance_id: number }>(`SELECT alliance_id FROM users WHERE id = $1`, [u]);
+      expect(rows[0].alliance_id).toBe(3000);
+    });
   });
 
   it('keeps a user admitted purely by the standings auto-admit', async () => {

--- a/server/src/services/accessRevalidate.integration.test.ts
+++ b/server/src/services/accessRevalidate.integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock ONLY config (real db). Proxy over the real config with a live-mutable
+// override so tests can flip restrictedMode / adminCharId / install type.
+const state = vi.hoisted(() => ({ over: {} as Record<string, unknown> }));
+vi.mock('../config.js', async (importActual) => {
+  const base = (await importActual<typeof import('../config.js')>()).config as Record<string, unknown>;
+  return { config: new Proxy({}, { get: (_t, k: string) => (k in state.over ? state.over[k] : base[k]) }) };
+});
+
+import { ensureIntegrationDb, truncateAll, seedUser, seedSession, liveSessionCount } from '../test/integrationDb.js';
+import { db } from '../db.js';
+import { setSetting } from './appSettings.js';
+import { revalidateActiveSessions } from './accessRevalidate.js';
+
+const dbReady = await ensureIntegrationDb();
+
+const grantCorp = (corpId: number) =>
+  db.query(`INSERT INTO access_grants (id, kind, eve_id, source, created_at) VALUES (gen_random_uuid(), 'corp', $1, 'admin', NOW())`, [corpId]);
+
+describe.skipIf(!dbReady)('revalidateActiveSessions (integration — real SQL)', () => {
+  beforeEach(async () => {
+    await truncateAll();
+    state.over = { corpMode: true, allianceMode: false, corpIds: [1000], allianceIds: [2000], restrictedMode: true, adminCharId: 777 };
+  });
+
+  it('keeps a still-permitted user, evicts one no longer permitted', async () => {
+    await grantCorp(500);
+    const ok  = await seedUser({ characterId: 1, corpId: 500 });   // permitted by grant
+    const bad = await seedUser({ characterId: 2, corpId: 999 });   // no grant, no standing
+    await seedSession(ok);
+    await seedSession(bad);
+
+    const res = await revalidateActiveSessions();
+
+    expect(res.usersEvicted).toBe(1);
+    expect(res.sessionsKilled).toBe(1);
+    expect(await liveSessionCount(ok)).toBe(1);
+    expect(await liveSessionCount(bad)).toBe(0);
+  });
+
+  it('kills every live session of an evicted user', async () => {
+    const bad = await seedUser({ characterId: 2, corpId: 999 });
+    await seedSession(bad);
+    await seedSession(bad);
+    const res = await revalidateActiveSessions();
+    expect(res.usersEvicted).toBe(1);
+    expect(res.sessionsKilled).toBe(2);
+    expect(await liveSessionCount(bad)).toBe(0);
+  });
+
+  it('never evicts the bootstrap admin, even with no grant', async () => {
+    const admin = await seedUser({ characterId: 777, corpId: 999, role: 'admin' });
+    await seedSession(admin);
+    const res = await revalidateActiveSessions();
+    expect(res.sessionsKilled).toBe(0);
+    expect(await liveSessionCount(admin)).toBe(1);
+  });
+
+  it('evicts a blocked user even when a grant would otherwise permit them', async () => {
+    await grantCorp(500);
+    const u = await seedUser({ characterId: 3, corpId: 500, blocked: true });
+    await seedSession(u);
+    const res = await revalidateActiveSessions();
+    expect(res.sessionsKilled).toBe(1);
+    expect(await liveSessionCount(u)).toBe(0);
+  });
+
+  it('is a no-op in solo (unrestricted) mode', async () => {
+    state.over = { ...state.over, restrictedMode: false };
+    const u = await seedUser({ characterId: 4, corpId: 999 });
+    await seedSession(u);
+    const res = await revalidateActiveSessions();
+    expect(res).toEqual({ usersEvicted: 0, sessionsKilled: 0 });
+    expect(await liveSessionCount(u)).toBe(1);
+  });
+
+  it('ignores expired sessions (only live sessions are scanned)', async () => {
+    const u = await seedUser({ characterId: 5, corpId: 999 }); // not permitted
+    await seedSession(u, { expired: true });
+    const res = await revalidateActiveSessions();
+    expect(res.sessionsKilled).toBe(0);
+    // The expired row is left untouched (the scan never reached this user).
+    expect(await liveSessionCount(u)).toBe(1);
+  });
+
+  it('keeps a user admitted purely by the standings auto-admit', async () => {
+    await setSetting('standings_login_enabled', 'true', null);
+    await setSetting('standings_login_threshold', '5', null);
+    await db.query(`INSERT INTO corp_standings (corp_id, contact_kind, contact_id, standing, updated_at) VALUES (1000, 'corporation', 600, 10, NOW())`);
+    const u = await seedUser({ characterId: 6, corpId: 600 }); // no grant, but +10 standing
+    await seedSession(u);
+    const res = await revalidateActiveSessions();
+    expect(res.sessionsKilled).toBe(0);
+    expect(await liveSessionCount(u)).toBe(1);
+  });
+});

--- a/server/src/services/accessRevalidate.ts
+++ b/server/src/services/accessRevalidate.ts
@@ -44,9 +44,13 @@ export async function revalidateActiveSessions(): Promise<RevalidateResult> {
   let usersEvicted = 0;
   let sessionsKilled = 0;
   for (const u of rows) {
+    // character_id is BIGINT — node-pg hands it back as a STRING, so normalise
+    // before any numeric comparison. (A `===` against the numeric adminCharId
+    // would otherwise never match, and the bootstrap admin would be evicted.)
+    const characterId = Number(u.characterId);
     // Never evict the configured bootstrap admin — the safety hatch.
-    if (config.adminCharId !== null && u.characterId === config.adminCharId) continue;
-    const ids = { characterId: u.characterId, corpId: u.corpId, allianceId: u.allianceId };
+    if (config.adminCharId !== null && characterId === config.adminCharId) continue;
+    const ids = { characterId, corpId: u.corpId, allianceId: u.allianceId };
     const stillOk = !u.blocked && (await isLoginPermitted(ids) || await standingsPermitLogin(ids));
     if (!stillOk) {
       const n = await invalidateSessionsForUser(u.id);

--- a/server/src/services/accessRevalidate.ts
+++ b/server/src/services/accessRevalidate.ts
@@ -12,13 +12,60 @@ import { db } from '../db.js';
 import { config } from '../config.js';
 import { isLoginPermitted, standingsPermitLogin } from './accessGrants.js';
 import { invalidateSessionsForUser } from '../utils/sessionInvalidate.js';
+import { audit } from './audit.js';
+import { esiFetch } from '../utils/esi.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('accessRevalidate');
 
 export interface RevalidateResult { usersEvicted: number; sessionsKilled: number }
 
-export async function revalidateActiveSessions(): Promise<RevalidateResult> {
+interface Affiliation { corpId: number | null; allianceId: number | null }
+
+// Batch-resolve each character's CURRENT corp/alliance via ESI's public
+// affiliation endpoint (POST, up to 1000 ids per call). This is how the sweep
+// notices a pilot who changed/left corp — the login gate ran only at sign-in, so
+// users.corp_id can be stale.
+//
+// FAIL-SAFE: on ANY error (offline, non-2xx, malformed) we return an EMPTY map so
+// callers fall back to the stored ids. An ESI outage must never mass-evict live
+// users — worst case we re-check against slightly stale affiliation, same as
+// before this feature existed.
+async function fetchAffiliations(charIds: number[]): Promise<Map<number, Affiliation>> {
+  const out = new Map<number, Affiliation>();
+  const ids = [...new Set(charIds.filter((n) => Number.isInteger(n) && n > 0))];
+  if (ids.length === 0) return out;
+  try {
+    for (let i = 0; i < ids.length; i += 1000) {
+      const chunk = ids.slice(i, i + 1000);
+      const r = await esiFetch('https://esi.evetech.net/latest/characters/affiliation/', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(chunk),
+        signal:  AbortSignal.timeout(10_000),
+      });
+      if (!r.ok) {
+        log.warn(`affiliation fetch returned ${r.status} — falling back to stored ids this sweep`);
+        return new Map();
+      }
+      const body = await r.json() as Array<{ character_id: number; corporation_id: number; alliance_id?: number }>;
+      if (!Array.isArray(body)) return new Map();
+      for (const a of body) out.set(a.character_id, { corpId: a.corporation_id ?? null, allianceId: a.alliance_id ?? null });
+    }
+  } catch (err) {
+    log.warn('affiliation fetch failed — falling back to stored ids this sweep:', err instanceof Error ? err.message : String(err));
+    return new Map();
+  }
+  return out;
+}
+
+// opts.refreshAffiliation: re-query each live user's CURRENT corp/alliance from
+// ESI before the gate check, so a pilot who changed/left corp is evaluated on
+// their real affiliation rather than the stored (stale) value. Used by the
+// periodic sweep. The admin-triggered sweeps (grant removed, settings/standings
+// changed) leave it OFF — they're reacting to a gate change, not corp drift, and
+// shouldn't pay an ESI round-trip in the request path.
+export async function revalidateActiveSessions(opts: { refreshAffiliation?: boolean } = {}): Promise<RevalidateResult> {
   // Solo (unrestricted) deployments have no gate — everyone is allowed, so
   // there is nothing to revoke.
   if (!config.restrictedMode) return { usersEvicted: 0, sessionsKilled: 0 };
@@ -41,6 +88,12 @@ export async function revalidateActiveSessions(): Promise<RevalidateResult> {
     return { rows: [] as Array<{ id: number; characterId: number; corpId: number | null; allianceId: number | null; blocked: boolean }> };
   });
 
+  // Fresh corp/alliance for every live user (empty map when disabled or on ESI
+  // failure — then we fall back to the stored ids per-user below).
+  const fresh = opts.refreshAffiliation
+    ? await fetchAffiliations(rows.map((r) => Number(r.characterId)))
+    : new Map<number, Affiliation>();
+
   let usersEvicted = 0;
   let sessionsKilled = 0;
   for (const u of rows) {
@@ -50,7 +103,23 @@ export async function revalidateActiveSessions(): Promise<RevalidateResult> {
     const characterId = Number(u.characterId);
     // Never evict the configured bootstrap admin — the safety hatch.
     if (config.adminCharId !== null && characterId === config.adminCharId) continue;
-    const ids = { characterId, corpId: u.corpId, allianceId: u.allianceId };
+
+    // Adopt fresh affiliation when we have it; persist + audit a real change so
+    // the DB stops being stale. Missing (char deleted / ESI gap) → stored ids.
+    let corpId = u.corpId;
+    let allianceId = u.allianceId;
+    const aff = fresh.get(characterId);
+    if (aff) {
+      if (aff.corpId !== u.corpId || aff.allianceId !== u.allianceId) {
+        await db.query(`UPDATE users SET corp_id = $1, alliance_id = $2, updated_at = NOW() WHERE id = $3`, [aff.corpId, aff.allianceId, u.id]);
+        await audit({ session: {} }, u.id, characterId, 'corp_change',
+          u.corpId !== null ? String(u.corpId) : null, aff.corpId !== null ? String(aff.corpId) : null);
+      }
+      corpId = aff.corpId;
+      allianceId = aff.allianceId;
+    }
+
+    const ids = { characterId, corpId, allianceId };
     const stillOk = !u.blocked && (await isLoginPermitted(ids) || await standingsPermitLogin(ids));
     if (!stillOk) {
       const n = await invalidateSessionsForUser(u.id);
@@ -69,6 +138,8 @@ export async function revalidateActiveSessions(): Promise<RevalidateResult> {
 export function startAccessRevalidation(): void {
   if (!config.restrictedMode || config.accessRevalidateMinutes <= 0) return;
   const ms = config.accessRevalidateMinutes * 60 * 1000;
-  setInterval(() => { void revalidateActiveSessions().catch((err) => log.error('periodic revalidation failed:', err)); }, ms);
+  // Periodic sweep refreshes affiliation from ESI — this is the path that catches
+  // a pilot who left an admitted corp without re-logging in.
+  setInterval(() => { void revalidateActiveSessions({ refreshAffiliation: true }).catch((err) => log.error('periodic revalidation failed:', err)); }, ms);
   log.info(`Access re-validation sweep every ${config.accessRevalidateMinutes} min.`);
 }

--- a/server/src/test/integrationDb.ts
+++ b/server/src/test/integrationDb.ts
@@ -1,0 +1,91 @@
+// Shared harness for the DB-integration suites: connects to the throwaway `*_test`
+// database (redirected by vitest.setup.ts), builds the real schema via migrate(),
+// and provides truncate + seed helpers. Runs the REAL SQL — nothing here is
+// mocked — so it catches authz bugs that the mocked-db unit tests cannot.
+//
+// If the test DB is unreachable, ensureIntegrationDb() returns false and the
+// suites skip (describe.skipIf) rather than fail — so `yarn test` still runs the
+// unit suites on a machine with no Postgres. CI provides the DB, so they run there.
+import { db } from '../db.js';
+import { migrate } from '../migrate.js';
+
+// connect-pg-simple creates its session table lazily on first login; migrate()
+// doesn't. revalidateActiveSessions() reads sessions.sess->>'userId' + .expire,
+// so build a matching table for the tests.
+const SESSIONS_DDL = `
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid    varchar     NOT NULL PRIMARY KEY,
+    sess   json        NOT NULL,
+    expire timestamp(6) NOT NULL
+  );`;
+
+let ready: Promise<boolean> | null = null;
+
+export function ensureIntegrationDb(): Promise<boolean> {
+  if (!ready) {
+    ready = (async () => {
+      try {
+        await db.query('SELECT 1');
+      } catch {
+        return false; // no test DB reachable — suites skip
+      }
+      await migrate();
+      await db.query(SESSIONS_DDL);
+      return true;
+    })();
+  }
+  return ready;
+}
+
+const TABLES = [
+  'access_grants', 'app_settings', 'map_shares', 'maps',
+  'corp_standings', 'alliance_standings', 'character_standings',
+  'standings_refresh', 'entity_names', 'sessions', 'user_events', 'users',
+];
+
+export async function truncateAll(): Promise<void> {
+  await db.query(`TRUNCATE ${TABLES.join(', ')} RESTART IDENTITY CASCADE`);
+}
+
+export interface SeedUser {
+  characterId: number;
+  corpId?:     number | null;
+  allianceId?: number | null;
+  role?:       string;
+  blocked?:    boolean;
+  name?:       string;
+}
+
+// Insert a user row (most columns default) and return its generated id.
+export async function seedUser(u: SeedUser): Promise<number> {
+  const { rows } = await db.query<{ id: number }>(
+    `INSERT INTO users (character_id, character_name, role, corp_id, alliance_id, blocked)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [u.characterId, u.name ?? `Pilot ${u.characterId}`, u.role ?? 'readonly',
+     u.corpId ?? null, u.allianceId ?? null, u.blocked ?? false],
+  );
+  return rows[0].id;
+}
+
+let sidCounter = 0;
+
+// Insert a session row for a user. Live by default; { expired: true } sets an
+// expiry in the past so the revalidation scan (WHERE expire > NOW()) skips it.
+export async function seedSession(userId: number, opts: { expired?: boolean } = {}): Promise<string> {
+  const sid = `test-sid-${userId}-${++sidCounter}`;
+  const expireExpr = opts.expired ? `NOW() - INTERVAL '1 hour'` : `NOW() + INTERVAL '1 day'`;
+  await db.query(
+    `INSERT INTO sessions (sid, sess, expire) VALUES ($1, $2::json, ${expireExpr})`,
+    [sid, JSON.stringify({ userId })],
+  );
+  return sid;
+}
+
+export async function liveSessionCount(userId: number): Promise<number> {
+  const { rows } = await db.query<{ n: string }>(
+    `SELECT COUNT(*)::int AS n FROM sessions WHERE (sess->>'userId')::int = $1`,
+    [userId],
+  );
+  return Number(rows[0]?.n ?? 0);
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,6 +4,12 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // Loads .env, relaxes prod guards, and redirects the pool to a *_test DB.
+    setupFiles: ['./vitest.setup.ts'],
+    // The *.integration.test.ts suites share one test database and TRUNCATE
+    // between tests, so files must not run in parallel or they clobber each
+    // other. The suite is small, so serial files cost little.
+    fileParallelism: false,
   },
   // Source imports use explicit `.js` extensions (NodeNext ESM style); tell the
   // resolver to fall back to the `.ts` source when the `.js` file doesn't exist.

--- a/server/vitest.setup.ts
+++ b/server/vitest.setup.ts
@@ -12,6 +12,13 @@ loadDotenv();
 // Relax the prod-only guards in config.ts (SESSION_SECRET etc.) for tests.
 process.env.NODE_ENV = 'development';
 
+// config.ts requires TOKEN_ENCRYPTION_KEY unconditionally (and SESSION_SECRET
+// outside dev). A local .env supplies them; CI has none, so provide throwaway
+// values when unset. `||=` keeps any real local value. 64 hex chars avoids the
+// weak-key warning. These are test-only and never touch real data.
+process.env.TOKEN_ENCRYPTION_KEY ||= '0'.repeat(64);
+process.env.SESSION_SECRET       ||= 'vitest-session-secret-not-a-real-secret';
+
 const current = process.env.PG_DB ?? 'eve_nexum';
 const testDb = process.env.PG_TEST_DB ?? (current.endsWith('_test') ? current : `${current}_test`);
 if (!testDb.endsWith('_test')) {

--- a/server/vitest.setup.ts
+++ b/server/vitest.setup.ts
@@ -1,0 +1,20 @@
+// Runs (via setupFiles) in every test worker before the test modules load.
+//
+// Loads the local .env for DB credentials, relaxes config.ts's production guards,
+// and — critically — redirects the DB pool to a DEDICATED throwaway `*_test`
+// database. The integration suites TRUNCATE tables between tests, so this guard
+// makes it impossible to point them at a real database by accident: if the
+// resolved name doesn't end in `_test`, we refuse to start.
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv();
+
+// Relax the prod-only guards in config.ts (SESSION_SECRET etc.) for tests.
+process.env.NODE_ENV = 'development';
+
+const current = process.env.PG_DB ?? 'eve_nexum';
+const testDb = process.env.PG_TEST_DB ?? (current.endsWith('_test') ? current : `${current}_test`);
+if (!testDb.endsWith('_test')) {
+  throw new Error(`Refusing to run tests against non-test database "${testDb}" — the test DB name must end in _test`);
+}
+process.env.PG_DB = testDb;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -166,10 +166,22 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.3"
 
+"@noble/hashes@^1.1.5":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
 "@oxc-project/types@=0.139.0":
   version "0.139.0"
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.139.0.tgz#38d76b9dbf934c2a02be174fb32ceebf182fe742"
   integrity sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==
+
+"@paralleldrive/cuid2@^2.2.2":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz#3d62ea9e7be867d3fa94b9897fab5b0ae187d784"
+  integrity sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
 
 "@rolldown/binding-android-arm64@1.1.5":
   version "1.1.5"
@@ -299,6 +311,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookiejar@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
+  integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
+
 "@types/cors@^2.8.17":
   version "2.8.19"
   resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz"
@@ -347,6 +364,11 @@
   version "2.0.5"
   resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz"
   integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
+
+"@types/methods@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
+  integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
 
 "@types/mime@^1":
   version "1.3.5"
@@ -409,6 +431,24 @@
     "@types/http-errors" "*"
     "@types/node" "*"
     "@types/send" "<1"
+
+"@types/superagent@^8.1.0":
+  version "8.1.11"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-8.1.11.tgz#14da75aa2f916dcdd6fb2a90a8fb24a9a1a86d08"
+  integrity sha512-KA7srSW/HENDtOw9DOqaFLgWuMqN9WgjEw62lh9dpvRaZDkhdOkazASd7X7i2eMUYLHa1U37ZttnePsH5zTDHw==
+  dependencies:
+    "@types/cookiejar" "^2.1.5"
+    "@types/methods" "^1.1.4"
+    "@types/node" "*"
+    form-data "^4.0.0"
+
+"@types/supertest@^7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-7.2.1.tgz#165e99f10fd652027cf1eaa74b55081b6daa0965"
+  integrity sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==
+  dependencies:
+    "@types/methods" "^1.1.4"
+    "@types/superagent" "^8.1.0"
 
 "@types/unzipper@^0.10.11":
   version "0.10.11"
@@ -490,10 +530,20 @@ array-flatten@1.1.1:
   resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 bluebird@~3.7.2:
   version "3.7.2"
@@ -578,6 +628,18 @@ cheerio@^1.2.0:
     undici "^7.19.0"
     whatwg-mimetype "^4.0.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+component-emitter@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"
+  integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
+
 connect-pg-simple@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz"
@@ -602,6 +664,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-signature@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
 cookie-signature@~1.0.6, cookie-signature@~1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz"
@@ -611,6 +678,11 @@ cookie@~0.7.1, cookie@~0.7.2:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -648,6 +720,18 @@ debug@2.6.9, debug@~2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@^4.3.7:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
@@ -662,6 +746,14 @@ detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+dezalgo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 dom-serializer@^2.0.0:
   version "2.0.0"
@@ -768,6 +860,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild@^0.28.1, esbuild@~0.28.0:
   version "0.28.1"
@@ -886,6 +988,11 @@ express@^4.19.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
@@ -903,6 +1010,26 @@ finalhandler@~1.3.1:
     parseurl "~1.3.3"
     statuses "~2.0.2"
     unpipe "~1.0.0"
+
+form-data@^4.0.0, form-data@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+
+formidable@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.4.tgz#ac9a593b951e829b3298f21aa9a2243932f32ed9"
+  integrity sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==
+  dependencies:
+    "@paralleldrive/cuid2" "^2.2.2"
+    dezalgo "^1.0.4"
+    once "^1.4.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -933,7 +1060,7 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -967,15 +1094,29 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-has-symbols@^1.1.0:
+has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 hasown@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz"
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -1144,7 +1285,7 @@ merge-descriptors@1.0.3:
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -1154,7 +1295,7 @@ mime-db@1.52.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -1166,12 +1307,17 @@ mime@1.6.0:
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -1224,6 +1370,13 @@ on-headers@~1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz"
   integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
+
+once@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
 
 parse5-htmlparser2-tree-adapter@^7.1.0:
   version "7.1.0"
@@ -1372,7 +1525,7 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-qs@^6.15.2, qs@~6.14.0, qs@~6.15.1:
+qs@^6.14.1, qs@^6.15.2, qs@~6.14.0, qs@~6.15.1:
   version "6.15.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
   integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
@@ -1562,6 +1715,30 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+superagent@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-10.3.0.tgz#ff1e39e7976b63f8084291d65f5bfbbbbd156989"
+  integrity sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==
+  dependencies:
+    component-emitter "^1.3.1"
+    cookiejar "^2.1.4"
+    debug "^4.3.7"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.5"
+    formidable "^3.5.4"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.14.1"
+
+supertest@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-7.2.2.tgz#dac3ee25a2aa59942a7f641e50c838a7c8819204"
+  integrity sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==
+  dependencies:
+    cookie-signature "^1.2.2"
+    methods "^1.1.2"
+    superagent "^10.3.0"
+
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -1733,6 +1910,11 @@ why-is-node-running@^2.3.0:
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
Implements the "next test layer" the access-control design doc flagged as not-yet-
done: tests that run the **real authz SQL** against a throwaway `eve_nexum_test`
database, plus admin-endpoint tests. Authz can't rely on tsc/CodeQL, so this is the
layer that actually validates the SQL and the endpoint guards.

## It caught a real bug (fixed here)
`revalidateActiveSessions()` compared `character_id` (a **BIGINT**, which node-pg
returns as a **string**) against the numeric `config.adminCharId` with `===`. That
never matches — so the **bootstrap-admin safety-hatch never fired**, and a
revalidation sweep (grant removal, settings tighten, standings sync, periodic) could
evict the admin. Fixed by `Number()`-coercing before the compare. The mocked unit
tests missed it because the mock db returned numbers; the real DB returns the string.

## 27 new tests
- **accessGrants.integration** — `isLoginPermitted` (grant match by corp/alliance/
  character, null-corp no-match), `standingPermitsTarget` (corp + alliance install,
  positive-only, corp-install alliance contact, fail-closed), `standingsPermitLogin`
  (toggle off, thresholds 5/10, corp-admits-alliance, negative denied at both).
- **accessRevalidate.integration** — keep/evict, kill all of a user's sessions,
  bootstrap-admin exemption (the regression above), blocked-user eviction, solo
  no-op, expired-session skip, standings-auto-admit kept.
- **adminAccess.integration** (supertest + fake session) — unauth 401, non-admin
  403, positive-standing 201, `standing_not_positive` 403 (nothing written),
  character exempt, `env_immutable` delete 400, revocation session-kill.

## Infrastructure
- `vitest.setup.ts` redirects the pool to a dedicated `*_test` DB and **refuses to
  start unless the name ends in `_test`** — the TRUNCATE-heavy suites can never touch
  a real database.
- `src/test/integrationDb.ts`: real `migrate()` + seed/truncate helpers. Suites
  **skip** (`describe.skipIf`) when no test DB is reachable, so `yarn test` still runs
  the 25 unit tests on a machine with no Postgres.
- `fileParallelism: false` — the integration files share one DB, so they run serially.
- **CI**: the server job gains a `postgres:16` service + `PG_*` env so the layer runs
  on every PR. Verified locally: 52 tests pass with a DB; 25 pass / 27 skip without.

Adds `supertest` as a dev dependency (yarn.lock updated).