### PR TITLE
feat: auto-set and auto-age wormhole connection lifetimes

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -158,6 +158,13 @@ export const config = {
     const n = parseInt(process.env.LAZY_WH_SWEEP_MINUTES ?? '15', 10);
     return Number.isFinite(n) && n >= 0 ? n : 15;
   })(),
+  // Cadence (minutes) of the connection-lifetime sweep, which re-buckets each
+  // wormhole connection's time status (fresh / <1d / <4h / <1h / expired) from
+  // its age so holes visibly decay on their own. Default 60; 0 disables it.
+  connLifetimeSweepMinutes: (() => {
+    const n = parseInt(process.env.CONN_LIFETIME_SWEEP_MINUTES ?? '60', 10);
+    return Number.isFinite(n) && n >= 0 ? n : 60;
+  })(),
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },

--- a/server/src/data/whLifetimes.test.ts
+++ b/server/src/data/whLifetimes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { lifeBucket, effectiveExpiryMs, whLifetimeHours } from './whLifetimes.js';
+
+const H = 3_600_000;
+
+describe('lifeBucket', () => {
+  it('maps remaining time to the right bucket', () => {
+    expect(lifeBucket(30 * H)).toBe('fresh');        // > 24h
+    expect(lifeBucket(24 * H)).toBe('lessThan24h');  // exactly a day → decaying
+    expect(lifeBucket(5 * H)).toBe('lessThan24h');
+    expect(lifeBucket(4 * H)).toBe('lessThan4h');    // exactly 4h → EOL window
+    expect(lifeBucket(2 * H)).toBe('lessThan4h');
+    expect(lifeBucket(1 * H)).toBe('lessThan1h');    // exactly 1h
+    expect(lifeBucket(30 * 60 * 1000)).toBe('lessThan1h');
+    expect(lifeBucket(0)).toBe('expired');
+    expect(lifeBucket(-1)).toBe('expired');
+    // Boundaries are inclusive of the shorter bucket.
+    expect(lifeBucket(24 * H + 1)).toBe('fresh');
+    expect(lifeBucket(4 * H + 1)).toBe('lessThan24h');
+    expect(lifeBucket(1 * H + 1)).toBe('lessThan4h');
+  });
+});
+
+describe('effectiveExpiryMs', () => {
+  const created = new Date('2026-01-01T00:00:00Z');
+  const createdMs = created.getTime();
+
+  it('auto: createdAt + charted max life for a known non-K162 code', () => {
+    // M609 is a 16h hole.
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'M609', createdAt: created });
+    expect(exp).toBe(createdMs + 16 * H);
+  });
+
+  it('a 16h hole is "< 1 day" at open and "< 4h" after 12h', () => {
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'M609', createdAt: created })!;
+    expect(lifeBucket(exp - createdMs)).toBe('lessThan24h');              // at open: 16h left
+    expect(lifeBucket(exp - (createdMs + 12 * H))).toBe('lessThan4h');    // after 12h: 4h left
+  });
+
+  it('a fresh 24h static opens at "< 1 day", never "fresh"', () => {
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'A239', createdAt: created })!;
+    expect(whLifetimeHours('A239')).toBe(24);
+    expect(lifeBucket(exp - createdMs)).toBe('lessThan24h');
+  });
+
+  it('a 48h hole opens "fresh"', () => {
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'B041', createdAt: created })!;
+    expect(whLifetimeHours('B041')).toBe(48);
+    expect(lifeBucket(exp - createdMs)).toBe('fresh');
+  });
+
+  it('untyped or bare K162 has no computable expiry', () => {
+    expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: null, createdAt: created })).toBeNull();
+    expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: '', createdAt: created })).toBeNull();
+    expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'K162', createdAt: created })).toBeNull();
+  });
+
+  it('manual override wins over the auto estimate', () => {
+    const override = new Date('2026-01-02T00:00:00Z');
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: override, eolAt: null, whType: 'M609', createdAt: created });
+    expect(exp).toBe(override.getTime());
+  });
+
+  it('a legacy eol_at mark ages as a 4h window from when it was set', () => {
+    const eol = new Date('2026-01-01T10:00:00Z');
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: eol, whType: 'M609', createdAt: created });
+    expect(exp).toBe(eol.getTime() + 4 * H);
+  });
+});

--- a/server/src/data/whLifetimes.test.ts
+++ b/server/src/data/whLifetimes.test.ts
@@ -49,10 +49,17 @@ describe('effectiveExpiryMs', () => {
     expect(lifeBucket(exp - createdMs)).toBe('fresh');
   });
 
-  it('untyped or bare K162 has no computable expiry', () => {
+  it('untyped / unrecognised has no computable expiry', () => {
     expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: null, createdAt: created })).toBeNull();
     expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: '', createdAt: created })).toBeNull();
