### PR TITLE
Release candidate: leads-to field alias display

### DIFF
--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -70,7 +70,9 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
   const band = value ? J_SPACE.find((o) => o.value === value) : undefined;
   const isClass = value ? value in CLASS_LABELS : false;
   const displayColor = band ? band.color : isClass ? CLASS_COLORS[value as SystemClass] : '#c0d0e8';
-  const displayLabel = band ? band.label : isClass ? CLASS_LABELS[value as SystemClass] : value;
+  // Free-form connected-system value: show its per-map alias when set (display
+  // only — the stored `value` stays the real system name).
+  const displayLabel = band ? band.label : isClass ? CLASS_LABELS[value as SystemClass] : aliasName(value);
 
   return (
     <div className="wh-picker">


### PR DESCRIPTION
Promotes `qa` to `release`.

### Included
- **Leads-to field: show alias in the closed picker label** (#472) - the leads-to dropdown list already showed a connected system's per-map alias; this routes the collapsed field's label through the same resolver so an aliased system reads consistently open and closed. Display-only; the stored leads-to value stays the real system name.