### PR TITLE
chore: backend audit batch 2 (standings /me cache + merge set-based UPDATEs)

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1541,16 +1541,16 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
         if (k) destSigMap.set(`${ds.systemId}|${k}`, ds.id);
       }
       const sigPh: string[] = []; const sigVals: unknown[] = [];
+      // Collisions are collected and flushed as one set-based UPDATE (below)
+      // instead of a query per row inside the transaction.
+      const sigUp: { id: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string }[] = [];
       for (const sg of srcSigs.rows) {
         const destSysId = idMap.get(sg.systemId);
         if (!destSysId) continue;
         const k = sg.sigId.trim().toLowerCase();
         const existing = k ? destSigMap.get(`${destSysId}|${k}`) : undefined;
         if (existing) {
-          await client.query(
-            `UPDATE map_signatures SET sig_type=$1, name=$2, notes=$3, wh_type=$4, wh_leads_to=$5, updated_at=NOW() WHERE id=$6`,
-            [sg.sigType, sg.name, sg.notes, sg.whType, sg.whLeadsTo, existing],
-          );
+          sigUp.push({ id: existing, sigType: sg.sigType, name: sg.name, notes: sg.notes, whType: sg.whType, whLeadsTo: sg.whLeadsTo });
           updatedSignatures++;
         } else {
           const base = sigVals.length;
@@ -1561,6 +1561,20 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
           sigVals.push(destSysId, sg.sigId, sg.sigType, sg.name, sg.notes, sg.whType, sg.whLeadsTo, req.session.userId, true);
           addedSignatures++;
         }
+      }
+      if (sigUp.length > 0) {
+        // One UPDATE for every collision — unnest of per-column arrays (6 params
+        // total, no param-cap / no per-row round-trips).
+        await client.query(
+          `UPDATE map_signatures AS m
+              SET sig_type = v.sig_type, name = v.name, notes = v.notes,
+                  wh_type = v.wh_type, wh_leads_to = v.wh_leads_to, updated_at = NOW()
+             FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[])
+                  AS v(id, sig_type, name, notes, wh_type, wh_leads_to)
+            WHERE m.id = v.id`,
+          [sigUp.map(u => u.id), sigUp.map(u => u.sigType), sigUp.map(u => u.name),
+           sigUp.map(u => u.notes), sigUp.map(u => u.whType), sigUp.map(u => u.whLeadsTo)],
+        );
       }
       if (sigPh.length > 0) {
         await client.query(
@@ -1590,6 +1604,7 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
         if (nk) byName.set(`${d.systemId}|${nk}`, d.id);
       }
       const stPh: string[] = []; const stVals: unknown[] = [];
+      const stUp: { id: string; name: string; structureType: string; ownerCorp: string; ownerCorpId: number | null; eveId: string | null; notes: string }[] = [];
       for (const st of srcStructs.rows) {
         const destSysId = idMap.get(st.systemId);
         if (!destSysId) continue;
@@ -1599,10 +1614,7 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
           if (nk) existing = byName.get(`${destSysId}|${nk}`);
         }
         if (existing) {
-          await client.query(
-            `UPDATE map_structures SET name=$1, structure_type=$2, owner_corp=$3, owner_corp_id=$4, eve_id=$5, notes=$6, updated_at=NOW() WHERE id=$7`,
-            [st.name, st.structureType, st.ownerCorp, st.ownerCorpId, st.eveId, st.notes, existing],
-          );
+          stUp.push({ id: existing, name: st.name, structureType: st.structureType, ownerCorp: st.ownerCorp, ownerCorpId: st.ownerCorpId, eveId: st.eveId, notes: st.notes });
           updatedStructures++;
         } else {
           const base = stVals.length;
@@ -1610,6 +1622,18 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
           stVals.push(destSysId, st.name, st.structureType, st.ownerCorp, st.eveId, st.notes, req.session.userId, st.ownerCorpId);
           addedStructures++;
         }
+      }
+      if (stUp.length > 0) {
+        await client.query(
+          `UPDATE map_structures AS m
+              SET name = v.name, structure_type = v.structure_type, owner_corp = v.owner_corp,
+                  owner_corp_id = v.owner_corp_id, eve_id = v.eve_id, notes = v.notes, updated_at = NOW()
+             FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[], $5::int[], $6::bigint[], $7::text[])
+                  AS v(id, name, structure_type, owner_corp, owner_corp_id, eve_id, notes)
+            WHERE m.id = v.id`,
+          [stUp.map(u => u.id), stUp.map(u => u.name), stUp.map(u => u.structureType), stUp.map(u => u.ownerCorp),
+           stUp.map(u => u.ownerCorpId), stUp.map(u => u.eveId), stUp.map(u => u.notes)],
+        );
       }
       if (stPh.length > 0) {
         await client.query(
@@ -1619,9 +1643,14 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
       }
     }
 
