### PR TITLE
feat: system aliases at ESI/route display sites (follow-up)

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -39,6 +39,7 @@ import { watchMarker } from '../../data/watchMarkers';
 import { useHeatmap } from '../../context/HeatmapContext';
 import { useShareMode } from '../../context/ShareModeContext';
 import { systemDisplayName } from '../../utils/systemName';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { heatValue, heatColor } from '../../utils/heatmap';
 import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
@@ -209,13 +210,14 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
 
   // Tooltip label: dedupe by scout system name (Thera / Turnur). Multiple
   // connections from the same scout are summarised, mixed scouts are listed.
+  const aliasName = useSystemAlias();
   const scoutLabel = useMemo(() => {
     if (scoutMatches.length === 0) return '';
-    const names = Array.from(new Set(scoutMatches.map(c => c.outSystemName)));
+    const names = Array.from(new Set(scoutMatches.map(c => aliasName(c.outSystemName))));
     return names.length === 1
       ? t('mapNode.scoutConnections', { name: names[0], count: scoutMatches.length })
       : t('mapNode.scoutConnectionsMulti', { names: names.join(' & ') });
-  }, [scoutMatches, t]);
+  }, [scoutMatches, t, aliasName]);
   const isTarget        = connection.inProgress && connection.fromNode?.id !== sys.id;
 
   // Measure the node so the map store can compute the largest natural

