### PR TITLE
fix: wormhole-lifetime menu checkmark drifting from the edge label

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -23,6 +23,7 @@ import { reportPresence } from '../services/presence.js';
 import { copyMap } from '../services/mapCopy.js';
 import { notifyDiscord, k162Embed, connectionEmbed, chainEmbed } from '../services/discord.js';
 import { whSizeForCode } from './wormholes.js';
+import { effectiveExpiryMs, lifeBucket } from '../data/whLifetimes.js';
 
 const log = createLogger('maps');
 const discordLog = createLogger('discord');
@@ -2210,6 +2211,31 @@ mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {
   if ('type' in updates && !('size' in updates)) {
     const derived = await whSizeForCode(updates.type as string | null);
     if (derived) updates.size = derived;
+  }
+
+  // When the wormhole type is (re)identified, stamp the current time bucket so
+  // the stored status is right immediately — otherwise it stays stale until the
+  // next hourly connLifetimeSweep and the right-click menu / scout list disagree
+  // with the live edge label. Skip if the client already sent an explicit
+  // timeStatus (a manual pick owns it).
+  if ('type' in updates && !('timeStatus' in updates)) {
+    try {
+      const cur = await db.query<{ createdAt: Date; eolAt: Date | null; lifetimeExpiresAt: Date | null }>(
+        `SELECT created_at AS "createdAt", eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt"
+           FROM map_connections WHERE id = $1 AND map_id = $2`,
+        [connectionId, mapId],
+      );
+      const row = cur.rows[0];
+      if (row) {
+        const expiry = effectiveExpiryMs({
+          lifetimeExpiresAt: row.lifetimeExpiresAt,
+          eolAt:             row.eolAt,
+          whType:            updates.type as string | null,
+          createdAt:         row.createdAt,
+        });
+        if (expiry != null) updates.timeStatus = lifeBucket(expiry - Date.now());
+      }
+    } catch { /* leave time_status as-is on any lookup failure */ }
   }
 
   const sets: string[] = [];

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -16,7 +16,7 @@ import { useMapSignatureIndex } from '../../hooks/useMapSignatureIndex';
 import { useUndivedWormholeIndex } from '../../hooks/useUndivedWormholeIndex';
 import { useLeadsToIndex } from '../../hooks/useLeadsToIndex';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
-import { knownMaxLifeHours } from '../../utils/whLifetime';
+import { knownMaxLifeHours, effectiveExpiryMs, lifeBucket, type TimeBucket } from '../../utils/whLifetime';
 import { useCanEdit } from '../../hooks/useCanEdit';
 import { useMinimapPosition } from '../../hooks/useMinimapPosition';
 import { useShareMode } from '../../context/ShareModeContext';
@@ -99,6 +99,9 @@ interface CtxMenu {
   nodeId?: string;
   edgeId?: string;
   selectedNodeIds?: string[]; // snapshot taken at right-click time before RF resets selection
+  openedAt?: number;          // Date.now() when opened, so the lifetime submenu can
+                              // show the same live bucket as the edge without calling
+                              // Date.now() during render (react-compiler purity rule)
 }
 
 function systemToNode(sys: MapSystem, selectedId: string | null, easyConnect = false, canEdit = true, dimmed = false, routeHighlighted = false): Node {
@@ -870,7 +873,7 @@ export function MapCanvas() {
       if (isShareMode) return;
       e.preventDefault();
       e.stopPropagation();
-      setContextMenu({ screenX: e.clientX, screenY: e.clientY, flowX: 0, flowY: 0, edgeId: edge.id });
+      setContextMenu({ screenX: e.clientX, screenY: e.clientY, flowX: 0, flowY: 0, edgeId: edge.id, openedAt: Date.now() });
     },
     [isShareMode],
   );
@@ -957,16 +960,20 @@ export function MapCanvas() {
         {
           label: t('ctxMenu.whLifetime'),
           submenu: (() => {
-            // The checked indicator is the coarse "what stage am I in?" hint from
-            // the stored category (the sweep keeps it current within the hour);
-            // the live countdown lives on the edge label. Picking a row sets a
-            // manual expiry (lifetimeExpiresAt) that then ages from that point.
-            const hasEol = !!conn?.eolAt || !!conn?.lifetimeExpiresAt;
-            const stage: 'fresh' | 'lessThan24h' | 'eol' =
-              timeStatus === 'lessThan24h' ? 'lessThan24h' :
-              (hasEol || timeStatus === 'eol' || timeStatus === 'lessThan4h'
-                || timeStatus === 'lessThan1h' || timeStatus === 'expired') ? 'eol' :
-              'fresh';
+            // The checked row is the SAME live bucket the edge label shows, so the
+            // menu never drifts from the label. Derived from the hole's effective
+            // expiry as of when the menu opened (openedAt) — calling Date.now()
+            // while building the items trips the react-compiler purity rule. When
+            // the lifetime is unknown (untyped) fall back to the stored category.
+            const openedAt = contextMenu.openedAt ?? 0;
+            const expiryMs = conn ? effectiveExpiryMs(conn, whTypes) : null;
+            const current: TimeBucket =
+              expiryMs != null && openedAt ? lifeBucket(expiryMs - openedAt)
+              : timeStatus === 'lessThan24h' ? 'lessThan24h'
+              : (timeStatus === 'lessThan4h' || timeStatus === 'eol') ? 'lessThan4h'
+              : timeStatus === 'lessThan1h' ? 'lessThan1h'
+              : timeStatus === 'expired' ? 'expired'
+              : 'fresh';
             // Date.now() only inside the action closures — calling it while
             // building the items trips the react-compiler "impure in render" rule.
             const expiresIn = (hrs: number) =>
@@ -983,7 +990,7 @@ export function MapCanvas() {
             const rows: { label: string; checked: boolean; action: () => void }[] = [];
             if (showFresh) rows.push({
               label: lifeHrs ? t('ctxMenu.lifeFreshMax', { hours: lifeHrs }) : t('ctxMenu.lifeFresh'),
-              checked: stage === 'fresh',
+              checked: current === 'fresh',
               action: () => updateConnection(eid, {
                 timeStatus: 'fresh', eolAt: null,
                 lifetimeExpiresAt: lifeHrs ? expiresIn(lifeHrs) : null,
@@ -992,22 +999,22 @@ export function MapCanvas() {
             rows.push(
               {
                 label: t('ctxMenu.life1d'),
-                checked: stage === 'lessThan24h',
+                checked: current === 'lessThan24h',
                 action: () => updateConnection(eid, { timeStatus: 'lessThan24h', eolAt: null, lifetimeExpiresAt: expiresIn(24) }),
               },
               {
                 label: t('ctxMenu.life4h'),
-                checked: stage === 'eol',
+                checked: current === 'lessThan4h',
                 action: () => updateConnection(eid, { timeStatus: 'lessThan4h', eolAt: null, lifetimeExpiresAt: expiresIn(4) }),
               },
               {
                 label: t('ctxMenu.life1h'),
-                checked: false,
+                checked: current === 'lessThan1h',
                 action: () => updateConnection(eid, { timeStatus: 'lessThan1h', eolAt: null, lifetimeExpiresAt: expiresIn(1) }),
               },
               {
                 label: t('ctxMenu.lifeExpired'),
-                checked: false,
+                checked: current === 'expired',
                 action: () => updateConnection(eid, { timeStatus: 'expired', eolAt: null, lifetimeExpiresAt: expiresIn(0) }),
               },
             );


### PR DESCRIPTION
Follow-up to #475 (auto-age wormhole lifetimes), from QA testing: after scanning a K162 and typing the source as a Q003 (a 4.5h frig hole), the edge label showed **"< 24h"** but the right-click **Wormhole Lifetime** menu showed **"Less than 4 hours"** checked - the two were out of sync.

**Cause:** the edge derives its bucket **live** from the hole's effective expiry, but the menu's checkmark came from a coarse stored-state heuristic (any `eolAt`/`lifetimeExpiresAt`, or an eol-ish `timeStatus`, forced the "< 4 hours" row checked). Stored `time_status` also wasn't stamped when a hole's type was identified, so it stayed stale until the next hourly sweep.

**Fix:**
- The menu now checks each row against the **same live bucket the edge shows**, computed from the effective expiry as of when the menu opened (`openedAt` captured in the right-click handler, so no `Date.now()` during render / no react-compiler violation). The "< 1 hr" and "expired" rows now get correct checkmarks too.
- The server now **stamps `time_status` on the type PATCH** when a hole is identified, so the stored status is correct immediately instead of lagging until the hourly sweep. An explicit `timeStatus` in the same PATCH (a manual pick) still wins.

Net: for the Q003 case both the edge and the menu read "< 1 day" until it crosses 4h, then both flip to "< 4h" together.

tsc (web + server), lint (0 errors), web build, server tests all pass locally.