-    // ── Apply queued system-note merges ──────────────────────────────────
-    for (const nm of noteMerges) {
-      await client.query(`UPDATE map_systems SET notes = $1 WHERE id = $2`, [nm.notes, nm.destSysId]);
+    // ── Apply queued system-note merges (one set-based UPDATE) ────────────
+    if (noteMerges.length > 0) {
+      await client.query(
+        `UPDATE map_systems AS m SET notes = v.notes
+           FROM unnest($1::uuid[], $2::text[]) AS v(id, notes)
+          WHERE m.id = v.id`,
+        [noteMerges.map((nm) => nm.destSysId), noteMerges.map((nm) => nm.notes)],
+      );
     }
 
     // ── Audit: one row per corp map involved (inside the transaction) ────

--- a/server/src/routes/standings.ts
+++ b/server/src/routes/standings.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { db } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
-import { refreshStandingsForUser } from '../services/standings.js';
+import { refreshStandingsForUser, loadOrgContacts } from '../services/standings.js';
 import { revalidateActiveSessions } from '../services/accessRevalidate.js';
 import { decryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
@@ -31,26 +31,16 @@ standingsRouter.get('/me', async (req, res) => {
   if (!userRows.length) { res.status(404).json({ error: 'User not found' }); return; }
   const { character_id, corp_id, alliance_id } = userRows[0];
 
-  const [charRows, corpRows, allianceRows, refreshRows] = await Promise.all([
+  const [charRows, corpContacts, allianceContacts, refreshRows] = await Promise.all([
     db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
       `SELECT contact_kind, contact_id, standing
        FROM character_standings WHERE character_id = $1`,
       [character_id],
     ),
-    corp_id !== null
-      ? db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
-          `SELECT contact_kind, contact_id, standing
-           FROM corp_standings WHERE corp_id = $1`,
-          [corp_id],
-        )
-      : Promise.resolve({ rows: [] as Array<{ contact_kind: ContactKind; contact_id: number; standing: number }> }),
-    alliance_id !== null
-      ? db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
-          `SELECT contact_kind, contact_id, standing
-           FROM alliance_standings WHERE alliance_id = $1`,
-          [alliance_id],
-        )
-      : Promise.resolve({ rows: [] as Array<{ contact_kind: ContactKind; contact_id: number; standing: number }> }),
+    // Corp/alliance buckets go through the shared read cache — these lists are
+    // shared across members and re-fetched by everyone on every poll.
+    corp_id !== null ? loadOrgContacts('corp', corp_id) : Promise.resolve([]),
+    alliance_id !== null ? loadOrgContacts('alliance', alliance_id) : Promise.resolve([]),
     db.query<{ owner_kind: string; last_fetched_at: string }>(
       `SELECT owner_kind, last_fetched_at FROM standings_refresh
        WHERE (owner_kind = 'character' AND owner_id = $1)
@@ -60,7 +50,7 @@ standingsRouter.get('/me', async (req, res) => {
     ),
   ]);
 
-  function toMap(rows: Array<{ contact_kind: ContactKind; contact_id: number; standing: number }>): Record<string, number> {
+  function toMap(rows: Array<{ contact_kind: string; contact_id: number; standing: number }>): Record<string, number> {
     const out: Record<string, number> = {};
     for (const r of rows) out[`${r.contact_kind}:${r.contact_id}`] = r.standing;
     return out;
@@ -74,8 +64,8 @@ standingsRouter.get('/me', async (req, res) => {
     corpId:      corp_id,
     allianceId:  alliance_id,
     character:   toMap(charRows.rows),
-    corp:        toMap(corpRows.rows),
-    alliance:    toMap(allianceRows.rows),
+    corp:        toMap(corpContacts),
+    alliance:    toMap(allianceContacts),
     refreshedAt,
   });
 });

--- a/server/src/services/standings.ts
+++ b/server/src/services/standings.ts
@@ -11,6 +11,33 @@ const log = createLogger('standings');
 // here just makes the server work harder for no fresher data.
 const REFRESH_TTL_MS = 6 * 60 * 60 * 1000;
 
+// ── Corp/alliance contact-bucket read cache ──────────────────────────────────
+// The corp/alliance buckets are shared across every member and change only on a
+// Contact-Manager sync, but /api/standings/me is hit per map load/poll by every
+// member — a big corp's thousands of contacts would otherwise be re-queried and
+// re-materialised for each member on each poll. Cache them briefly, keyed by
+// kind:id, invalidated on write (below) so a fresh sync is seen at once; the TTL
+// bounds staleness for any write path that forgets to invalidate.
+export type OrgContactRow = { contact_kind: string; contact_id: number; standing: number };
+const CONTACT_TTL_MS = 60_000;
+const orgContactCache = new Map<string, { rows: OrgContactRow[]; at: number }>();
+
+export async function loadOrgContacts(kind: 'corp' | 'alliance', id: number): Promise<OrgContactRow[]> {
+  const key = `${kind}:${id}`;
+  const hit = orgContactCache.get(key);
+  if (hit && Date.now() - hit.at < CONTACT_TTL_MS) return hit.rows;
+  const sql = kind === 'corp'
+    ? `SELECT contact_kind, contact_id, standing FROM corp_standings WHERE corp_id = $1`
+    : `SELECT contact_kind, contact_id, standing FROM alliance_standings WHERE alliance_id = $1`;
+  const { rows } = await db.query<OrgContactRow>(sql, [id]);
+  orgContactCache.set(key, { rows, at: Date.now() });
+  return rows;
+}
+
+function invalidateOrgContacts(kind: 'corp' | 'alliance', id: number): void {
+  orgContactCache.delete(`${kind}:${id}`);
+}
+
 type ContactKind = 'character' | 'corporation' | 'alliance' | 'faction';
 
 interface EsiContact {
@@ -149,6 +176,7 @@ export async function refreshStandingsForUser(params: {
       if (Array.isArray(r)) {
         log.info(`corp ${corpId}: fetched ${r.length} corp contacts (via character ${characterId})`);
         await replaceStandings('corp_standings', 'corp_id', corpId, r, userId);
+        invalidateOrgContacts('corp', corpId);
         await markRefreshed('corp', corpId);
       } else {
         log.info(`corp ${corpId}: contacts fetch returned ${r.status} (${r.error}) — character ${characterId} likely lacks Contact Manager role or the read_contacts scope`);
@@ -167,6 +195,7 @@ export async function refreshStandingsForUser(params: {
       if (Array.isArray(r)) {
         log.info(`alliance ${allianceId}: fetched ${r.length} alliance contacts (via character ${characterId})`);
         await replaceStandings('alliance_standings', 'alliance_id', allianceId, r, userId);
+        invalidateOrgContacts('alliance', allianceId);
         await markRefreshed('alliance', allianceId);
       } else {
         log.info(`alliance ${allianceId}: contacts fetch returned ${r.status} (${r.error}) — character ${characterId} likely lacks alliance-executor role or the read_contacts scope`);


### PR DESCRIPTION
Second batch from the backend audit — the two biggest performance wins. **Stacked on #490** (base is `chore/backend-audit-batch-1`); it'll retarget to `qa` once #490 merges.

## standings `/me` cache (highest-frequency path)
The corp/alliance contact buckets are shared across every member and change only on a Contact-Manager sync, but `/api/standings/me` is hit per map load / poll by every member — so a big corp's (thousands of) contacts were re-queried and re-materialised for everyone on every poll.

- Added a **60s read cache** keyed by `kind:id` in `services/standings.ts` (`loadOrgContacts`), **invalidated on write** right after each corp/alliance `replaceStandings` (covers both the manual `/refresh` and the login refresh) so a fresh sync is seen immediately. The TTL bounds staleness for any path that writes without invalidating.
- The character bucket and refresh timestamps stay per-request (small / per-user).

## Merge: per-row UPDATE loops → set-based
The map-merge transaction UPDATE'd colliding signatures, structures, and system notes **one row per round-trip, serially** (up to 500+ per merge) while holding its pooled connection and row locks.

- Each loop is now **one `UPDATE ... FROM unnest($1::type[], $2::type[], …)`** — one array param per column, so: no per-row round-trips, **no 65,535-param cap** (a lurking edge case for very large corp maps), and node-pg escapes the array values. Also materially shortens the long merge transaction.

## Testing note
There is **no merge integration test** in the repo, so the set-based UPDATEs were verified by inspection: each preserves the original SET columns/values, and the `unnest` casts match the schema (`map_signatures` text/uuid; `map_structures` `owner_corp_id` int, `eve_id` bigint; `map_systems.notes` text/uuid). server tsc clean; 42 unit tests pass (CI's postgres runs the integration suite, incl. standings/access paths).