### PR TITLE
chore: backend audit batch 1 (access-grant hardening, FK indexes, projection single-source)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ changes.md
 # Local-only Compose overrides (e.g. publishing Postgres to the host for yarn-dev)
 docker-compose.override.yml
 
-# Local frontend audit working notes (not committed)
+# Local audit working notes (not committed)
 frontend-audit.md
+backend-audit.md

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -596,6 +596,14 @@ export async function migrate() {
       ON map_systems (map_id, eve_system_id)
       WHERE eve_system_id IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_map_connections_map   ON map_connections (map_id);
+    -- FK referencing columns on map_connections. Postgres does NOT auto-index a
+    -- referencing side, so without these every map_signatures DELETE (the wh /
+    -- lifetime sweeps run these on a timer) and every map_systems DELETE / map
+    -- cascade seq-scans the whole map_connections table to find referencing rows.
+    CREATE INDEX IF NOT EXISTS idx_map_connections_source     ON map_connections (source_id);
+    CREATE INDEX IF NOT EXISTS idx_map_connections_target     ON map_connections (target_id);
+    CREATE INDEX IF NOT EXISTS idx_map_connections_source_sig ON map_connections (source_signature_id);
+    CREATE INDEX IF NOT EXISTS idx_map_connections_target_sig ON map_connections (target_signature_id);
     CREATE INDEX IF NOT EXISTS idx_map_signatures_system ON map_signatures (system_id);
     CREATE INDEX IF NOT EXISTS idx_map_structures_system ON map_structures (system_id);
     CREATE INDEX IF NOT EXISTS idx_user_events_user      ON user_events (user_id, created_at);

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -246,6 +246,10 @@ adminRouter.patch('/users/:id/role', async (req, res) => {
   const newRole = role as Role;
   await db.query(`UPDATE users SET role = $1, updated_at = NOW() WHERE id = $2`, [newRole, userId]);
   await audit(req, userId, target.character_id, 'role_change', target.role, newRole);
+  // A live session carries a login-time role snapshot; drop the user's sessions so
+  // the change takes effect immediately (a demotion otherwise keeps its old map
+  // write access until re-login / the 7-day cookie TTL). Matches the block handler.
+  await invalidateSessionsForUser(userId);
 
   res.json({ ok: true });
 });

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -13,7 +13,7 @@ import { resolveEntityNames } from '../services/entityNames.js';
 import { audit } from '../services/audit.js';
 import { publishToMap } from '../services/mapEvents.js';
 import { streamMapEvents } from '../services/mapStream.js';
-import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures } from '../services/mapRead.js';
+import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures, CONNECTION_COLS } from '../services/mapRead.js';
 import {
   createSignature, updateSignature, deleteSignature,
   createAnomaly, updateAnomaly, deleteAnomaly,
@@ -1920,7 +1920,8 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
     const { rows } = await db.query(
       `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
               region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
-              status, intel, is_home AS "isHome", locked, notes, alias,
+              status, intel, is_home AS "isHome", locked, notes,
+              labels, custom_labels AS "customLabels", tag, alias,
               (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
               last_activity_at AS "lastActivityAt"
          FROM map_systems WHERE id = $1 AND map_id = $2`,
@@ -2155,13 +2156,7 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
   await touchMap(mapId);
   // Re-read the canonical row so remote clients get the full MapConnection shape.
   db.query(
-    `SELECT id, source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
-            target_handle AS "targetHandle", connection_type AS "connectionType", mass_status AS "massStatus",
-            time_status AS "timeStatus", size, wh_type AS "type", COALESCE(mass_used, 0)::float8 AS "massUsed",
-            eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
-            source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId",
-            created_at AS "createdAt"
-       FROM map_connections WHERE id = $1 AND map_id = $2`,
+    `SELECT ${CONNECTION_COLS} FROM map_connections WHERE id = $1 AND map_id = $2`,
     [id, mapId],
   ).then(({ rows }) => {
     if (rows[0]) publishToMap(mapId, { type: 'connection.add', actor: req.get('x-client-id') ?? null, connection: rows[0] });
@@ -2814,6 +2809,21 @@ mapsRouter.post('/:mapId/shares', async (req, res) => {
     res.status(403).json({
       error: 'standing_not_positive',
       message: 'Your deployment does not hold this entity at positive standing (contacts must be synced and standing must be > 0).',
+    });
+    return;
+  }
+
+  // Granting login access widens the deployment's login allow-list. corp/alliance
+  // targets are validated by the positive-standing gate above; an individual
+  // CHARACTER grant has no such gate (requiresPositiveStanding is false for
+  // characters), so restrict it to admins — matching the admin-only allow-list
+  // endpoint. Without this, any member (even readonly) could self-admit an
+  // arbitrary character into a restricted deployment via a map share.
+  if (alsoGrantLogin === true && config.restrictedMode && kind === 'character'
+      && !isAdmin(req.session.role ?? 'readonly')) {
+    res.status(403).json({
+      error: 'forbidden',
+      message: 'Only an admin can grant login access to an individual character.',
     });
     return;
   }

--- a/server/src/routes/share.ts
+++ b/server/src/routes/share.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { db } from '../db.js';
 import { onMapEvent } from '../services/mapEvents.js';
+import { CONNECTION_COLS } from '../services/mapRead.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('share');
@@ -176,15 +177,7 @@ shareRouter.get('/:token', async (req, res) => {
         [mapId],
       ),
       db.query(
-        `SELECT id, source_id AS "sourceId", target_id AS "targetId",
-                source_handle AS "sourceHandle", target_handle AS "targetHandle",
-                connection_type AS "connectionType", mass_status AS "massStatus",
-                time_status AS "timeStatus", size, wh_type AS "type",
-                COALESCE(mass_used, 0)::float8 AS "massUsed",
-                eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
-                source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId",
-                created_at AS "createdAt"
-         FROM map_connections ${connectionWhere}`,
+        `SELECT ${CONNECTION_COLS} FROM map_connections ${connectionWhere}`,
         [mapId],
       ),
       includeSigs

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -8,6 +8,23 @@ import { config } from '../config.js';
 
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
+// The full MapConnection column projection, single-sourced so every shape that
+// reaches a client — the full map load, the share view, and the connection.add
+// broadcast re-read — stays identical (they used to be three hand-copied lists
+// that could drift, notably the "type" vs "whType" alias). A fixed constant,
+// never interpolated with user input.
+export const CONNECTION_COLS = `
+  id, source_id AS "sourceId", target_id AS "targetId",
+  source_handle AS "sourceHandle", target_handle AS "targetHandle",
+  connection_type AS "connectionType", mass_status AS "massStatus",
+  time_status AS "timeStatus", size, wh_type AS "type",
+  COALESCE(mass_used, 0)::float8 AS "massUsed",
+  eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
+  source_signature_id AS "sourceSignatureId",
+  target_signature_id AS "targetSignatureId",
+  created_at AS "createdAt"
+`;
+
 export interface VisibleMapsParams {
   userId:         number;
   ownerId:        number | null;
@@ -105,16 +122,7 @@ export async function loadFullMap(mapId: string) {
       [mapId],
     ),
     db.query(
-      `SELECT id, source_id AS "sourceId", target_id AS "targetId",
-              source_handle AS "sourceHandle", target_handle AS "targetHandle",
-              connection_type AS "connectionType", mass_status AS "massStatus",
-              time_status AS "timeStatus", size, wh_type AS "type",
-              COALESCE(mass_used, 0)::float8 AS "massUsed",
-              eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
-              source_signature_id AS "sourceSignatureId",
-              target_signature_id AS "targetSignatureId",
-              created_at AS "createdAt"
-       FROM map_connections WHERE map_id = $1`,
+      `SELECT ${CONNECTION_COLS} FROM map_connections WHERE map_id = $1`,
       [mapId],
     ),
     db.query(

--- a/server/src/utils/apiKeys.ts
+++ b/server/src/utils/apiKeys.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
+import { randomBytes, createHash } from 'node:crypto';
 
 // External API keys. Unlike the EVE OAuth tokens (encrypted at rest so they can
 // be decrypted and replayed to ESI — see tokenCrypto.ts), an API key is only
@@ -29,12 +29,3 @@ export function generateApiKey(): GeneratedKey {
   return { raw, hash: hashApiKey(raw), prefix: raw.slice(0, PREFIX_LEN) };
 }
 
-// Constant-time compare of two sha-256 hex digests. Lookup is by the unique
-// token_hash column; this is defence-in-depth against timing oracles on the
-// off chance a non-indexed compare path is ever added.
-export function hashesEqual(a: string, b: string): boolean {
-  const ba = Buffer.from(a, 'utf8');
-  const bb = Buffer.from(b, 'utf8');
-  if (ba.length !== bb.length) return false;
-  return timingSafeEqual(ba, bb);
-}


### PR DESCRIPTION
First batch from the backend audit (three parallel security / performance / DRY reviews). Low-risk, high-value items only; findings are in the local `backend-audit.md`.

## Security
- **Gate `alsoGrantLogin` character grants behind admin** (`maps.ts`). The share endpoint's positive-standing gate is skipped for individual characters (`requiresPositiveStanding` is false), so `alsoGrantLogin` let **any authenticated member — even readonly — self-admit an arbitrary character into a restricted deployment's login allow-list**, bypassing the admin-only endpoint. Now admin-only for character grants; corp/alliance grants keep their standing gate.
- **Role change invalidates the user's sessions** (`admin.ts`). A live session carries a login-time role snapshot, so a demotion (full → readonly) previously kept its map write access until re-login / the 7-day cookie TTL. Now mirrors the block handler.

## Performance
- **4 missing `map_connections` FK indexes** (`migrate.ts`): `source_id`, `target_id`, `source_signature_id`, `target_signature_id`. Postgres doesn't auto-index the referencing side, so every `map_signatures` DELETE (the wh/lifetime sweeps run on a timer) and every system DELETE / map cascade seq-scanned the whole table.

## DRY / correctness
- **Single-source the connection projection** → `CONNECTION_COLS` in `mapRead.ts`, used by `share.ts` and the `maps.ts` `connection.add` re-read. Was three hand-copied SELECT lists that could drift (notably the `"type"` vs `"whType"` alias).
- **`system.add` re-read dropped `labels`/`customLabels`/`tag`** vs the canonical `loadFullMap` projection — restored so the broadcast shape matches a full load.
- **Delete dead `hashesEqual`** (`apiKeys.ts`) — zero references; API-key auth looks up by the unique `token_hash` column.

## Deferred (noted for a later batch)
- Refreshing a live session's **corp/alliance** scope on a corp move — the current design deliberately keeps sessions on corp change (an integration test asserts it), so the right fix is refreshing the stored session fields, not killing the session.

**Headline from the audit:** no P1 security findings — no exploitable IDOR, SQLi, SSRF, auth bypass, or secret exposure.

server tsc clean; 42 unit tests pass (31 integration skipped locally w/o DB — CI's postgres runs them).