-    expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'K162', createdAt: created })).toBeNull();
+    expect(effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'ZZZ9', createdAt: created })).toBeNull();
+  });
+
+  it('a bare K162 decays against the 48h ceiling and opens fresh', () => {
+    expect(whLifetimeHours('K162')).toBe(48);
+    const exp = effectiveExpiryMs({ lifetimeExpiresAt: null, eolAt: null, whType: 'K162', createdAt: created })!;
+    expect(exp).toBe(createdMs + 48 * H);
+    expect(lifeBucket(exp - createdMs)).toBe('fresh');
   });
 
   it('manual override wins over the auto estimate', () => {

--- a/server/src/data/whLifetimes.ts
+++ b/server/src/data/whLifetimes.ts
@@ -71,11 +71,12 @@ export function lifeBucket(remainingMs: number): TimeBucket {
 
 /**
  * Estimated collapse time (ms since epoch) for a connection, or null when its
- * lifetime is unknown (untyped, or a bare K162 with no manual override — we
- * can't know the reverse side's real life, so it never auto-ages). Priority:
+ * lifetime is unknown (untyped / unrecognised code). Priority:
  *   1. manual override (lifetime_expires_at) — a user set it, so it always wins;
  *   2. legacy EOL mark (eol_at) — treated as a 4h window from when it was set;
- *   3. auto: created_at + the wh type's charted max life.
+ *   3. auto: created_at + the wh type's charted max life. A bare K162 (reverse
+ *      side, forward type unknown) has no inherent life, so it decays against the
+ *      48h max-possible ceiling — conservative, so it never expires early.
  */
 export function effectiveExpiryMs(row: {
   lifetimeExpiresAt: Date | string | null;
@@ -85,10 +86,7 @@ export function effectiveExpiryMs(row: {
 }): number | null {
   if (row.lifetimeExpiresAt) return new Date(row.lifetimeExpiresAt).getTime();
   if (row.eolAt)             return new Date(row.eolAt).getTime() + EOL_LIFE_MS;
-  const code = (row.whType ?? '').trim().toUpperCase();
-  if (code && code !== 'K162') {
-    const h = whLifetimeHours(code);
-    if (h != null) return new Date(row.createdAt).getTime() + h * HOUR_MS;
-  }
+  const h = whLifetimeHours(row.whType);   // K162 → 48h ceiling; unknown → null
+  if (h != null) return new Date(row.createdAt).getTime() + h * HOUR_MS;
   return null;
 }

--- a/server/src/data/whLifetimes.ts
+++ b/server/src/data/whLifetimes.ts
@@ -42,3 +42,53 @@ export function whLifetimeHours(code: string | null | undefined): number | null 
   if (c === 'K162') return MAX_WH_LIFETIME_HOURS;
   return WH_LIFETIME_HOURS[c] ?? null;
 }
+
+// ── Connection time-bucket model (mirrors web/src/utils/whLifetime.ts) ─────────
+// A connection's remaining life maps to one of these buckets. Kept in lockstep
+// with the client so the hourly sweep and the live edge label always agree.
+
+export type TimeBucket = 'fresh' | 'lessThan24h' | 'lessThan4h' | 'lessThan1h' | 'expired';
+
+const HOUR_MS = 3_600_000;
+// Length of the final "EOL" window a legacy eol_at mark represents (a marked
+// hole has ~4h of life left), so an old eol_at still ages correctly here.
+const EOL_LIFE_MS = 4 * HOUR_MS;
+
+/**
+ * The bucket a connection is in given the milliseconds of life it has left.
+ * Boundaries are inclusive of the shorter bucket, so a hole flips exactly at the
+ * threshold: a fresh 24h static opens at "< 1 day" (never "fresh"), and a 16h
+ * hole drops to "< 4h" once 12h have elapsed. "fresh" (> 24h left) is therefore
+ * only reachable by a hole whose max life exceeds 24h.
+ */
+export function lifeBucket(remainingMs: number): TimeBucket {
+  if (remainingMs <= 0)             return 'expired';
+  if (remainingMs <= HOUR_MS)       return 'lessThan1h';
+  if (remainingMs <= EOL_LIFE_MS)   return 'lessThan4h';
+  if (remainingMs <= 24 * HOUR_MS)  return 'lessThan24h';
+  return 'fresh';
+}
+
+/**
+ * Estimated collapse time (ms since epoch) for a connection, or null when its
+ * lifetime is unknown (untyped, or a bare K162 with no manual override — we
+ * can't know the reverse side's real life, so it never auto-ages). Priority:
+ *   1. manual override (lifetime_expires_at) — a user set it, so it always wins;
+ *   2. legacy EOL mark (eol_at) — treated as a 4h window from when it was set;
+ *   3. auto: created_at + the wh type's charted max life.
+ */
+export function effectiveExpiryMs(row: {
+  lifetimeExpiresAt: Date | string | null;
+  eolAt:             Date | string | null;
+  whType:            string | null;
+  createdAt:         Date | string;
+}): number | null {
+  if (row.lifetimeExpiresAt) return new Date(row.lifetimeExpiresAt).getTime();
+  if (row.eolAt)             return new Date(row.eolAt).getTime() + EOL_LIFE_MS;
+  const code = (row.whType ?? '').trim().toUpperCase();
+  if (code && code !== 'K162') {
+    const h = whLifetimeHours(code);
+    if (h != null) return new Date(row.createdAt).getTime() + h * HOUR_MS;
+  }
+  return null;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -35,6 +35,7 @@ import { seedAccessGrantsFromEnv } from './services/accessGrantsSeed.js';
 import { startSdeAutoUpdate } from './services/sdeUpdate.js';
 import { startLocationPoller } from './services/locationPoll.js';
 import { startWhSweeper } from './services/whSweep.js';
+import { startConnLifetimeSweeper } from './services/connLifetimeSweep.js';
 import { startAccessRevalidation } from './services/accessRevalidate.js';
 import { startTelemetry } from './services/telemetry.js';
 import { telemetryRouter } from './routes/telemetry.js';
@@ -186,6 +187,7 @@ migrate()
     startSdeAutoUpdate();
     startLocationPoller();
     startWhSweeper();
+    startConnLifetimeSweeper();
     startAccessRevalidation();
     void startTelemetry();
   })

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -228,6 +228,13 @@ export async function migrate() {
     -- connection is kept on the map but quarantined (rendered severed, excluded
     -- from routing) so the chain is still traceable. See broken_chain_feature.
     ALTER TABLE map_connections ADD COLUMN IF NOT EXISTS broken    BOOLEAN NOT NULL DEFAULT FALSE;
+    -- Manual wormhole-lifetime override: when set, this is the estimated moment
+    -- the hole collapses and it drives the connection's time bucket (fresh / <1d
+    -- / <4h / <1h / expired). NULL = auto: the lifetime is derived on the fly
+    -- from created_at + the wh_type's charted max life (see services/connLifetimeSweep.ts
+    -- and the client's whLifetime util). Only user edits write this column, so a
+    -- non-null value always wins over the auto estimate.
+    ALTER TABLE map_connections ADD COLUMN IF NOT EXISTS lifetime_expires_at TIMESTAMPTZ;
     ALTER TABLE map_systems     ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
     -- Manual intel tag a user can apply to a system via right-click. Distinct

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -2147,7 +2147,7 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
     `SELECT id, source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
             target_handle AS "targetHandle", connection_type AS "connectionType", mass_status AS "massStatus",
             time_status AS "timeStatus", size, wh_type AS "type", COALESCE(mass_used, 0)::float8 AS "massUsed",
-            eol_at AS "eolAt", broken,
+            eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
             source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId",
             created_at AS "createdAt"
        FROM map_connections WHERE id = $1 AND map_id = $2`,
@@ -2178,11 +2178,29 @@ mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {
     timeStatus: 'time_status', size: 'size',
     sourceHandle: 'source_handle', targetHandle: 'target_handle',
     type: 'wh_type', massUsed: 'mass_used',
-    eolAt: 'eol_at', broken: 'broken',
+    eolAt: 'eol_at', lifetimeExpiresAt: 'lifetime_expires_at', broken: 'broken',
     sourceSignatureId: 'source_signature_id', targetSignatureId: 'target_signature_id',
   };
 
   const updates: Record<string, unknown> = { ...(req.body as Record<string, unknown>) };
+
+  // Validate the two time-bucket fields. The whitelist below trusts values
+  // verbatim, so reject anything malformed here (a bad ISO string would 22007
+  // the UPDATE and 500 the request; an unknown time_status would corrupt the
+  // edge state read by every client).
+  if ('timeStatus' in updates) {
+    const v = updates.timeStatus;
+    const VALID = ['fresh', 'eol', 'lessThan24h', 'lessThan4h', 'lessThan1h', 'expired'];
+    if (v !== null && (typeof v !== 'string' || !VALID.includes(v))) {
+      res.status(400).json({ error: 'invalid timeStatus' }); return;
+    }
+  }
+  if ('lifetimeExpiresAt' in updates) {
+    const v = updates.lifetimeExpiresAt;
+    if (v !== null && (typeof v !== 'string' || Number.isNaN(Date.parse(v)))) {
+      res.status(400).json({ error: 'invalid lifetimeExpiresAt' }); return;
+    }
+  }
 
   // The stored size should follow the hole type. When the wormhole type is set
   // without an explicit size — wormhole auto-detect and external API writes both

--- a/server/src/routes/share.ts
+++ b/server/src/routes/share.ts
@@ -181,7 +181,7 @@ shareRouter.get('/:token', async (req, res) => {
                 connection_type AS "connectionType", mass_status AS "massStatus",
                 time_status AS "timeStatus", size, wh_type AS "type",
                 COALESCE(mass_used, 0)::float8 AS "massUsed",
-                eol_at AS "eolAt", broken,
+                eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
                 source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId",
                 created_at AS "createdAt"
          FROM map_connections ${connectionWhere}`,

--- a/server/src/services/connLifetimeSweep.ts
+++ b/server/src/services/connLifetimeSweep.ts
@@ -1,0 +1,99 @@
+import { db } from '../db.js';
+import { config } from '../config.js';
+import { createLogger } from '../utils/logger.js';
+import { publishToMap } from './mapEvents.js';
+import { effectiveExpiryMs, lifeBucket, type TimeBucket } from '../data/whLifetimes.js';
+
+const log = createLogger('connLifetimeSweep');
+
+interface Row {
+  id:                string;
+  mapId:             string;
+  timeStatus:        string | null;
+  whType:            string | null;
+  eolAt:             Date | null;
+  lifetimeExpiresAt: Date | null;
+  createdAt:         Date;
+}
+
+/**
+ * One sweep pass: re-derive every standard wormhole connection's time bucket
+ * from its effective expiry (manual override > legacy EOL mark > createdAt +
+ * charted max life) and persist + broadcast the ones whose stored bucket has
+ * drifted. Display-only — this never deletes or severs a connection (an expired
+ * hole simply shows the expired state; sig-based removal stays with whSweep).
+ *
+ * The prefilter keeps the candidate set to holes with a determinable lifetime:
+ * a manual/legacy timestamp, or a known non-K162 type. Untyped and bare-K162
+ * connections have no computable expiry and are left untouched.
+ */
+async function sweepConnLifetimes(): Promise<void> {
+  let rows: Row[];
+  try {
+    const res = await db.query<Row>(
+      `SELECT id, map_id AS "mapId", time_status AS "timeStatus", wh_type AS "whType",
+              eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", created_at AS "createdAt"
+         FROM map_connections
+        WHERE connection_type = 'standard'
+          AND broken = FALSE
+          AND (lifetime_expires_at IS NOT NULL
+            OR eol_at IS NOT NULL
+            OR (wh_type IS NOT NULL AND wh_type <> '' AND UPPER(wh_type) <> 'K162'))`,
+    );
+    rows = res.rows;
+  } catch (err) {
+    log.warn(`candidate query failed: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  const now = Date.now();
+  // Group the connections whose bucket changed, keyed by their new bucket, so a
+  // whole sweep persists in at most one UPDATE per bucket value.
+  const changedByBucket = new Map<TimeBucket, string[]>();
+  const changed: { id: string; mapId: string; bucket: TimeBucket }[] = [];
+  for (const r of rows) {
+    const expiry = effectiveExpiryMs(r);
+    if (expiry === null) continue;
+    const bucket = lifeBucket(expiry - now);
+    if (bucket === r.timeStatus) continue;
+    const list = changedByBucket.get(bucket);
+    if (list) list.push(r.id); else changedByBucket.set(bucket, [r.id]);
+    changed.push({ id: r.id, mapId: r.mapId, bucket });
+  }
+
+  if (changed.length === 0) return;
+
+  try {
+    for (const [bucket, ids] of changedByBucket) {
+      await db.query(`UPDATE map_connections SET time_status = $1 WHERE id = ANY($2::uuid[])`, [bucket, ids]);
+    }
+  } catch (err) {
+    log.warn(`bucket update failed: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  // Bump updated_at for affected maps (so a delta-sync sees the change) and
+  // broadcast each connection.update with actor null → every open client applies
+  // it and its edge re-buckets live.
+  const affectedMaps = new Set(changed.map((c) => c.mapId));
+  for (const mapId of affectedMaps) {
+    await db.query(`UPDATE maps SET updated_at = NOW() WHERE id = $1`, [mapId]).catch(() => {});
+  }
+  for (const c of changed) {
+    publishToMap(c.mapId, { type: 'connection.update', actor: null, id: c.id, updates: { timeStatus: c.bucket } });
+  }
+  log.info(`re-bucketed ${changed.length} connection(s) across ${affectedMaps.size} map(s)`);
+}
+
+/**
+ * Start the periodic connection-lifetime sweep. Cadence is
+ * config.connLifetimeSweepMinutes (env CONN_LIFETIME_SWEEP_MINUTES, default 60);
+ * 0 disables it. First pass runs shortly after boot.
+ */
+export function startConnLifetimeSweeper(): void {
+  const mins = config.connLifetimeSweepMinutes;
+  if (mins <= 0) { log.info('connection-lifetime sweep disabled (CONN_LIFETIME_SWEEP_MINUTES=0)'); return; }
+  log.info(`connection-lifetime sweep enabled (every ${mins} min)`);
+  setTimeout(() => { void sweepConnLifetimes(); }, 90_000);
+  setInterval(() => { void sweepConnLifetimes(); }, mins * 60_000);
+}

--- a/server/src/services/connLifetimeSweep.ts
+++ b/server/src/services/connLifetimeSweep.ts
@@ -24,8 +24,8 @@ interface Row {
  * hole simply shows the expired state; sig-based removal stays with whSweep).
  *
  * The prefilter keeps the candidate set to holes with a determinable lifetime:
- * a manual/legacy timestamp, or a known non-K162 type. Untyped and bare-K162
- * connections have no computable expiry and are left untouched.
+ * a manual/legacy timestamp, or any typed hole (K162 decays against the 48h
+ * ceiling). Untyped connections have no computable expiry and are skipped in JS.
  */
 async function sweepConnLifetimes(): Promise<void> {
   let rows: Row[];
@@ -38,7 +38,7 @@ async function sweepConnLifetimes(): Promise<void> {
           AND broken = FALSE
           AND (lifetime_expires_at IS NOT NULL
             OR eol_at IS NOT NULL
-            OR (wh_type IS NOT NULL AND wh_type <> '' AND UPPER(wh_type) <> 'K162'))`,
+            OR (wh_type IS NOT NULL AND wh_type <> ''))`,
     );
     rows = res.rows;
   } catch (err) {

--- a/server/src/services/mapCopy.ts
+++ b/server/src/services/mapCopy.ts
@@ -118,13 +118,13 @@ export async function copyMap(params: {
     const connRes = await client.query<{
       sourceId: string; targetId: string; sourceHandle: string | null; targetHandle: string | null;
       connectionType: string; massStatus: string | null; timeStatus: string | null; size: string;
-      whType: string | null; massUsed: string; eolAt: Date | null; broken: boolean;
+      whType: string | null; massUsed: string; eolAt: Date | null; lifetimeExpiresAt: Date | null; broken: boolean;
       sourceSignatureId: string | null; targetSignatureId: string | null;
     }>(
       `SELECT source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
               target_handle AS "targetHandle", connection_type AS "connectionType",
               mass_status AS "massStatus", time_status AS "timeStatus", size, wh_type AS "whType",
-              mass_used AS "massUsed", eol_at AS "eolAt", broken,
+              mass_used AS "massUsed", eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
               source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId"
          FROM map_connections WHERE map_id = $1`,
       [sourceMapId],
@@ -132,7 +132,7 @@ export async function copyMap(params: {
     const remapSig = (id: string | null) => (id ? sigIdMap.get(id) ?? null : null);
     await insertBatch(client, 'map_connections',
       ['id', 'map_id', 'source_id', 'target_id', 'source_handle', 'target_handle', 'connection_type',
-       'mass_status', 'time_status', 'size', 'wh_type', 'mass_used', 'eol_at', 'broken',
+       'mass_status', 'time_status', 'size', 'wh_type', 'mass_used', 'eol_at', 'lifetime_expires_at', 'broken',
        'source_signature_id', 'target_signature_id'],
       connRes.rows.flatMap((c): unknown[][] => {
         const src = sysIdMap.get(c.sourceId);
@@ -140,7 +140,7 @@ export async function copyMap(params: {
         if (!src || !tgt) return [];
         return [[
           crypto.randomUUID(), newMapId, src, tgt, c.sourceHandle, c.targetHandle, c.connectionType,
-          c.massStatus, c.timeStatus, c.size, c.whType, c.massUsed, c.eolAt, c.broken,
+          c.massStatus, c.timeStatus, c.size, c.whType, c.massUsed, c.eolAt, c.lifetimeExpiresAt, c.broken,
           remapSig(c.sourceSignatureId), remapSig(c.targetSignatureId),
         ]];
       }),

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -108,7 +108,7 @@ export async function loadFullMap(mapId: string) {
               connection_type AS "connectionType", mass_status AS "massStatus",
               time_status AS "timeStatus", size, wh_type AS "type",
               COALESCE(mass_used, 0)::float8 AS "massUsed",
-              eol_at AS "eolAt", broken,
+              eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
               source_signature_id AS "sourceSignatureId",
               target_signature_id AS "targetSignatureId",
               created_at AS "createdAt"

--- a/web/src/components/map/ConnectionEdge.tsx
+++ b/web/src/components/map/ConnectionEdge.tsx
@@ -9,9 +9,12 @@ import type { MapConnection } from '../../types';
 import { useMapStore } from '../../store/mapStore';
 import { useNow30s } from '../../hooks/useNow30s';
 import { useWatchlist } from '../../hooks/useWatchlist';
+import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { matchConnection } from '../../utils/watchMatch';
 import { watchMarker } from '../../data/watchMarkers';
+import { effectiveExpiryMs, lifeBucket, type TimeBucket } from '../../utils/whLifetime';
 import { hoursMins } from '../../i18n/format';
+import type { TFunction } from 'i18next';
 
 // CSS custom properties (resolved via the edge path's inline `style`) so the
 // colour-vision palettes (--cv-conn-* in App.css) re-map connection colours.
@@ -23,9 +26,6 @@ const HIGHLIGHT_COLOR = 'var(--cv-conn-highlight)';
 // Perpendicular spacing between multiple connections that share the same pair
 // of systems, so they fan apart instead of stacking on one line.
 const PARALLEL_SEP = 18;
-
-const EOL_LIFE_MS    = 4 * 60 * 60 * 1000;
-const EOL_LESS_1H_MS = 60 * 60 * 1000;
 
 const TIME_COLORS: Record<string, string> = {
   lessThan4h: 'var(--cv-conn-4h)',
@@ -40,20 +40,20 @@ const MASS_LABELS: Record<string, { text: string; cls: string }> = {
 };
 
 /**
- * Given the EOL timestamp, return the live display state. Counts down from
- * 4h at the time EOL was marked; flips to "< 1 hr" when 3h have elapsed;
- * marks expired after 4h.
+ * Colour + label for a live time bucket. The two sub-4h buckets show a live
+ * countdown (updated by useNow30s); "< 1 day" is a static band label; a fresh
+ * hole (> 24h left) carries no time label. Returns null text ⇒ no label drawn.
  */
-function computeEolState(eolAt: string | null | undefined, now: number) {
-  if (!eolAt) return null;
-  const elapsed   = now - new Date(eolAt).getTime();
-  const remaining = EOL_LIFE_MS - elapsed;
-  if (remaining <= 0) return { color: TIME_COLORS.expired, label: '!', cls: 'connection-label__crit', expired: true };
-  const label = hoursMins(remaining);
-  if (remaining < EOL_LESS_1H_MS) {
-    return { color: TIME_COLORS.lessThan1h, label, cls: 'connection-label__eol', expired: false };
+function bucketDisplay(
+  bucket: TimeBucket, remainingMs: number, t: TFunction,
+): { color: string; text: string | null; cls: string } {
+  switch (bucket) {
+    case 'expired':     return { color: TIME_COLORS.expired,    text: '!',                     cls: 'connection-label__crit' };
+    case 'lessThan1h':  return { color: TIME_COLORS.lessThan1h, text: hoursMins(remainingMs),  cls: 'connection-label__eol' };
+    case 'lessThan4h':  return { color: TIME_COLORS.lessThan4h, text: hoursMins(remainingMs),  cls: 'connection-label__eol' };
+    case 'lessThan24h': return { color: STANDARD_COLOR,         text: t('mapEdge.lessThan24h'), cls: 'connection-label__eol' };
+    default:            return { color: STANDARD_COLOR,         text: null,                    cls: '' };
   }
-  return   { color: TIME_COLORS.lessThan4h, label, cls: 'connection-label__eol', expired: false };
 }
 
 export const ConnectionEdge = memo(({
@@ -70,6 +70,7 @@ export const ConnectionEdge = memo(({
     parallelCount?: number;
   };
   const selectConnection = useMapStore((s) => s.selectConnection);
+  const whTypes = useWormholeTypes();
   const now = useNow30s();
 
   // Lit because the hovered/selected system is one of its endpoints — these get
@@ -126,13 +127,17 @@ export const ConnectionEdge = memo(({
   // still traceable but clearly no longer an active link.
   const broken = !!conn?.broken;
 
-  // Live EOL state takes priority over the legacy categorical timeStatus.
-  const eolState   = !noLifetime ? computeEolState(conn?.eolAt, now) : null;
+  // Live lifetime: derive the current bucket from the hole's effective expiry
+  // (manual override, legacy EOL mark, or createdAt + the wh type's max life),
+  // re-evaluated every 30s via `now` so a hole visibly ages on its own. Null =
+  // lifetime unknown (untyped / bare K162) → fall back to the stored category.
+  const expiryMs   = !noLifetime && conn ? effectiveExpiryMs(conn, whTypes) : null;
+  const lifeState  = expiryMs != null ? bucketDisplay(lifeBucket(expiryMs - now), expiryMs - now, t) : null;
   const timeStatus = conn?.timeStatus ?? null;
 
   const color = isJumpgate ? JUMPGATE_COLOR
     : isGate ? GATE_COLOR
-    : (eolState?.color ?? TIME_COLORS[timeStatus ?? ''] ?? STANDARD_COLOR);
+    : (lifeState?.color ?? TIME_COLORS[timeStatus ?? ''] ?? STANDARD_COLOR);
   // Final stroke: broken keeps severed-red; otherwise a highlighted link (its
   // system is hovered/selected) takes the highlight hue, else its own state colour.
   const strokeColor = broken
@@ -151,10 +156,11 @@ export const ConnectionEdge = memo(({
   const strokeWidth = emphasized ? baseWidth + 2 : baseWidth;
   const massLabel   = !noLifetime && conn?.massStatus ? (MASS_LABELS[conn.massStatus] ?? null) : null;
 
-  // Prefer the live countdown label; fall back to the static category label
-  // if a connection has a legacy timeStatus value but no eolAt.
+  // Prefer the live bucket label; fall back to the stored category label only
+  // for a connection whose lifetime is unknown but which carries a legacy
+  // timeStatus value (e.g. a hand-set band on an untyped hole).
   const timeLabel = (() => {
-    if (eolState) return { text: eolState.label, cls: eolState.cls };
+    if (lifeState) return lifeState.text ? { text: lifeState.text, cls: lifeState.cls } : null;
     switch (timeStatus) {
       case 'lessThan24h': return { text: t('mapEdge.lessThan24h'), cls: 'connection-label__eol' };
       case 'lessThan4h':  return { text: t('mapEdge.lessThan4h'),  cls: 'connection-label__eol' };

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -956,52 +956,62 @@ export function MapCanvas() {
         {
           label: t('ctxMenu.whLifetime'),
           submenu: (() => {
-            // The submenu's checked indicator reflects what the user last
-            // selected (categorical), not the live derived stage. Live stage
-            // lives on the edge label; this is just "what option did I click?".
-            const hasEol = !!conn?.eolAt;
+            // The checked indicator is the coarse "what stage am I in?" hint from
+            // the stored category (the sweep keeps it current within the hour);
+            // the live countdown lives on the edge label. Picking a row sets a
+            // manual expiry (lifetimeExpiresAt) that then ages from that point.
+            const hasEol = !!conn?.eolAt || !!conn?.lifetimeExpiresAt;
             const stage: 'fresh' | 'lessThan24h' | 'eol' =
               timeStatus === 'lessThan24h' ? 'lessThan24h' :
-              hasEol || timeStatus === 'eol' ? 'eol' :
+              (hasEol || timeStatus === 'eol' || timeStatus === 'lessThan4h'
+                || timeStatus === 'lessThan1h' || timeStatus === 'expired') ? 'eol' :
               'fresh';
-            const eolFromOffset = (hrsBack: number) =>
-              new Date(Date.now() - hrsBack * 3_600_000).toISOString();
+            // Date.now() only inside the action closures — calling it while
+            // building the items trips the react-compiler "impure in render" rule.
+            const expiresIn = (hrs: number) =>
+              new Date(Date.now() + hrs * 3_600_000).toISOString();
             // "Fresh" carries the wormhole type's max lifetime when we know it. A
             // bare K162 (reverse side, forward type unidentified) has no inherent
             // lifetime, so it — and any untyped connection — shows no timespan.
             const whCode = (conn?.type ?? '').trim().toUpperCase();
             const lifeHrs = whCode && whCode !== 'K162' ? whTypes[whCode]?.lifetimeHours : undefined;
-            // Every row carries a `checked` boolean so they share the same layout
-            // (the check column). The state is categorical — the three EOL rows
-            // are quick "set how deep into EOL" actions; the eol stage reads on
-            // the first, matching the coarse indicator the edge label refines.
-            return [
-              {
-                label: lifeHrs ? t('ctxMenu.lifeFreshMax', { hours: lifeHrs }) : t('ctxMenu.lifeFresh'),
-                checked: stage === 'fresh',
-                action: () => updateConnection(eid, { timeStatus: 'fresh', eolAt: null }),
-              },
+            // Fresh = more than a day of life left, only reachable by a >24h hole.
+            // Hide it for a known 24h/16h hole (it opens straight into "< 1 day");
+            // keep it when the life is unknown (K162/untyped) since we can't rule
+            // it out. Setting it clears any legacy eol_at so the override wins.
+            const showFresh = !lifeHrs || lifeHrs > 24;
+            const rows: { label: string; checked: boolean; action: () => void }[] = [];
+            if (showFresh) rows.push({
+              label: lifeHrs ? t('ctxMenu.lifeFreshMax', { hours: lifeHrs }) : t('ctxMenu.lifeFresh'),
+              checked: stage === 'fresh',
+              action: () => updateConnection(eid, {
+                timeStatus: 'fresh', eolAt: null,
+                lifetimeExpiresAt: lifeHrs ? expiresIn(lifeHrs) : null,
+              }),
+            });
+            rows.push(
               {
                 label: t('ctxMenu.life1d'),
                 checked: stage === 'lessThan24h',
-                action: () => updateConnection(eid, { timeStatus: 'lessThan24h', eolAt: null }),
+                action: () => updateConnection(eid, { timeStatus: 'lessThan24h', eolAt: null, lifetimeExpiresAt: expiresIn(24) }),
               },
               {
                 label: t('ctxMenu.life4h'),
                 checked: stage === 'eol',
-                action: () => updateConnection(eid, { timeStatus: 'eol', eolAt: eolFromOffset(0) }),
+                action: () => updateConnection(eid, { timeStatus: 'lessThan4h', eolAt: null, lifetimeExpiresAt: expiresIn(4) }),
               },
               {
                 label: t('ctxMenu.life1h'),
                 checked: false,
-                action: () => updateConnection(eid, { timeStatus: 'eol', eolAt: eolFromOffset(3) }),
+                action: () => updateConnection(eid, { timeStatus: 'lessThan1h', eolAt: null, lifetimeExpiresAt: expiresIn(1) }),
               },
               {
                 label: t('ctxMenu.lifeExpired'),
                 checked: false,
-                action: () => updateConnection(eid, { timeStatus: 'eol', eolAt: eolFromOffset(4) }),
+                action: () => updateConnection(eid, { timeStatus: 'expired', eolAt: null, lifetimeExpiresAt: expiresIn(0) }),
               },
-            ];
+            );
+            return rows;
           })(),
         },
         {

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -16,6 +16,7 @@ import { useMapSignatureIndex } from '../../hooks/useMapSignatureIndex';
 import { useUndivedWormholeIndex } from '../../hooks/useUndivedWormholeIndex';
 import { useLeadsToIndex } from '../../hooks/useLeadsToIndex';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
+import { knownMaxLifeHours } from '../../utils/whLifetime';
 import { useCanEdit } from '../../hooks/useCanEdit';
 import { useMinimapPosition } from '../../hooks/useMinimapPosition';
 import { useShareMode } from '../../context/ShareModeContext';
@@ -970,11 +971,10 @@ export function MapCanvas() {
             // building the items trips the react-compiler "impure in render" rule.
             const expiresIn = (hrs: number) =>
               new Date(Date.now() + hrs * 3_600_000).toISOString();
-            // "Fresh" carries the wormhole type's max lifetime when we know it. A
-            // bare K162 (reverse side, forward type unidentified) has no inherent
-            // lifetime, so it — and any untyped connection — shows no timespan.
-            const whCode = (conn?.type ?? '').trim().toUpperCase();
-            const lifeHrs = whCode && whCode !== 'K162' ? whTypes[whCode]?.lifetimeHours : undefined;
+            // "Fresh" carries the hole's max lifetime when we know it: the type's
+            // charted life, or the 48h ceiling for a bare K162 (reverse side,
+            // forward type unidentified). Only an untyped connection has none.
+            const lifeHrs = knownMaxLifeHours({ type: conn?.type ?? null }, whTypes) ?? undefined;
             // Fresh = more than a day of life left, only reachable by a >24h hole.
             // Hide it for a known 24h/16h hole (it opens straight into "< 1 day");
             // keep it when the life is unknown (K162/untyped) since we can't rule

--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -9,6 +9,7 @@ import { systemDisplayName } from '../../utils/systemName';
 import { useCharacterLocation } from '../../hooks/useCharacterLocation';
 import { WHTypeInfo } from './WHTypeInfo';
 import { whSizeForType } from '../../utils/wormholeSize';
+import { effectiveExpiryMs, lifeBucket, knownMaxLifeHours } from '../../utils/whLifetime';
 import { ConfirmModal } from './ConfirmModal';
 import { XIcon } from '@phosphor-icons/react';
 import { api } from '../../api/client';
@@ -335,30 +336,29 @@ export function ConnectionPanel() {
         <span>{t('connPanel.timeStatus')}</span>
         <select
           value={(() => {
-            // Derive the live stage from eolAt + timeStatus so the dropdown
-            // tracks the same countdown the edge label shows.
-            if (conn.timeStatus === 'lessThan24h' && !conn.eolAt) return 'lessThan24h';
-            if (conn.eolAt) {
-              const elapsedH = (now - new Date(conn.eolAt).getTime()) / 3_600_000;
-              if (elapsedH >= 4) return 'expired';
-              if (elapsedH >= 3) return 'lessThan1h';
-              return 'lessThan4h';
-            }
-            return 'fresh';
+            // Derive the live stage from the hole's effective expiry so the
+            // dropdown tracks the same countdown the edge label shows.
+            const expiry = effectiveExpiryMs(conn, whTypes);
+            if (expiry != null) return lifeBucket(expiry - now);
+            return conn.timeStatus === 'lessThan24h' ? 'lessThan24h' : 'fresh';
           })()}
           onChange={(e) => {
             const v = e.target.value as TimeStatus;
-            const offset = (h: number) => new Date(Date.now() - h * 3_600_000).toISOString();
+            // A picked stage becomes a manual expiry that then ages from now.
+            const expiresIn = (h: number) => new Date(Date.now() + h * 3_600_000).toISOString();
+            const maxLife = knownMaxLifeHours(conn, whTypes);
             switch (v) {
-              case 'fresh':       update({ timeStatus: 'fresh',       eolAt: null });            break;
-              case 'lessThan24h': update({ timeStatus: 'lessThan24h', eolAt: null });            break;
-              case 'lessThan4h':  update({ timeStatus: 'eol',         eolAt: offset(0) });        break;
-              case 'lessThan1h':  update({ timeStatus: 'eol',         eolAt: offset(3) });        break;
-              case 'expired':     update({ timeStatus: 'eol',         eolAt: offset(4) });        break;
+              case 'fresh':       update({ timeStatus: 'fresh',       eolAt: null, lifetimeExpiresAt: maxLife ? expiresIn(maxLife) : null }); break;
+              case 'lessThan24h': update({ timeStatus: 'lessThan24h', eolAt: null, lifetimeExpiresAt: expiresIn(24) }); break;
+              case 'lessThan4h':  update({ timeStatus: 'lessThan4h',  eolAt: null, lifetimeExpiresAt: expiresIn(4) });  break;
+              case 'lessThan1h':  update({ timeStatus: 'lessThan1h',  eolAt: null, lifetimeExpiresAt: expiresIn(1) });  break;
+              case 'expired':     update({ timeStatus: 'expired',     eolAt: null, lifetimeExpiresAt: expiresIn(0) });  break;
             }
           }}
         >
-          <option value="fresh">{t('connPanel.fresh')}</option>
+          {(knownMaxLifeHours(conn, whTypes) ?? 48) > 24 && (
+            <option value="fresh">{t('connPanel.fresh')}</option>
+          )}
           <option value="lessThan24h">{t('connPanel.lessThan1d')}</option>
           <option value="lessThan4h">{t('connPanel.lessThan4h')}</option>
           <option value="lessThan1h">{t('connPanel.lessThan1h')}</option>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -167,6 +167,11 @@ export interface MapConnection {
   size: ConnectionSize;
   massUsed: number; // kg — total mass jumped through this connection
   eolAt: string | null; // ISO timestamp when EOL was marked (null = fresh)
+  /** Manual wormhole-lifetime override: the estimated ISO timestamp the hole
+   *  collapses, driving its time bucket. Null = auto (derived from createdAt +
+   *  the wh type's charted max life). Only user edits set this; a non-null value
+   *  wins over the auto estimate. See utils/whLifetime.ts. */
+  lifetimeExpiresAt?: string | null;
   /** Optional links to the backing wormhole signature at each end: the sig you
    *  warp to in the source system, and the (usually K162) sig in the target.
    *  Powers the per-hop "warp to ABC-123" directions in saved chains. Null when

--- a/web/src/utils/whLifetime.ts
+++ b/web/src/utils/whLifetime.ts
@@ -1,0 +1,63 @@
+import type { MapConnection } from '../types';
+import type { WormholeSpec } from '../hooks/useWormholeTypes';
+
+// Connection wormhole-lifetime model. Mirrors the server copy in
+// server/src/data/whLifetimes.ts (lifeBucket / effectiveExpiryMs) so the live
+// edge label and the hourly server sweep always land on the same bucket. Keep
+// the two in lockstep if the thresholds ever change.
+
+export type TimeBucket = 'fresh' | 'lessThan24h' | 'lessThan4h' | 'lessThan1h' | 'expired';
+
+const HOUR_MS = 3_600_000;
+// A legacy eol_at mark means "~4h of life left from when it was marked".
+export const EOL_LIFE_MS = 4 * HOUR_MS;
+
+/**
+ * The bucket a connection is in given the milliseconds of life it has left.
+ * Boundaries are inclusive of the shorter bucket, so a hole flips exactly at the
+ * threshold: a fresh 24h static opens at "< 1 day" (never "fresh"), and a 16h
+ * hole drops to "< 4h" once 12h have elapsed. Mirrors the server copy.
+ */
+export function lifeBucket(remainingMs: number): TimeBucket {
+  if (remainingMs <= 0)            return 'expired';
+  if (remainingMs <= HOUR_MS)      return 'lessThan1h';
+  if (remainingMs <= EOL_LIFE_MS)  return 'lessThan4h';
+  if (remainingMs <= 24 * HOUR_MS) return 'lessThan24h';
+  return 'fresh';
+}
+
+/**
+ * Estimated collapse time (ms since epoch) for a connection, or null when its
+ * lifetime is unknown (untyped, or a bare K162 with no manual override). Priority:
+ *   1. manual override (lifetimeExpiresAt) — a user set it, so it always wins;
+ *   2. legacy EOL mark (eolAt) — a 4h window from when it was set;
+ *   3. auto: createdAt + the wh type's charted max life.
+ */
+export function effectiveExpiryMs(
+  conn: Pick<MapConnection, 'lifetimeExpiresAt' | 'eolAt' | 'type' | 'createdAt'>,
+  whTypes: Record<string, WormholeSpec>,
+): number | null {
+  if (conn.lifetimeExpiresAt) return new Date(conn.lifetimeExpiresAt).getTime();
+  if (conn.eolAt)             return new Date(conn.eolAt).getTime() + EOL_LIFE_MS;
+  const code = (conn.type ?? '').trim().toUpperCase();
+  if (code && code !== 'K162') {
+    const h = whTypes[code]?.lifetimeHours;
+    if (h) return new Date(conn.createdAt).getTime() + h * HOUR_MS;
+  }
+  return null;
+}
+
+/**
+ * The wormhole type's charted max lifetime in hours, or null for an untyped or
+ * bare-K162 connection (life unknown). Drives the right-click / panel menus:
+ * "Fresh" (life > 24h remaining) is only reachable by a >24h hole, so the menu
+ * hides it when this is a known value <= 24.
+ */
+export function knownMaxLifeHours(
+  conn: Pick<MapConnection, 'type'>,
+  whTypes: Record<string, WormholeSpec>,
+): number | null {
+  const code = (conn.type ?? '').trim().toUpperCase();
+  if (!code || code === 'K162') return null;
+  return whTypes[code]?.lifetimeHours || null;
+}

--- a/web/src/utils/whLifetime.ts
+++ b/web/src/utils/whLifetime.ts
@@ -11,6 +11,10 @@ export type TimeBucket = 'fresh' | 'lessThan24h' | 'lessThan4h' | 'lessThan1h' |
 const HOUR_MS = 3_600_000;
 // A legacy eol_at mark means "~4h of life left from when it was marked".
 export const EOL_LIFE_MS = 4 * HOUR_MS;
+// A bare K162's forward type is unknown, so it decays against the longest life
+// any wormhole can have (48h) — conservative, so it never expires early. Mirrors
+// MAX_WH_LIFETIME_HOURS in server/src/data/whLifetimes.ts.
+const K162_MAX_LIFE_HOURS = 48;
 
 /**
  * The bucket a connection is in given the milliseconds of life it has left.
@@ -28,10 +32,10 @@ export function lifeBucket(remainingMs: number): TimeBucket {
 
 /**
  * Estimated collapse time (ms since epoch) for a connection, or null when its
- * lifetime is unknown (untyped, or a bare K162 with no manual override). Priority:
+ * lifetime is unknown (untyped / unrecognised code). Priority:
  *   1. manual override (lifetimeExpiresAt) — a user set it, so it always wins;
  *   2. legacy EOL mark (eolAt) — a 4h window from when it was set;
- *   3. auto: createdAt + the wh type's charted max life.
+ *   3. auto: createdAt + the wh type's charted max life (K162 → the 48h ceiling).
  */
 export function effectiveExpiryMs(
   conn: Pick<MapConnection, 'lifetimeExpiresAt' | 'eolAt' | 'type' | 'createdAt'>,
@@ -39,25 +43,23 @@ export function effectiveExpiryMs(
 ): number | null {
   if (conn.lifetimeExpiresAt) return new Date(conn.lifetimeExpiresAt).getTime();
   if (conn.eolAt)             return new Date(conn.eolAt).getTime() + EOL_LIFE_MS;
-  const code = (conn.type ?? '').trim().toUpperCase();
-  if (code && code !== 'K162') {
-    const h = whTypes[code]?.lifetimeHours;
-    if (h) return new Date(conn.createdAt).getTime() + h * HOUR_MS;
-  }
+  const h = knownMaxLifeHours(conn, whTypes);
+  if (h) return new Date(conn.createdAt).getTime() + h * HOUR_MS;
   return null;
 }
 
 /**
- * The wormhole type's charted max lifetime in hours, or null for an untyped or
- * bare-K162 connection (life unknown). Drives the right-click / panel menus:
- * "Fresh" (life > 24h remaining) is only reachable by a >24h hole, so the menu
- * hides it when this is a known value <= 24.
+ * The wormhole type's charted max lifetime in hours, or null for an untyped /
+ * unrecognised connection. A bare K162 resolves to the 48h ceiling. Drives the
+ * right-click / panel menus: "Fresh" (life > 24h remaining) is only reachable by
+ * a >24h hole, so the menu hides it when this is a known value <= 24.
  */
 export function knownMaxLifeHours(
   conn: Pick<MapConnection, 'type'>,
   whTypes: Record<string, WormholeSpec>,
 ): number | null {
   const code = (conn.type ?? '').trim().toUpperCase();
-  if (!code || code === 'K162') return null;
+  if (!code) return null;
+  if (code === 'K162') return K162_MAX_LIFE_HOURS;
   return whTypes[code]?.lifetimeHours || null;
 }


### PR DESCRIPTION
Wormhole connections now decay on their own based on the hole type's charted max life, instead of every lifetime being set by hand.

## Model
One source of truth per connection - its **effective expiry**:
1. **Manual override** (new `lifetime_expires_at` column) - a value a user set; always wins.
2. **Legacy `eol_at` mark** - treated as a 4h window from when it was set (old data still ages correctly).
3. **Auto** - `created_at + whLifetimeHours(type)` for known non-K162 codes.

Bare **K162 / untyped** holes have no computable life and are never auto-aged (unchanged behaviour).

## Buckets
Remaining life, boundaries inclusive of the shorter bucket:

| remaining | bucket |
|-----------|--------|
| > 24h | fresh |
| <= 24h | < 1 day |
| <= 4h | < 4h |
| <= 1h | < 1h |
| <= 0 | expired |

So a fresh **24h** static opens at **"< 1 day"**, a **16h** hole drops to **"< 4h"** after 12h, and **"Fresh"** is only reachable by a **> 24h** hole - the right-click and panel menus **hide Fresh for a known <=24h type** (per the agreed cutoff: only 48h holes are ever fresh).

## Display + monitoring
- **Live on the client**: `ConnectionEdge` derives the bucket from the effective expiry against `useNow30s()`, so a hole visibly ages with no refresh (the old `eolAt` 4h countdown is folded into this single path).
- **Hourly server sweep** (`connLifetimeSweep`, `CONN_LIFETIME_SWEEP_MINUTES`, default 60): re-buckets the stored `time_status` and broadcasts `connection.update` (`actor: null`) so non-watching state and other consumers stay correct. Runs on **all maps**; only ever changes the label, never deletes.
- **At expiry**: the edge shows expired but the connection **stays on the map** (sig-based removal remains with the opt-in lazy-wormhole sweep).

## Manual overrides
Menu / panel picks now write `lifetime_expires_at` (and clear `eol_at`), so a hand-set lifetime **ages from that point** ("if the user manually changes the lifespan, we use that value"). Manual values survive re-scans of the same hole.

## Also
- Adds the **enum / ISO validation** the connection PATCH route previously lacked (`timeStatus` must be a known bucket; `lifetimeExpiresAt` a valid ISO string or null).
- New column carried through map read / share / full-copy projections. Import & merge keep dropping it alongside `eol_at`, as before.
- Server unit tests cover the bucket + effective-expiry logic (`whLifetimes.test.ts`).

## Heads-up on first deploy
Auto-aging is retroactive: existing **standard wormhole** connections whose `created_at` is already older than their type's max life will render as **expired** (they stay on the map - nothing is deleted). Old hand-set "fresh" marks (which never aged) are likewise superseded by the auto estimate. Gates/Ansiblex are unaffected (no lifetime).

tsc (web + server), lint (0 errors), web build, and server tests all pass.