### PR TITLE
chore: backend audit batch 3 (loadFullMap LEFT JOIN + config/apiV1 DRY)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,24 +1,37 @@
 import { createHash, randomBytes } from 'node:crypto';
 
+// Comma-separated list of positive integer IDs from an env value (CORP_ID,
+// ALLIANCE_ID). Blanks and non-positive/non-integer entries are dropped.
+function parseIdList(raw: string | undefined): number[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => parseInt(s, 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
+// Boolean env flag — 1 / true / yes (case-insensitive), else false.
+function parseBool(raw: string | undefined): boolean {
+  return /^(1|true|yes)$/i.test(raw ?? '');
+}
+
+// Bounded integer env with a default and minimum; falls back to `def` when
+// unset/NaN/out of range.
+function intEnv(raw: string | undefined, def: number, min = 0): number {
+  const n = parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n >= min ? n : def;
+}
+
 // CORP_ID accepts a comma-separated list of corporation IDs. Any member of
 // any listed corp is allowed to log in.
-const CORP_IDS: number[] = (process.env.CORP_ID ?? '')
-  .split(',')
-  .map((s) => s.trim())
-  .filter(Boolean)
-  .map((s) => parseInt(s, 10))
-  .filter((n) => Number.isInteger(n) && n > 0);
+const CORP_IDS: number[] = parseIdList(process.env.CORP_ID);
 
 // ALLIANCE_ID accepts a comma-separated list of alliance IDs, mirroring
 // CORP_ID. Any member of any listed alliance is allowed to log in, and the
 // list doubles as the coalition set for alliance-map sharing. Lets a whole
 // alliance be permitted without enumerating every member corp.
-const ALLIANCE_IDS: number[] = (process.env.ALLIANCE_ID ?? '')
-  .split(',')
-  .map((s) => s.trim())
-  .filter(Boolean)
-  .map((s) => parseInt(s, 10))
-  .filter((n) => Number.isInteger(n) && n > 0);
+const ALLIANCE_IDS: number[] = parseIdList(process.env.ALLIANCE_ID);
 
 const ADMIN_CHAR_ID = process.env.ADMIN_CHAR_ID ? parseInt(process.env.ADMIN_CHAR_ID, 10) : null;
 const REPORTS_CHAR_ID = process.env.RV_REPORT_ID ? parseInt(process.env.RV_REPORT_ID, 10) : null;
@@ -28,13 +41,13 @@ const CORP_MAP_TIME = parseInt(process.env.CORP_MAP_TIME ?? '30', 10);
 // of which corp created it. When false (default), corp maps are visible only
 // to members of the corp that created them — Corp A's chain is invisible to
 // Corp B even if they share the deployment.
-const CORP_MAP_SHARED = /^(1|true|yes)$/i.test(process.env.CORP_MAP_SHARED ?? '');
+const CORP_MAP_SHARED = parseBool(process.env.CORP_MAP_SHARED);
 
 // Alliance-map counterpart of CORP_MAP_SHARED. When true, every member of any
 // listed alliance sees every alliance map (coalition mode). When false
 // (default), an alliance map is visible only to members of the alliance that
 // owns it.
-const ALLIANCE_MAP_SHARED = /^(1|true|yes)$/i.test(process.env.ALLIANCE_MAP_SHARED ?? '');
+const ALLIANCE_MAP_SHARED = parseBool(process.env.ALLIANCE_MAP_SHARED);
 
 // A restricted (non-solo) deployment — corp OR alliance gated — needs a
 // bootstrap admin so someone can always administer it.
@@ -147,24 +160,15 @@ export const config = {
   // a standing drifting below threshold, or leaving an admitted corp). Restricted
   // deployments only. Default 60; set to 0 to disable the periodic sweep (an
   // admin settings change still sweeps immediately).
-  accessRevalidateMinutes: (() => {
-    const n = parseInt(process.env.ACCESS_REVALIDATE_MINUTES ?? '60', 10);
-    return Number.isFinite(n) && n >= 0 ? n : 60;
-  })(),
+  accessRevalidateMinutes: intEnv(process.env.ACCESS_REVALIDATE_MINUTES, 60),
   // Cadence (minutes) of the lazy wormhole-removal sweep, which deletes aged-out
   // WH sigs (and quarantines the connections they backed) on maps that have
   // opted in. Default 15; set to 0 to disable the sweep globally.
-  lazyWhSweepMinutes:  (() => {
-    const n = parseInt(process.env.LAZY_WH_SWEEP_MINUTES ?? '15', 10);
-    return Number.isFinite(n) && n >= 0 ? n : 15;
-  })(),
+  lazyWhSweepMinutes:  intEnv(process.env.LAZY_WH_SWEEP_MINUTES, 15),
   // Cadence (minutes) of the connection-lifetime sweep, which re-buckets each
   // wormhole connection's time status (fresh / <1d / <4h / <1h / expired) from
   // its age so holes visibly decay on their own. Default 60; 0 disables it.
-  connLifetimeSweepMinutes: (() => {
-    const n = parseInt(process.env.CONN_LIFETIME_SWEEP_MINUTES ?? '60', 10);
-    return Number.isFinite(n) && n >= 0 ? n : 60;
-  })(),
+  connLifetimeSweepMinutes: intEnv(process.env.CONN_LIFETIME_SWEEP_MINUTES, 60),
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },

--- a/server/src/data/whLifetimes.ts
+++ b/server/src/data/whLifetimes.ts
@@ -25,7 +25,7 @@ const WH_LIFETIME_HOURS: Record<string, number> = {
 // The longest lifetime any wormhole can have. K162 (the reverse side of a hole)
 // carries no type-specific lifetime of its own — we can't know the originating
 // hole's type — so it's aged against this conservative maximum.
-export const MAX_WH_LIFETIME_HOURS = 48;
+const MAX_WH_LIFETIME_HOURS = 48;
 
 /**
  * Maximum lifetime in hours for a wormhole sig of the given type code, or

--- a/server/src/routes/apiV1.ts
+++ b/server/src/routes/apiV1.ts
@@ -54,7 +54,7 @@ apiV1Router.get('/maps', async (req, res) => {
 // reason to leak.
 apiV1Router.get('/maps/:mapId', async (req, res) => {
   const { mapId } = req.params;
-  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
+  if (!(await requireMapRead(res, mapId, req))) return;
   const full = await loadFullMap(mapId);
   if (!full) { res.status(404).json({ error: 'Map not found' }); return; }
   const {
@@ -66,11 +66,19 @@ apiV1Router.get('/maps/:mapId', async (req, res) => {
   res.json(safe);
 });
 
+// Confirm the caller can read this map, else 404 (response sent). Returns false
+// when denied — mirrors the maps.ts requireMapWrite guard shape.
+async function requireMapRead(res: Response, mapId: string, req: Request): Promise<boolean> {
+  if (await getMapAccess(mapId, req)) return true;
+  res.status(404).json({ error: 'Map not found' });
+  return false;
+}
+
 // Per-system intel. Each guards access on the map, then confirms the system
 // belongs to it (cross-map IDOR + malformed-uuid guard) before loading.
 async function systemScope(req: Request, res: Response): Promise<boolean> {
   const { mapId, systemId } = req.params;
-  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return false; }
+  if (!(await requireMapRead(res, mapId, req))) return false;
   if (!(await isSystemInMap(systemId, mapId))) { res.status(404).json({ error: 'System not found' }); return false; }
   return true;
 }
@@ -102,7 +110,7 @@ apiV1Router.get('/maps/:mapId/events', async (req, res) => {
     return;
   }
   const { mapId } = req.params;
-  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
+  if (!(await requireMapRead(res, mapId, req))) return;
   streamMapEvents(req, res, mapId);
 });
 

--- a/server/src/services/appSettings.ts
+++ b/server/src/services/appSettings.ts
@@ -2,7 +2,7 @@
 // per-user ui_settings blob — these are instance-wide and admin-managed.
 import { db } from '../db.js';
 
-export async function getSetting(key: string): Promise<string | null> {
+async function getSetting(key: string): Promise<string | null> {
   const { rows } = await db.query<{ value: string }>(
     `SELECT value FROM app_settings WHERE key = $1`,
     [key],

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -111,14 +111,16 @@ export async function loadFullMap(mapId: string) {
       [mapId],
     ),
     db.query(
-      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass",
-              effect, statics, region_name AS "regionName", npc_type AS "npcType",
-              position_x AS x, position_y AS y,
-              status, intel, is_home AS "isHome", locked, notes,
-              labels, custom_labels AS "customLabels", tag, alias,
-              (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
-              last_activity_at AS "lastActivityAt"
-       FROM map_systems WHERE map_id = $1`,
+      `SELECT ms.id, ms.eve_system_id AS "eveSystemId", ms.name, ms.system_class AS "systemClass",
+              ms.effect, ms.statics, ms.region_name AS "regionName", ms.npc_type AS "npcType",
+              ms.position_x AS x, ms.position_y AS y,
+              ms.status, ms.intel, ms.is_home AS "isHome", ms.locked, ms.notes,
+              ms.labels, ms.custom_labels AS "customLabels", ms.tag, ms.alias,
+              ss.security::float8 AS "security",
+              ms.last_activity_at AS "lastActivityAt"
+       FROM map_systems ms
+       LEFT JOIN solar_systems ss ON ss.id = ms.eve_system_id
+       WHERE ms.map_id = $1`,
       [mapId],
     ),
     db.query(


### PR DESCRIPTION
Third batch — safe perf + DRY cleanup. Branched **off qa** and touches different files/regions than #492 (Batch 2), so the two merge to qa independently, in any order.

## Performance
- **`loadFullMap`: correlated subquery → LEFT JOIN.** The systems query resolved each row's `security` with a per-row scalar subquery on `solar_systems` (N PK lookups per map open — a hot path). Now a single `LEFT JOIN solar_systems`.

## DRY
- **`config.ts` env parsing** deduped: `parseIdList` (`CORP_ID` / `ALLIANCE_ID`), `parseBool` (`CORP_MAP_SHARED` / `ALLIANCE_MAP_SHARED`), and `intEnv` for the three sweep-cadence IIFEs. (Left the `on`-accepting bool variant alone — it's a deliberately different set.)
- **`apiV1`**: extracted `requireMapRead(res, mapId, req)` for the three repeated `getMapAccess → 404` sites, mirroring the `maps.ts` `requireMapWrite` guard shape.
- Dropped needless `export`s (`getSetting`, `MAX_WH_LIFETIME_HOURS`) — both used only within their own file.

## Deferred (logged in backend-audit.md)
`crossMapSync` batching (nuanced fill-blanks upsert), the orphan-sweep prefilter (changes which dormant-map connections get quarantined), the sig/structure/system projection single-sourcing (the copies differ by table prefix + `systemId` — not a clean identical-copy consolidation), `timeStatus 'eol'`, WH-class enum consolidation, admin pagination, and the two-sweep reconciliation — all need more care / lack test coverage.

server tsc clean; 42 unit tests pass (CI's postgres runs the integration suite).