### PR TITLE
fix: always show collapse-grace dropdown (disabled until auto-removal is on)

### DIFF
--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -501,25 +501,23 @@ function LazyWhSweepToggle() {
         />
       </label>
       <div className="map-sidebar__hint">{t("mapSidebar.lazyRemoveWhHint")}</div>
-      {enabled && (
-        <>
-          <div className="map-sidebar__row">
-            <label className="map-sidebar__label" htmlFor="collapse-grace">{t("mapSidebar.collapseGrace")}</label>
-            <select
-              id="collapse-grace"
-              className="map-sidebar__select"
-              value={String(grace)}
-              disabled={saving}
-              onChange={(e) => persist({ collapseGraceHours: parseFloat(e.target.value) }, { collapseGraceHours: grace })}
-            >
-              {COLLAPSE_GRACE_OPTIONS.map((o) => (
-                <option key={o.h} value={String(o.h)}>{o.label(t)}</option>
-              ))}
-            </select>
-          </div>
-          <div className="map-sidebar__hint">{t("mapSidebar.collapseGraceHint")}</div>
-        </>
-      )}
+      {/* Always shown for discoverability; only editable once auto-removal is on,
+          since the grace period has no effect otherwise. */}
+      <div className="map-sidebar__row">
+        <label className="map-sidebar__label" htmlFor="collapse-grace">{t("mapSidebar.collapseGrace")}</label>
+        <select
+          id="collapse-grace"
+          className="map-sidebar__select"
+          value={String(grace)}
+          disabled={!enabled || saving}
+          onChange={(e) => persist({ collapseGraceHours: parseFloat(e.target.value) }, { collapseGraceHours: grace })}
+        >
+          {COLLAPSE_GRACE_OPTIONS.map((o) => (
+            <option key={o.h} value={String(o.h)}>{o.label(t)}</option>
+          ))}
+        </select>
+      </div>
+      <div className="map-sidebar__hint">{t("mapSidebar.collapseGraceHint")}</div>
     </>
   );
 }


### PR DESCRIPTION
Small UX tweak: the "Collapse grace" dropdown was only rendered once "Auto-remove aged wormholes" was ticked, so it wasn't discoverable. Now it's **always visible** but **disabled** while the toggle is off (the grace period has no effect until collapse/removal is enabled).

One-line change in `MapSidebar.tsx` (`disabled={!enabled || saving}`, dropped the `{enabled && ...}` wrapper). tsc + build + lint (0 errors) pass.