### PR TITLE
feat: collapse expired wormhole connections (sever + drop sigs)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -168,10 +168,10 @@ export const config = {
   // Grace period (hours) a connection stays past its expiry before the lifetime
   // sweep collapses it — severs it (broken) and deletes its backing wormhole
   // sigs — on maps opted into lazy wormhole removal. A buffer so a hole that
-  // lingers slightly past the estimate isn't cut early. Default 2.
+  // lingers slightly past the estimate isn't cut early. Default 0.5 (30 min).
   connCollapseGraceHours: (() => {
-    const n = parseFloat(process.env.CONN_COLLAPSE_GRACE_HOURS ?? '2');
-    return Number.isFinite(n) && n >= 0 ? n : 2;
+    const n = parseFloat(process.env.CONN_COLLAPSE_GRACE_HOURS ?? '0.5');
+    return Number.isFinite(n) && n >= 0 ? n : 0.5;
   })(),
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -165,6 +165,14 @@ export const config = {
     const n = parseInt(process.env.CONN_LIFETIME_SWEEP_MINUTES ?? '60', 10);
     return Number.isFinite(n) && n >= 0 ? n : 60;
   })(),
+  // Grace period (hours) a connection stays past its expiry before the lifetime
+  // sweep collapses it — severs it (broken) and deletes its backing wormhole
+  // sigs — on maps opted into lazy wormhole removal. A buffer so a hole that
+  // lingers slightly past the estimate isn't cut early. Default 2.
+  connCollapseGraceHours: (() => {
+    const n = parseFloat(process.env.CONN_COLLAPSE_GRACE_HOURS ?? '2');
+    return Number.isFinite(n) && n >= 0 ? n : 2;
+  })(),
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },

--- a/server/src/services/connLifetimeSweep.test.ts
+++ b/server/src/services/connLifetimeSweep.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { connLifetimeAction } from './connLifetimeSweep.js';
+
+const H = 3_600_000;
+const GRACE = 2 * H;
+
+// A base row: a Q003 (4.5h frig hole) created `ageH` hours ago.
+function q003(ageH: number, over: Partial<Parameters<typeof connLifetimeAction>[0]> = {}) {
+  return {
+    timeStatus: null as string | null,
+    whType: 'Q003',
+    eolAt: null as Date | string | null,
+    lifetimeExpiresAt: null as Date | string | null,
+    createdAt: new Date(Date.now() - ageH * H),
+    lazyRemove: false,
+    ...over,
+  };
+}
+
+describe('connLifetimeAction', () => {
+  const now = Date.now();
+
+  it('does nothing when the lifetime is unknown', () => {
+    const row = { timeStatus: null, whType: null, eolAt: null, lifetimeExpiresAt: null, createdAt: new Date(), lazyRemove: true };
+    expect(connLifetimeAction(row, now, GRACE)).toEqual({ kind: 'none' });
+  });
+
+  it('does nothing when the stored bucket already matches', () => {
+    // 1h-old Q003 → ~3.5h left → lessThan4h; stored already lessThan4h.
+    expect(connLifetimeAction(q003(1, { timeStatus: 'lessThan4h' }), now, GRACE)).toEqual({ kind: 'none' });
+  });
+
+  it('re-buckets when the stored status has drifted', () => {
+    // fresh Q003 stored as fresh, but 4.5h hole opens at lessThan24h.
+    expect(connLifetimeAction(q003(0, { timeStatus: 'fresh' }), now, GRACE))
+      .toEqual({ kind: 'rebucket', bucket: 'lessThan24h' });
+  });
+
+  it('marks an expired hole expired (not collapse) when the map has not opted in', () => {
+    // 5h-old Q003 (expired ~0.5h ago), lazyRemove off.
+    expect(connLifetimeAction(q003(5, { lazyRemove: false }), now, GRACE))
+      .toEqual({ kind: 'rebucket', bucket: 'expired' });
+  });
+
+  it('does not collapse within the grace period even on an opt-in map', () => {
+    // expired ~0.5h ago, grace 2h → still just expired.
+    expect(connLifetimeAction(q003(5, { lazyRemove: true, timeStatus: 'lessThan1h' }), now, GRACE))
+      .toEqual({ kind: 'rebucket', bucket: 'expired' });
+  });
+
+  it('does nothing extra once expired and already stored expired, within grace', () => {
+    expect(connLifetimeAction(q003(5, { lazyRemove: true, timeStatus: 'expired' }), now, GRACE))
+      .toEqual({ kind: 'none' });
+  });
+
+  it('collapses once expired past the grace period on an opt-in map', () => {
+    // 7h-old Q003 → expired ~2.5h ago > 2h grace.
+    expect(connLifetimeAction(q003(7, { lazyRemove: true, timeStatus: 'expired' }), now, GRACE))
+      .toEqual({ kind: 'collapse' });
+  });
+
+  it('a manual override drives collapse timing, not the type age', () => {
+    // A 48h B041 hole, but manually set to have expired 3h ago → past grace.
+    const row = {
+      timeStatus: 'expired' as string | null,
+      whType: 'B041',
+      eolAt: null as Date | string | null,
+      lifetimeExpiresAt: new Date(Date.now() - 3 * H),
+      createdAt: new Date(Date.now() - 1 * H),
+      lazyRemove: true,
+    };
+    expect(connLifetimeAction(row, now, GRACE)).toEqual({ kind: 'collapse' });
+  });
+});

