### PR TITLE
fix: apply the skip-K-space filter to the jump simulator too

### DIFF
--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -1,3 +1,5 @@
+import type { JumpSystem } from './hooks/useLocationTracking';
+
 interface LogEntry {
   ts: string;
   level: 'error' | 'warn' | 'api';
@@ -122,13 +124,15 @@ const nexumDebug = {
       return;
     }
     const { dryRun = false } = opts;
-    const [{ applyJump }, store, esi, client] = await Promise.all([
+    const [{ applyTrackedJump }, store, esi, client, userSettings] = await Promise.all([
       import('./hooks/useLocationTracking'),
       import('./store/mapStore'),
       import('./hooks/useEsiSearch'),
       import('./api/client'),
+      import('./hooks/useUserSetting'),
     ]);
     const { useMapStore } = store;
+    const { readUserSetting } = userSettings;
 
     const resolve = async (name: string) => {
       const results = await (await fetch(
@@ -145,9 +149,18 @@ const nexumDebug = {
     };
 
     if (this._jumpTimer) { clearInterval(this._jumpTimer); this._jumpTimer = null; }
-    let prev = useMapStore.getState().currentSystemId;
+    // Drive the exact filter live tracking uses: keep a separate "previous
+    // physical system" (for the K-space skip logic) and connection anchor.
+    let prevAnchor = useMapStore.getState().currentSystemId;
+    const startNode = useMapStore.getState().map.systems.find((s) => s.id === prevAnchor);
+    let prevPhysical: JumpSystem | null = startNode && startNode.eveSystemId != null ? {
+      eveSystemId: startNode.eveSystemId, name: startNode.name, systemClass: startNode.systemClass,
+      effect: startNode.effect, statics: startNode.statics,
+      regionName: startNode.regionName, npcType: startNode.npcType,
+    } : null;
+    const skipKspace = readUserSetting<boolean>('nexum.tracking.skipKspace', false);
     let i = 0;
-    console.log(`[nexum] Simulating ${names.length} jumps, one every ${intervalMs}ms${dryRun ? ' (dry run — no server writes)' : ''}. nexumDebug.stopJumps() to cancel.`);
+    console.log(`[nexum] Simulating ${names.length} jumps, one every ${intervalMs}ms${dryRun ? ' (dry run — no server writes)' : ''}${skipKspace ? ' (skip K-space on)' : ''}. nexumDebug.stopJumps() to cancel.`);
 
     const step = async () => {
       if (i >= names.length) { this.stopJumps(); console.log('[nexum] Jump simulation complete.'); return; }
@@ -157,14 +170,16 @@ const nexumDebug = {
       // applyJump's writes are dispatched synchronously (the suppression check
       // runs before fetch), so toggling around this call captures them all.
       if (dryRun) client.setWritesSuppressed(true);
-      let id: string | null;
+      let result: { mapSystemId: string | null; anchor: string | null | 'keep' };
       try {
-        id = applyJump(sys, prev, true);
+        result = applyTrackedJump(sys, prevPhysical, prevAnchor, { skipKspace, canAdd: true });
       } finally {
         if (dryRun) client.setWritesSuppressed(false);
       }
+      prevPhysical = sys;
+      if (result.anchor !== 'keep') prevAnchor = result.anchor;
+      const id = result.mapSystemId;
       if (id) {
-        prev = id;
         useMapStore.getState().setCurrentSystem(id);
         // Selecting a system opens its detail panel, whose panes immediately
         // GET /systems/:id/{signatures,structures,anomalies}. In a dry run the
@@ -174,6 +189,8 @@ const nexumDebug = {
         if (!dryRun) useMapStore.getState().selectSystem(id);
         const pos = useMapStore.getState().map.systems.find((s) => s.id === id)?.position;
         console.log(`[nexum] jump ${i}/${names.length} → ${sys.name}  @ (${pos?.x}, ${pos?.y})`);
+      } else {
+        console.log(`[nexum] jump ${i}/${names.length} → ${sys.name}  (skipped — K-space)`);
       }
     };
     await step();

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -205,6 +205,53 @@ export function applyJump(system: JumpSystem, prevMapSystemId: string | null, ca
 }
 
 /**
+ * One jump through the "don't track K-space" filter, funnelling to `applyJump`.
+ * Shared by the live tracker AND `nexumDebug.simulateJumps`, so the simulator
+ * reproduces exactly what real flying records.
+ *
+ * With `skipKspace` off it's a plain `applyJump`. With it on, only the K-space
+ * systems bordering a J-space jump are recorded: the first entered from J-space,
+ * and the last before jumping back into J-space (added retroactively here).
+ * Intermediate K-space is dropped. Returns the resulting map-system id (or null
+ * when nothing was recorded) plus how the caller should advance its connection
+ * anchor: a node id, null (clear), or 'keep' (a skipped system must not become
+ * the anchor). `prev` is the previous PHYSICAL system, mapped or not.
+ */
+export function applyTrackedJump(
+  curr: JumpSystem,
+  prev: JumpSystem | null,
+  prevMapSystemId: string | null,
+  opts: { skipKspace: boolean; canAdd: boolean },
+): { mapSystemId: string | null; anchor: string | null | 'keep' } {
+  const skip = opts.skipKspace && opts.canAdd;
+  const systems = () => useMapStore.getState().map.systems;
+
+  if (skip && isKspaceSkip(curr.systemClass)) {
+    // Arriving in K-space: keep it only when jumping in FROM J-space (the first
+    // K-space of this excursion). Intermediate K-space, or a login already
+    // parked in K-space, is skipped.
+    const fromJspace = prev !== null && !isKspaceSkip(prev.systemClass);
+    if (fromJspace) {
+      const mapSystemId = applyJump(curr, prevMapSystemId, true);
+      return { mapSystemId, anchor: mapSystemId };
+    }
+    return { mapSystemId: systems().find((s) => s.eveSystemId === curr.eveSystemId)?.id ?? null, anchor: 'keep' };
+  }
+
+  if (skip && prev !== null && isKspaceSkip(prev.systemClass)) {
+    // Arriving in J-space (or Pochven) from K-space: record the K-space system
+    // we jumped from — retroactively if it was skipped — and link it to here.
+    const prevOnMap = systems().find((s) => s.eveSystemId === prev.eveSystemId)?.id ?? null;
+    const source = prevOnMap ?? applyJump(prev, null, true); // add the last K-space isolated
+    const mapSystemId = applyJump(curr, source, true);       // then connect it through
+    return { mapSystemId, anchor: mapSystemId };
+  }
+
+  const mapSystemId = applyJump(curr, prevMapSystemId, opts.canAdd);
+  return { mapSystemId, anchor: mapSystemId };
+}
+
+/**
  * Map-side reaction to character location changes. The actual polling lives
  * in `useCharacterLocation` (10s, module-level, shared with the sidebar);
  * this hook just runs map-mutation side-effects whenever the location data
@@ -281,44 +328,10 @@ export function useLocationTracking(enabled: boolean) {
     // no-topology user is viewing; track-jumps off opts out of auto-add too.
     const trackJumps = useMapStore.getState().trackJumps;
     const canAdd = trackJumps && !map.locked && canEdit;
-    // Opt-in: only record the K-space systems that border a J-space jump — the
-    // first one entered from J-space and the last one before jumping back into
-    // J-space — skipping everything gated through in between. HS/LS/NS only;
-    // Pochven is always tracked.
-    const skipKspace = canAdd && readUserSetting<boolean>('nexum.tracking.skipKspace', false);
+    const skipKspace = readUserSetting<boolean>('nexum.tracking.skipKspace', false);
 
-    let mapSystemId: string | null;
-    // How to advance the connection anchor: a node id, null (clear), or 'keep'
-    // (a skipped K-space system must not become the anchor).
-    let anchorUpdate: string | null | 'keep';
-
-    if (skipKspace && isKspaceSkip(curr.systemClass)) {
-      // Arriving in K-space: keep it only when jumping in FROM J-space (the first
-      // K-space of this excursion). Intermediate K-space, or a login already
-      // parked in K-space, is skipped.
-      const fromJspace = prev !== null && !isKspaceSkip(prev.systemClass);
-      if (fromJspace) {
-        mapSystemId = applyJump(curr, prevMapSystemId, true);
-        anchorUpdate = mapSystemId;
-      } else {
-        mapSystemId = map.systems.find((s) => s.eveSystemId === curr.eveSystemId)?.id ?? null;
-        anchorUpdate = 'keep';
-      }
-    } else if (skipKspace && prev !== null && isKspaceSkip(prev.systemClass)) {
-      // Arriving in J-space (or Pochven) from K-space: record the K-space system
-      // we jumped from — retroactively if it was skipped — and link it to here.
-      const prevOnMap = map.systems.find((s) => s.eveSystemId === prev.eveSystemId)?.id ?? null;
-      const source = prevOnMap ?? applyJump(prev, null, true); // add the last K-space isolated
-      mapSystemId = applyJump(curr, source, true);             // then connect it through
-      anchorUpdate = mapSystemId;
-    } else {
-      // Normal tracking (K-space skipping off, or a step that needs no special
-      // handling).
-      mapSystemId = applyJump(curr, prevMapSystemId, canAdd);
-      anchorUpdate = mapSystemId;
-    }
-
-    if (anchorUpdate !== 'keep') lastMapSystemId.current = anchorUpdate;
+    const { mapSystemId, anchor } = applyTrackedJump(curr, prev, prevMapSystemId, { skipKspace, canAdd });
+    if (anchor !== 'keep') lastMapSystemId.current = anchor;
 
     if (mapSystemId === null) {
       // On an untracked system (skipped K-space, or can't-add and not on map).


### PR DESCRIPTION
Follow-up to #482. The "don't track K-space" logic lived only in `useLocationTracking`, but `nexumDebug.simulateJumps` calls `applyJump` **directly** — so the simulator bypassed the filter and still tracked every K-space hop (that's what the QA test showed: full gate chains through null/hi-sec).

**Fix:** extracted the filter into a shared `applyTrackedJump(curr, prevPhysical, prevAnchor, { skipKspace, canAdd })` in `useLocationTracking`, used by **both** the live tracker and the simulator. The simulator now tracks the previous *physical* system + connection anchor (not just the last mapped node) and logs skipped K-space hops.

No behaviour change for real flying — same code path, just shared. With the sequence from testing, only the K-space systems bordering a J-space jump (SN9S-N, Ohmahailen, Hykkota, Amarr) are recorded off J104606; the intermediate/trailing hops (Z-MO29, Eskunen, Outuni, Jita) are skipped.

tsc + build + lint (0 errors) pass locally.