--- a/web/src/components/ui/A0Pane.tsx
+++ b/web/src/components/ui/A0Pane.tsx
@@ -6,12 +6,14 @@ import { useA0Systems } from '../../hooks/useA0Systems';
 import { useRouteOrigin } from '../../hooks/useRouteOrigin';
 import { useRoute } from '../../hooks/useRoute';
 import { setWaypoint, RouteSquares } from './routeUi';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { useMapStore } from '../../store/mapStore';
 
 const TOP_N = 10;
 
 export function A0Pane() {
   const { t } = useTranslation();
+  const aliasName = useSystemAlias();
   const all      = useA0Systems();
   const routeMode = useMapStore((s) => s.routeMode);
   const origin   = useRouteOrigin();
@@ -58,9 +60,9 @@ export function A0Pane() {
   return (
     <div className="scout-pane">
       {origin.characterName && origin.name ? (
-        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: origin.name })}</div>
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: aliasName(origin.name) })}</div>
       ) : origin.fromLastKnown && origin.name ? (
-        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: origin.name })}</div>
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: aliasName(origin.name) })}</div>
       ) : null}
       <div className="scout-pane__note">{t('a0.showing', { count: TOP_N })}</div>
       {closest.map(s => {
@@ -69,7 +71,7 @@ export function A0Pane() {
         return (
           <div key={s.id} className="scout-row">
             <div className="scout-row__sys">
-              <span className="scout-row__name">{s.name}</span>
+              <span className="scout-row__name">{aliasName(s.name)}</span>
               <span className="scout-row__class scout-row__class--a0">A0</span>
             </div>
             <div className="scout-row__region">{s.regionName}</div>

--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -4,6 +4,7 @@ import { api } from '../../api/client';
 import { useMapStore, awaitSystemCreate } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useShareMode } from '../../context/ShareModeContext';
+import { systemDisplayName } from '../../utils/systemName';
 import { useUserSetting } from '../../hooks/useUserSetting';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import type { Anomaly, AnomType } from '../../types';
@@ -368,8 +369,10 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
       const delaySec = overwriteDelay;
 
       if (currentSystemId && currentSystemId !== systemId) {
-        const currentName  = map.systems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
-        const selectedName = map.systems.find((s) => s.id === systemId)?.name ?? 'unknown';
+        const cur = map.systems.find((s) => s.id === currentSystemId);
+        const sel = map.systems.find((s) => s.id === systemId);
+        const currentName  = cur ? systemDisplayName(cur) : 'unknown';
+        const selectedName = sel ? systemDisplayName(sel) : 'unknown';
         setPendingAction({
           message: t('anomalies.pasteDifferentSystem', { current: currentName, selected: selectedName }),
           fn: () => processPaste(parsed, overwrite, delaySec),

--- a/web/src/components/ui/ClosestSystemsPane.tsx
+++ b/web/src/components/ui/ClosestSystemsPane.tsx
@@ -12,6 +12,7 @@ import { useEsiSearch } from '../../hooks/useEsiSearch';
 import { useMapStore } from '../../store/mapStore';
 import { useUserSetting } from '../../hooks/useUserSetting';
 import { setWaypoint, RouteSquares } from './routeUi';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { useRouteOrigin } from '../../hooks/useRouteOrigin';
 import { jumps as jumpsLabel } from '../../i18n/format';
 
@@ -70,6 +71,7 @@ interface RowProps {
 
 function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
   const { t } = useTranslation();
+  const aliasName = useSystemAlias();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: String(item.id) });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -88,7 +90,7 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
         >
           ⠿
         </button>
-        <span className="scout-row__name">{item.name}</span>
+        <span className="scout-row__name">{aliasName(item.name)}</span>
         {item.isHome && (
           <span className="scout-row__home" aria-label={t('closest.home')} data-tooltip={t('closest.home')}>
             <HouseIcon size={14} weight="regular" color="#f0c040" />
@@ -153,6 +155,7 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
 
 export function ClosestSystemsPane() {
   const { t } = useTranslation();
+  const aliasName = useSystemAlias();
   const origin    = useRouteOrigin();
   const routeMode = useMapStore((s) => s.routeMode);
   const homeSystem = useMapStore(useShallow((s) => {
@@ -312,9 +315,9 @@ export function ClosestSystemsPane() {
   return (
     <div className="scout-pane">
       {origin.characterName && origin.name ? (
-        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: origin.name })}</div>
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: aliasName(origin.name) })}</div>
       ) : origin.fromLastKnown && origin.name ? (
-        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: origin.name })}</div>
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: aliasName(origin.name) })}</div>
       ) : null}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <SortableContext items={items.map((i) => String(i.id))} strategy={verticalListSortingStrategy}>
@@ -387,7 +390,7 @@ export function ClosestSystemsPane() {
                 onMouseEnter={() => !already && setActiveIndex(i)}
                 onMouseDown={(e) => { e.preventDefault(); if (!already) addSystem(r.id, r.name); }}
               >
-                <span className="scout-pane__add-result-name">{r.name}</span>
+                <span className="scout-pane__add-result-name">{aliasName(r.name)}</span>
                 <span className="scout-pane__add-result-region">
                   {already ? t('closest.onList') : (r.regionName ?? r.systemClass)}
                 </span>

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -5,6 +5,7 @@ import type { MapSystem, SystemClass } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS } from '../../data/wormholes';
 import { LEADS_TO_BANDS } from '../../utils/whDest';
 import { usePopover } from '../../hooks/usePopover';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 
 interface Props {
   value: string;
@@ -35,6 +36,7 @@ const K_SPACE: SystemClass[] = ['HS', 'LS', 'NS'];
 
 export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Props) {
   const { t } = useTranslation();
+  const aliasName = useSystemAlias();
   const { open, setOpen, pos, btnRef, dropdownRef, openAt } = usePopover();
   const [search, setSearch] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
@@ -128,7 +130,7 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
                     onMouseDown={() => select(sys.name || sys.id)}
                   >
                     <span className="wh-picker__code" style={{ color: '#c0d0e8', minWidth: 'auto', marginRight: 4 }}>
-                      {sys.name || t('mapNode.unknown')}
+                      {aliasName(sys.name) || t('mapNode.unknown')}
                     </span>
                     <span className="wh-picker__arrow"><ArrowRightIcon size={11} weight="bold" /></span>
                     <span className="wh-picker__dest" style={{ color: CLASS_COLORS[sys.systemClass] }}>

--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -7,6 +7,7 @@ import { whSizeForType, whSizeShort } from '../../utils/wormholeSize';
 import { useRouteOrigin } from '../../hooks/useRouteOrigin';
 import { useRoute } from '../../hooks/useRoute';
 import { setWaypoint, RouteSquares } from './routeUi';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { truesecColor } from '../../utils/truesec';
 import { useMapStore } from '../../store/mapStore';
 import { MapPinSimpleIcon, PathIcon } from '@phosphor-icons/react';
@@ -63,6 +64,7 @@ function formatRemaining(t: TFunction, hours: number): string {
 
 export function ScoutConnectionsPane({ scoutSystem }: Props) {
   const { t }    = useTranslation();
+  const aliasName = useSystemAlias();
   const all      = useScoutConnections();
   const origin   = useRouteOrigin();
   const routeMode = useMapStore((s) => s.routeMode);
@@ -131,9 +133,9 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
   return (
     <div className="scout-pane">
       {origin.characterName && origin.name ? (
-        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: origin.name })}</div>
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromCharacter', { character: origin.characterName, system: aliasName(origin.name) })}</div>
       ) : origin.fromLastKnown && origin.name ? (
-        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: origin.name })}</div>
+        <div className="scout-pane__note scout-pane__note--lastknown">{t('route.fromLastKnown', { system: aliasName(origin.name) })}</div>
       ) : null}
       <div className="scout-pane__sort">
         <label className="scout-pane__sort-label" htmlFor={`scout-sort-${scoutSystem}`}>
