### PR TITLE
feat: show system alias in the closed leads-to field

### DIFF
--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -70,7 +70,9 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
   const band = value ? J_SPACE.find((o) => o.value === value) : undefined;
   const isClass = value ? value in CLASS_LABELS : false;
   const displayColor = band ? band.color : isClass ? CLASS_COLORS[value as SystemClass] : '#c0d0e8';
-  const displayLabel = band ? band.label : isClass ? CLASS_LABELS[value as SystemClass] : value;
+  // Free-form connected-system value: show its per-map alias when set (display
+  // only — the stored `value` stays the real system name).
+  const displayLabel = band ? band.label : isClass ? CLASS_LABELS[value as SystemClass] : aliasName(value);
 
   return (
     <div className="wh-picker">


### PR DESCRIPTION
The leads-to picker's open list already displays a connected system's per-map alias (from #469). But the **collapsed** field still showed the raw stored value (the real name), so an aliased system read inconsistently - alias when open, real name when closed (see screenshots in chat).

This routes the free-form value label through the existing `aliasName` resolver. `aliasName` is a no-op for anything that isn't an aliased map system, so bands (C1-C3), classes, and non-aliased names are unaffected.

Display-only: the stored leads-to `value` (what `onChange` persists and what topology/matching use) stays the real system name.