### PR TITLE
fix: bookmark {dest_type} shows destination class; add {leads_to} token

### DIFF
--- a/web/src/utils/signatureBookmark.ts
+++ b/web/src/utils/signatureBookmark.ts
@@ -1,6 +1,7 @@
 import type { Signature } from '../types';
 import type { WormholeSpec } from '../hooks/useWormholeTypes';
 import { whSizeClass, whSizeShort } from './wormholeSize';
+import { whDestClass, isUnresolvedLeadsTo } from './whDest';
 
 // Tokens the bookmark-name format understands. Also drives the legend shown
 // next to the format setting.
@@ -9,6 +10,7 @@ export const BOOKMARK_TOKENS: { token: string; desc: string }[] = [
   { token: '{sig_letters}', desc: 'First 3 chars (ABC)' },
   { token: '{type}',        desc: 'Wormhole type code (D382)' },
   { token: '{dest_type}',   desc: 'Destination class (C5, HS)' },
+  { token: '{leads_to}',    desc: 'Leads to — pinned system or class (J110555)' },
   { token: '{size}',        desc: 'Hole size (S / M / L / XL)' },
   { token: '{mass}',        desc: 'Total mass in billions (3.0)' },
   { token: '{age}',         desc: 'Hours since first seen (2h)' },
@@ -31,7 +33,7 @@ function sizeLetter(jumpMassKg: number): string {
 }
 
 // Matches the longest tokens first so {sig_letters} isn't eaten by {sig}.
-const TOKEN_RE = /\{sig_letters\}|\{sig\}|\{type\}|\{dest_type\}|\{size\}|\{mass\}|\{age\}|\{name\}|\{notes\}/g;
+const TOKEN_RE = /\{sig_letters\}|\{sig\}|\{type\}|\{dest_type\}|\{leads_to\}|\{size\}|\{mass\}|\{age\}|\{name\}|\{notes\}/g;
 
 /**
  * Build an in-game bookmark name for a wormhole signature from a token format
@@ -47,7 +49,14 @@ export function formatBookmarkName(
   // The full wormhole catalog (useWormholeTypes) keyed by type code — the small
   // static map only covers k-space statics, so most holes (e.g. A641) miss it.
   const wh   = sig.whType ? whTypes[sig.whType] : undefined;
-  const dest = sig.whLeadsTo || wh?.dest || '';
+  // {dest_type} is the destination CLASS — from the wormhole type (D364 -> C2),
+  // falling back to the leads-to only when that is itself a class/band (e.g. a
+  // K162 the user tagged "C4"), never a pinned system. {leads_to} carries the
+  // raw leads-to: a pinned system (J110555) or the class/band the user set.
+  const leadsToRaw = (sig.whLeadsTo ?? '').trim();
+  const leadsTo    = leadsToRaw.toLowerCase() === 'unknown' ? '' : leadsToRaw;
+  const destClass  = whDestClass(sig.whType, whTypes);
+  const destType   = destClass ?? (leadsTo && isUnresolvedLeadsTo(leadsTo) ? leadsTo : '');
   const ageH = sig.createdAt
     ? Math.max(0, Math.floor((now - new Date(sig.createdAt).getTime()) / 3_600_000))
     : null;
@@ -56,7 +65,8 @@ export function formatBookmarkName(
     '{sig}':         sig.sigId ?? '',
     '{sig_letters}': (sig.sigId ?? '').slice(0, 3).toUpperCase(),
     '{type}':        sig.whType ?? '',
-    '{dest_type}':   dest,
+    '{dest_type}':   destType,
+    '{leads_to}':    leadsTo,
     '{size}':        wh ? sizeLetter(wh.maxJumpMass) : '',
     '{mass}':        wh && wh.totalMass ? String(Number((wh.totalMass / 1_000_000_000).toFixed(1))) : '',
     '{age}':         ageH != null ? `${ageH}h` : '',


### PR DESCRIPTION
**Bug:** `{dest_type}` resolved to `whLeadsTo || wh.dest`, so a hole pinned to a specific system rendered that system (e.g. `J110555`) instead of a destination class — even though the token is labelled "Destination class (C5, HS)". Reported: `{sig} {dest_type} {type} {age}` → `ABC-123 J110555 D364 0h`.

**Fix:**
- `{dest_type}` is now the destination **class** via `whDestClass()` — the wormhole type's charted destination (D364 → C2). It falls back to the leads-to **only** when that's itself a class/band (e.g. a K162 the user tagged "C4"), never a pinned system.
- New **`{leads_to}`** token = the raw leads-to value: a pinned system (`J110555`) or the class/band the user set.

So the reported format now gives `ABC-123 C2 D364 0h`, and adding `{leads_to}` yields the specific destination.

**Behaviour note:** anyone whose custom format used `{dest_type}` to surface a *pinned system* will now see the class there instead — they should switch that token to `{leads_to}`. The default format (`{sig} {dest_type} {size}`) is unchanged in shape; for typed holes it now shows a proper uppercase class.

(The token legend in settings is hardcoded English — pre-existing, not i18n'd — so the new `{leads_to}` entry follows suit. No web test harness exists to add a unit test; verified via build.)

tsc + build + lint (0 errors) pass locally.