--- a/server/src/services/connLifetimeSweep.ts
+++ b/server/src/services/connLifetimeSweep.ts
@@ -14,31 +14,96 @@ interface Row {
   eolAt:             Date | null;
   lifetimeExpiresAt: Date | null;
   createdAt:         Date;
+  sourceId:          string;
+  targetId:          string;
+  sourceSignatureId: string | null;
+  targetSignatureId: string | null;
+  lazyRemove:        boolean;
+}
+
+export type LifetimeAction =
+  | { kind: 'none' }
+  | { kind: 'rebucket'; bucket: TimeBucket }
+  | { kind: 'collapse' };
+
+/**
+ * Decide what the sweep should do with one connection (pure, so it's unit
+ * tested without a DB):
+ *   - unknown lifetime → nothing;
+ *   - expired for longer than the grace period on a lazy-removal map → collapse
+ *     (sever + drop its backing sigs — a dead hole has no sig on the scanner);
+ *   - otherwise re-bucket if the stored status has drifted from the live one.
+ * Collapse takes priority over re-bucketing so an over-grace hole doesn't first
+ * get stamped 'expired' only to be severed the same tick.
+ */
+export function connLifetimeAction(
+  row: Pick<Row, 'timeStatus' | 'whType' | 'eolAt' | 'lifetimeExpiresAt' | 'createdAt' | 'lazyRemove'>,
+  now: number,
+  graceMs: number,
+): LifetimeAction {
+  const expiry = effectiveExpiryMs(row);
+  if (expiry === null) return { kind: 'none' };
+  if (row.lazyRemove && now - expiry > graceMs) return { kind: 'collapse' };
+  const bucket = lifeBucket(expiry - now);
+  return bucket === row.timeStatus ? { kind: 'none' } : { kind: 'rebucket', bucket };
 }
 
 /**
- * One sweep pass: re-derive every standard wormhole connection's time bucket
- * from its effective expiry (manual override > legacy EOL mark > createdAt +
- * charted max life) and persist + broadcast the ones whose stored bucket has
- * drifted. Display-only — this never deletes or severs a connection (an expired
- * hole simply shows the expired state; sig-based removal stays with whSweep).
+ * Collapse one map's over-grace connections in a transaction: delete the
+ * wormhole sigs backing them, sever the connections (broken = true), then
+ * broadcast so open clients drop the sigs and render the severed edge live.
+ */
+async function collapseMap(mapId: string, conns: Row[]): Promise<void> {
+  const connIds = conns.map((c) => c.id);
+  const sigIds = conns.flatMap((c) => [c.sourceSignatureId, c.targetSignatureId]).filter((x): x is string => !!x);
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    if (sigIds.length) await client.query(`DELETE FROM map_signatures WHERE id = ANY($1::uuid[])`, [sigIds]);
+    await client.query(`UPDATE map_connections SET broken = TRUE WHERE id = ANY($1::uuid[])`, [connIds]);
+    await client.query(`UPDATE maps SET updated_at = NOW() WHERE id = $1`, [mapId]);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    log.warn(`collapse failed for map ${mapId}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  } finally {
+    client.release();
+  }
+
+  const affectedSystems = new Set(conns.flatMap((c) => [c.sourceId, c.targetId]));
+  for (const systemId of affectedSystems) publishToMap(mapId, { type: 'sig.changed', actor: null, systemId });
+  for (const id of connIds) publishToMap(mapId, { type: 'connection.update', actor: null, id, updates: { broken: true } });
+  log.info(`map ${mapId}: collapsed ${connIds.length} expired connection(s), removed ${sigIds.length} sig(s)`);
+}
+
+/**
+ * One sweep pass: for every standard wormhole connection with a determinable
+ * lifetime, either re-bucket its stored time_status (all maps) or — once it has
+ * been expired past the grace period on a lazy-removal map — collapse it. Purely
+ * display/state work: re-bucketing never deletes; collapse mirrors a real hole
+ * dying (sig gone, connection severed) and only fires where the map opted in.
  *
- * The prefilter keeps the candidate set to holes with a determinable lifetime:
- * a manual/legacy timestamp, or any typed hole (K162 decays against the 48h
+ * The prefilter keeps the candidate set to holes with a determinable lifetime
+ * (a manual/legacy timestamp, or any typed hole — K162 decays against the 48h
  * ceiling). Untyped connections have no computable expiry and are skipped in JS.
  */
 async function sweepConnLifetimes(): Promise<void> {
   let rows: Row[];
   try {
     const res = await db.query<Row>(
-      `SELECT id, map_id AS "mapId", time_status AS "timeStatus", wh_type AS "whType",
-              eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", created_at AS "createdAt"
-         FROM map_connections
-        WHERE connection_type = 'standard'
-          AND broken = FALSE
-          AND (lifetime_expires_at IS NOT NULL
-            OR eol_at IS NOT NULL
-            OR (wh_type IS NOT NULL AND wh_type <> ''))`,
+      `SELECT c.id, c.map_id AS "mapId", c.time_status AS "timeStatus", c.wh_type AS "whType",
+              c.eol_at AS "eolAt", c.lifetime_expires_at AS "lifetimeExpiresAt", c.created_at AS "createdAt",
+              c.source_id AS "sourceId", c.target_id AS "targetId",
+              c.source_signature_id AS "sourceSignatureId", c.target_signature_id AS "targetSignatureId",
+              m.lazy_remove_wormholes AS "lazyRemove"
+         FROM map_connections c
+         JOIN maps m ON m.id = c.map_id
+        WHERE c.connection_type = 'standard'
+          AND c.broken = FALSE
+          AND (c.lifetime_expires_at IS NOT NULL
+            OR c.eol_at IS NOT NULL
+            OR (c.wh_type IS NOT NULL AND c.wh_type <> ''))`,
     );
     rows = res.rows;
   } catch (err) {
@@ -47,42 +112,46 @@ async function sweepConnLifetimes(): Promise<void> {
   }
 
   const now = Date.now();
-  // Group the connections whose bucket changed, keyed by their new bucket, so a
-  // whole sweep persists in at most one UPDATE per bucket value.
+  const graceMs = config.connCollapseGraceHours * 3_600_000;
+  // Re-bucket updates grouped by their new bucket (one UPDATE per bucket value);
+  // collapses grouped by map (one transaction per map).
   const changedByBucket = new Map<TimeBucket, string[]>();
-  const changed: { id: string; mapId: string; bucket: TimeBucket }[] = [];
+  const rebucketed: { id: string; mapId: string; bucket: TimeBucket }[] = [];
+  const collapseByMap = new Map<string, Row[]>();
+
   for (const r of rows) {
-    const expiry = effectiveExpiryMs(r);
-    if (expiry === null) continue;
-    const bucket = lifeBucket(expiry - now);
-    if (bucket === r.timeStatus) continue;
-    const list = changedByBucket.get(bucket);
-    if (list) list.push(r.id); else changedByBucket.set(bucket, [r.id]);
-    changed.push({ id: r.id, mapId: r.mapId, bucket });
-  }
-
-  if (changed.length === 0) return;
-
-  try {
-    for (const [bucket, ids] of changedByBucket) {
-      await db.query(`UPDATE map_connections SET time_status = $1 WHERE id = ANY($2::uuid[])`, [bucket, ids]);
+    const action = connLifetimeAction(r, now, graceMs);
+    if (action.kind === 'collapse') {
+      const list = collapseByMap.get(r.mapId);
+      if (list) list.push(r); else collapseByMap.set(r.mapId, [r]);
+    } else if (action.kind === 'rebucket') {
+      const list = changedByBucket.get(action.bucket);
+      if (list) list.push(r.id); else changedByBucket.set(action.bucket, [r.id]);
+      rebucketed.push({ id: r.id, mapId: r.mapId, bucket: action.bucket });
     }
-  } catch (err) {
-    log.warn(`bucket update failed: ${err instanceof Error ? err.message : String(err)}`);
-    return;
   }
 
-  // Bump updated_at for affected maps (so a delta-sync sees the change) and
-  // broadcast each connection.update with actor null → every open client applies
-  // it and its edge re-buckets live.
-  const affectedMaps = new Set(changed.map((c) => c.mapId));
-  for (const mapId of affectedMaps) {
-    await db.query(`UPDATE maps SET updated_at = NOW() WHERE id = $1`, [mapId]).catch(() => {});
+  if (rebucketed.length > 0) {
+    try {
+      for (const [bucket, ids] of changedByBucket) {
+        await db.query(`UPDATE map_connections SET time_status = $1 WHERE id = ANY($2::uuid[])`, [bucket, ids]);
+      }
+      const rebucketMaps = new Set(rebucketed.map((c) => c.mapId));
+      for (const mapId of rebucketMaps) {
+        await db.query(`UPDATE maps SET updated_at = NOW() WHERE id = $1`, [mapId]).catch(() => {});
+      }
+      for (const c of rebucketed) {
+        publishToMap(c.mapId, { type: 'connection.update', actor: null, id: c.id, updates: { timeStatus: c.bucket } });
+      }
+      log.info(`re-bucketed ${rebucketed.length} connection(s) across ${rebucketMaps.size} map(s)`);
+    } catch (err) {
+      log.warn(`bucket update failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
-  for (const c of changed) {
-    publishToMap(c.mapId, { type: 'connection.update', actor: null, id: c.id, updates: { timeStatus: c.bucket } });
+
+  for (const [mapId, conns] of collapseByMap) {
+    await collapseMap(mapId, conns);
   }
-  log.info(`re-bucketed ${changed.length} connection(s) across ${affectedMaps.size} map(s)`);
 }
 
 /**

--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -171,12 +171,16 @@ async function sweepAll(): Promise<void> {
   }
 
   const now = Date.now();
+  // Same grace buffer the connection-lifetime collapse uses, so a hole's sig and
+  // its connection are removed together (~max life + grace) rather than the sig
+  // vanishing a couple of hours before the edge severs.
+  const graceH = config.connCollapseGraceHours;
   const byMap = new Map<string, CandidateRow[]>();
   for (const r of rows) {
     const maxH = whLifetimeHours(r.whType);
     if (maxH === null) continue; // unknown code → never auto-remove
     const ageH = (now - new Date(r.createdAt).getTime()) / 3_600_000;
-    if (ageH <= maxH) continue;
+    if (ageH <= maxH + graceH) continue;
     const list = byMap.get(r.mapId);
     if (list) list.push(r); else byMap.set(r.mapId, [r]);
   }


### PR DESCRIPTION
Follow-up to the wormhole-lifetime work: links the connection-lifetime clock to the **collapse** state (dashed + scissors), per the discussion that a dead connection means its signatures are gone too.

## Behaviour
On maps **opted into lazy wormhole removal**, once a connection has been **expired for longer than a grace period**, the lifetime sweep collapses it:
- **severs** it (`broken = true` -> dashed/scissors, excluded from routing but still traceable), and
- **deletes its backing wormhole sigs** (a dead hole has no sig on the scanner).

Driven by the connection's **effective expiry**, so a **manual lifetime override** collapses the hole on the user's timeline (e.g. you marked it "< 1h"), not just the raw type age.

## Details
- `connLifetimeSweep`: new pure `connLifetimeAction()` returns `none` / `rebucket` / `collapse` per connection (unit-tested, 8 cases). Collapse runs per-map in a transaction: delete linked sigs, set `broken`, bump `updated_at`, then broadcast `sig.changed` + `connection.update{broken:true}` so clients drop the sigs and render the severed edge live. No new client code - the existing `broken` rendering + `sig.changed` refetch already handle it.
- **Grace period** configurable via `CONN_COLLAPSE_GRACE_HOURS` (default **2h**).
- `whSweep`'s sig-age removal gets the **same grace buffer**, so a hole's sig and its connection are removed together (~max life + grace) instead of the sig vanishing a couple of hours before the edge severs. (This slightly extends how long aged sigs linger on lazy-removal maps - by the grace amount.)

## Scope
**Opt-in per map** (reuses the existing `lazy_remove_wormholes` toggle). Non-opt-in maps are unchanged: an expired hole still just shows the red "!" and keeps its sigs. Timing: **after a grace period** past expiry.

tsc + server tests (42 pass, incl. the new decision-logic suite) green locally.