### PR TITLE
Release 3.1.2

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.1.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/LeadsToDropdown.tsx
+++ b/web/src/components/ui/LeadsToDropdown.tsx
@@ -70,7 +70,9 @@ export function LeadsToDropdown({ value, onChange, connectedSystems = [] }: Prop
   const band = value ? J_SPACE.find((o) => o.value === value) : undefined;
   const isClass = value ? value in CLASS_LABELS : false;
   const displayColor = band ? band.color : isClass ? CLASS_COLORS[value as SystemClass] : '#c0d0e8';
-  const displayLabel = band ? band.label : isClass ? CLASS_LABELS[value as SystemClass] : value;
+  // Free-form connected-system value: show its per-map alias when set (display
+  // only — the stored `value` stays the real system name).
+  const displayLabel = band ? band.label : isClass ? CLASS_LABELS[value as SystemClass] : aliasName(value);
 
   return (
     <div className="wh-picker">


### PR DESCRIPTION
Promotes `release` to `main` for the **3.1.2** patch.

### Included
- **Leads-to field: show alias in the closed picker label** (#472) - the leads-to dropdown list already showed a connected system's per-map alias; this routes the collapsed field's label through the same resolver so an aliased system reads consistently open and closed. Display-only; the stored leads-to value stays the real system name.

Version bumped to 3.1.2 (web + server). A `v3.1.2` GitHub release/tag will be cut after merge.