@@ -160,7 +162,7 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
         return (
           <div key={c.id} className="scout-row">
             <div className="scout-row__sys">
-              <span className="scout-row__name">{c.inSystemName}</span>
+              <span className="scout-row__name">{aliasName(c.inSystemName)}</span>
               {c.inSystemClass && (
                 <span
                   className="scout-row__class"

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -4,6 +4,7 @@ import { api } from '../../api/client';
 import { useMapStore, awaitSystemCreate } from '../../store/mapStore';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useShareMode } from '../../context/ShareModeContext';
+import { systemDisplayName } from '../../utils/systemName';
 import { useUserSetting } from '../../hooks/useUserSetting';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import type { Signature, SigType } from '../../types';
@@ -432,8 +433,8 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       updates.whType?.toUpperCase() === 'K162' &&
       existing?.whType?.toUpperCase() !== 'K162'
     ) {
-      const sysName = mapSystems.find((s) => s.id === systemId)?.name ?? 'unknown system';
-      alertInboundK162(sysName);
+      const sysForAlert = mapSystems.find((s) => s.id === systemId);
+      alertInboundK162(sysForAlert ? systemDisplayName(sysForAlert) : 'unknown system');
     }
 
     // Re-evaluate connections whenever whType or whLeadsTo changes — either
@@ -635,8 +636,10 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
       // Warn if the character is in a different system than the one being edited
       if (currentSystemId && currentSystemId !== systemId) {
-        const currentName  = mapSystems.find((s) => s.id === currentSystemId)?.name  ?? 'unknown';
-        const selectedName = mapSystems.find((s) => s.id === systemId)?.name ?? 'unknown';
+        const cur = mapSystems.find((s) => s.id === currentSystemId);
+        const sel = mapSystems.find((s) => s.id === systemId);
+        const currentName  = cur ? systemDisplayName(cur) : 'unknown';
+        const selectedName = sel ? systemDisplayName(sel) : 'unknown';
         setPendingAction({
           message: t('signatures.pasteDifferentSystem', { current: currentName, selected: selectedName }),
           fn: () => processPaste(parsed, overwrite, delaySec),

--- a/web/src/components/ui/SystemCombobox.tsx
+++ b/web/src/components/ui/SystemCombobox.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { MapSystem } from '../../types';
+import { systemDisplayName } from '../../utils/systemName';
 
 interface Props {
   systems: MapSystem[];
@@ -18,7 +19,7 @@ interface Props {
 // overflow can't clip it.
 export function SystemCombobox({ systems, value, onChange, placeholder, excludeId }: Props) {
   const { t } = useTranslation();
-  const nameById = useMemo(() => new Map(systems.map((s) => [s.id, s.name])), [systems]);
+  const nameById = useMemo(() => new Map(systems.map((s) => [s.id, systemDisplayName(s)])), [systems]);
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -139,7 +140,7 @@ export function SystemCombobox({ systems, value, onChange, placeholder, excludeI
                 onMouseDown={(e) => { e.preventDefault(); select(s.id); }}
                 onMouseEnter={() => setActiveIndex(i)}
               >
-                <span>{s.name}</span>
+                <span>{systemDisplayName(s)}</span>
                 <span className="search-results__class">{s.systemClass}</span>
               </li>
             ))

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -6,6 +6,7 @@ import { useMapStore } from '../../store/mapStore';
 import { useAuth, formatRole, isAdminRole } from '../../context/AuthContext';
 import { useOnlineStatus } from '../../hooks/useOnlineStatus';
 import { useCharacterLocation } from '../../hooks/useCharacterLocation';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { useCanEdit } from '../../hooks/useCanEdit';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
 import { useIsMapOwner } from '../../hooks/useIsMapOwner';
@@ -261,6 +262,7 @@ export function Toolbar() {
   // Ship + live system come from the same poll that drives passive location
   // tracking, so no extra ESI traffic — we just surface fields already on hand.
   const { ship, system: liveSystem, online: locOnline } = useCharacterLocation();
+  const aliasName = useSystemAlias();
   // What to show next to the avatar: the live system when the pilot is online
   // in EVE, otherwise the last known system from their profile.
   const shownSystem = (locOnline && liveSystem?.name) ? liveSystem.name : (user?.lastKnownSystem?.name ?? null);
@@ -269,6 +271,9 @@ export function Toolbar() {
   // Clicking the system centres the map on it — but only when it's actually on
   // the current map.
   const shownSystemOnMap = shownSystemEveId != null && mapSystems.some((s) => s.eveSystemId === shownSystemEveId);
+  // Display-only: show the per-map alias when this system has one (real name
+  // still drives centring via shownSystemEveId).
+  const shownSystemDisplay = aliasName(shownSystem);
   const eveStatus = useEveServerStatus();
   const [showMaps, setShowMaps]   = useState(false);
   const [showStats, setShowStats] = useState(false);
@@ -619,11 +624,11 @@ export function Toolbar() {
               <button
                 type="button"
                 className="toolbar__char-system toolbar__char-system--clickable"
-                data-tooltip={t('toolbar.centerOnSystem', { system: shownSystem })}
+                data-tooltip={t('toolbar.centerOnSystem', { system: shownSystemDisplay })}
                 onClick={() => { if (shownSystemEveId != null) requestCenterOnEveSystem(shownSystemEveId); }}
               >
                 <MapPinIcon size={11} weight="fill" />
-                {shownSystem}
+                {shownSystemDisplay}
               </button>
             ) : (
               <span
@@ -631,7 +636,7 @@ export function Toolbar() {
                 data-tooltip={shownSystemIsLast ? t('toolbar.lastKnownSystem') : t('toolbar.currentSystem')}
               >
                 <MapPinIcon size={11} weight="fill" />
-                {shownSystem}
+                {shownSystemDisplay}
               </span>
             ))}
             {checkedAt && <CheckedAtIcon checkedAt={checkedAt} />}

--- a/web/src/components/ui/routeUi.tsx
+++ b/web/src/components/ui/routeUi.tsx
@@ -6,6 +6,7 @@ import { toast } from './Toaster';
 import i18n from '../../i18n';
 import { truesecColor } from '../../utils/truesec';
 import { ContextMenu } from './ContextMenu';
+import { useSystemAlias } from '../../hooks/useSystemAlias';
 import type { RouteEntry, RoutePathNode, EdgeMeta } from '../../hooks/useRoute';
 
 /** Fire ESI waypoint endpoint; surface success/failure via toast. */
@@ -43,6 +44,7 @@ function viaLabel(t: TFunction, via: EdgeMeta): string {
  */
 export function RouteSquares({ route }: { route: RouteEntry }) {
   const { t } = useTranslation();
+  const aliasName = useSystemAlias();
   const [menu, setMenu] = useState<{ x: number; y: number; node: RoutePathNode } | null>(null);
 
   return (
@@ -61,8 +63,8 @@ export function RouteSquares({ route }: { route: RouteEntry }) {
           <span
             className={`scout-route__square${sys.kspace ? ' scout-route__square--kspace' : ''}`}
             style={{ background: truesecColor(sys.security) }}
-            data-tooltip={`${sys.name} ${sys.security.toFixed(1)}`}
-            aria-label={`${sys.name} ${sys.security.toFixed(1)}`}
+            data-tooltip={`${aliasName(sys.name)} ${sys.security.toFixed(1)}`}
+            aria-label={`${aliasName(sys.name)} ${sys.security.toFixed(1)}`}
             onContextMenu={sys.kspace
               ? (e) => { e.preventDefault(); setMenu({ x: e.clientX, y: e.clientY, node: sys }); }
               : undefined}

--- a/web/src/hooks/useSystemAlias.ts
+++ b/web/src/hooks/useSystemAlias.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useMapStore } from '../store/mapStore';
+
+/**
+ * Returns a resolver `(realName) => alias || realName` for display sites that
+ * only have a system's real NAME string (route hops, closest/scout lists, live
+ * location, pickers) rather than the MapSystem object. Looks the name up against
+ * the current map's aliases so an aliased system reads consistently everywhere.
+ *
+ * Display-only: never feed the result back into routing/ESI or a stored value —
+ * pass the real name to those. Memoised on the systems array (stable until
+ * systems change); maps are small.
+ */
+export function useSystemAlias(): (realName: string | null | undefined) => string {
+  const systems = useMapStore((s) => s.map.systems);
+  const aliasByName = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of systems) {
+      const a = s.alias?.trim();
+      if (a) m.set(s.name, a);
+    }
+    return m;
+  }, [systems]);
+  return (realName) => (realName ? aliasByName.get(realName) ?? realName : (realName ?? ''));
+}


### PR DESCRIPTION
Follow-up to the system-alias core (#468).

#468 aliased every **MapSystem-backed** display site (map node, system-panel header, connection panel, chains, command palette, watchlist toasts). It deliberately deferred the sites that only carry a system's real **name string** (ESI / route-sourced), where `name` doubles as a routing/matching key.

This PR closes those out using the `useSystemAlias()` resolver (`realName -> alias || realName`, built from the current map's systems):

- **routeUi** route squares (tooltip/aria)
- **ClosestSystemsPane** / **A0Pane** rows, origin notes, add-search results
- **ScoutConnectionsPane** list rows + origin notes; **SystemNode** scout tooltip
- **Toolbar** character location chip
- **LeadsToDropdown** / **SystemCombobox** picker labels (selected/stored value stays the real name)
- **AnomalyPane** / **SignaturePane** paste-different-system confirm dialogs + inbound-K162 alert

Display-only, as before: every waypoint/`setWaypoint`, `addSystem`, filter/sort, name-based match and stored value continues to use the **real** system name. Alias is purely cosmetic.

tsc + lint (0 errors) + build all pass.