### PR TITLE
chore: backend audit batch 5 (fix deprecated concurrent-query-on-one-tx-client, pg@9)

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1328,29 +1328,31 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
     await client.query('BEGIN');
 
     // ── Load both sides ─────────────────────────────────────────────────
-    const [destSysRes, destConnRes, srcSysRes, srcConnRes] = await Promise.all([
-      client.query<{ id: string; eveSystemId: number | null; name: string; notes: string; x: number; y: number }>(
-        `SELECT id, eve_system_id AS "eveSystemId", name, notes, position_x AS x, position_y AS y
-           FROM map_systems WHERE map_id = $1`, [destId]),
-      client.query<{ sourceId: string; targetId: string }>(
-        `SELECT source_id AS "sourceId", target_id AS "targetId" FROM map_connections WHERE map_id = $1`, [destId]),
-      client.query<{
-        id: string; eveSystemId: number | null; name: string; systemClass: string; effect: string;
-        statics: string[]; regionName: string | null; npcType: string | null; x: number; y: number;
-        status: string; notes: string;
-      }>(
-        `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
-                region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y, status, notes
-           FROM map_systems WHERE map_id = $1`, [sourceId]),
-      client.query<{
-        sourceId: string; targetId: string; sourceHandle: string | null; targetHandle: string | null;
-        connectionType: string; massStatus: string | null; timeStatus: string | null; size: string; whType: string | null;
-      }>(
-        `SELECT source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
-                target_handle AS "targetHandle", connection_type AS "connectionType",
-                mass_status AS "massStatus", time_status AS "timeStatus", size, wh_type AS "whType"
-           FROM map_connections WHERE map_id = $1`, [sourceId]),
-    ]);
+    // Sequential awaits, not Promise.all: these all run on the ONE pooled
+    // transaction client, which node-pg already serialises — and the concurrent
+    // form ("client.query while the client is executing a query") is deprecated
+    // and removed in pg@9. Same in-transaction snapshot either way.
+    const destSysRes = await client.query<{ id: string; eveSystemId: number | null; name: string; notes: string; x: number; y: number }>(
+      `SELECT id, eve_system_id AS "eveSystemId", name, notes, position_x AS x, position_y AS y
+         FROM map_systems WHERE map_id = $1`, [destId]);
+    const destConnRes = await client.query<{ sourceId: string; targetId: string }>(
+      `SELECT source_id AS "sourceId", target_id AS "targetId" FROM map_connections WHERE map_id = $1`, [destId]);
+    const srcSysRes = await client.query<{
+      id: string; eveSystemId: number | null; name: string; systemClass: string; effect: string;
+      statics: string[]; regionName: string | null; npcType: string | null; x: number; y: number;
+      status: string; notes: string;
+    }>(
+      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
+              region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y, status, notes
+         FROM map_systems WHERE map_id = $1`, [sourceId]);
+    const srcConnRes = await client.query<{
+      sourceId: string; targetId: string; sourceHandle: string | null; targetHandle: string | null;
+      connectionType: string; massStatus: string | null; timeStatus: string | null; size: string; whType: string | null;
+    }>(
+      `SELECT source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
+              target_handle AS "targetHandle", connection_type AS "connectionType",
+              mass_status AS "massStatus", time_status AS "timeStatus", size, wh_type AS "whType"
+         FROM map_connections WHERE map_id = $1`, [sourceId]);
 
     if (srcSysRes.rows.length > MAX_IMPORT_SYSTEMS) {
       await client.query('ROLLBACK');
@@ -1526,15 +1528,13 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
     // ── Signatures: upsert by sig_id within the destination system ───────
     let addedSignatures = 0, updatedSignatures = 0;
     if (include.signatures && srcSysIds.length > 0) {
-      const [srcSigs, destSigs] = await Promise.all([
-        client.query<{ systemId: string; sigId: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string }>(
-          `SELECT system_id AS "systemId", sig_id AS "sigId", sig_type AS "sigType", name, notes,
-                  wh_type AS "whType", wh_leads_to AS "whLeadsTo"
-             FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]),
-        client.query<{ id: string; systemId: string; sigId: string }>(
-          `SELECT id, system_id AS "systemId", sig_id AS "sigId"
-             FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [destSysIds]),
-      ]);
+      const srcSigs = await client.query<{ systemId: string; sigId: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string }>(
+        `SELECT system_id AS "systemId", sig_id AS "sigId", sig_type AS "sigType", name, notes,
+                wh_type AS "whType", wh_leads_to AS "whLeadsTo"
+           FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]);
+      const destSigs = await client.query<{ id: string; systemId: string; sigId: string }>(
+        `SELECT id, system_id AS "systemId", sig_id AS "sigId"
+           FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [destSysIds]);
       const destSigMap = new Map<string, string>(); // `${destSysId}|${sigIdLower}` → dest sig id
       for (const ds of destSigs.rows) {
         const k = ds.sigId.trim().toLowerCase();
@@ -1587,15 +1587,13 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
     // ── Structures: upsert by eve_id, falling back to name, per system ───
     let addedStructures = 0, updatedStructures = 0;
     if (include.structures && srcSysIds.length > 0) {
-      const [srcStructs, destStructs] = await Promise.all([
-        client.query<{ systemId: string; name: string; structureType: string; ownerCorp: string; eveId: string | null; notes: string; ownerCorpId: number | null }>(
-          `SELECT system_id AS "systemId", name, structure_type AS "structureType", owner_corp AS "ownerCorp",
-                  eve_id AS "eveId", notes, owner_corp_id AS "ownerCorpId"
-             FROM map_structures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]),
-        client.query<{ id: string; systemId: string; name: string; eveId: string | null }>(
-          `SELECT id, system_id AS "systemId", name, eve_id AS "eveId"
-             FROM map_structures WHERE system_id = ANY($1::uuid[])`, [destSysIds]),
-      ]);
+      const srcStructs = await client.query<{ systemId: string; name: string; structureType: string; ownerCorp: string; eveId: string | null; notes: string; ownerCorpId: number | null }>(
+        `SELECT system_id AS "systemId", name, structure_type AS "structureType", owner_corp AS "ownerCorp",
+                eve_id AS "eveId", notes, owner_corp_id AS "ownerCorpId"
+           FROM map_structures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]);
+      const destStructs = await client.query<{ id: string; systemId: string; name: string; eveId: string | null }>(
+        `SELECT id, system_id AS "systemId", name, eve_id AS "eveId"
+           FROM map_structures WHERE system_id = ANY($1::uuid[])`, [destSysIds]);
       const byEve  = new Map<string, string>(); // `${destSysId}|${eveId}`     → id
       const byName = new Map<string, string>(); // `${destSysId}|${nameLower}` → id
       for (const d of destStructs.rows) {

--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -93,14 +93,14 @@ async function sweepMap(mapId: string, expired: CandidateRow[]): Promise<void> {
   try {
     await client.query('BEGIN');
 
-    const [sysRes, connRes] = await Promise.all([
-      client.query<SysRow>(
-        `SELECT id, name, system_class AS "systemClass" FROM map_systems WHERE map_id = $1`, [mapId]),
-      client.query<ConnRow>(
-        `SELECT id, source_id AS "sourceId", target_id AS "targetId", wh_type AS "type",
-                connection_type AS "connectionType", broken
-           FROM map_connections WHERE map_id = $1`, [mapId]),
-    ]);
+    // Sequential, not Promise.all — concurrent queries on one pooled tx client
+    // are serialised by node-pg anyway and the parallel form is deprecated (pg@9).
+    const sysRes = await client.query<SysRow>(
+      `SELECT id, name, system_class AS "systemClass" FROM map_systems WHERE map_id = $1`, [mapId]);
+    const connRes = await client.query<ConnRow>(
+      `SELECT id, source_id AS "sourceId", target_id AS "targetId", wh_type AS "type",
+              connection_type AS "connectionType", broken
+         FROM map_connections WHERE map_id = $1`, [mapId]);
 
     await client.query(`DELETE FROM map_signatures WHERE id = ANY($1::uuid[])`, [expiredIds]);
 


### PR DESCRIPTION
Correctness / future-proofing batch. Surfaced while writing the merge integration test (#494): the merge and `whSweep` transactions ran their initial reads as `Promise.all([client.query(...), client.query(...)])` on a **single pooled transaction client**. node-pg serialises those anyway, and the concurrent form ("client.query() when the client is already executing a query") is **deprecated and removed in pg@9** — it also emits a runtime `DeprecationWarning`.

Replaced with **sequential awaits on the same client**: identical in-transaction snapshot, no behaviour change, warnings gone.

**Sites fixed:**
- The map-merge transaction (`maps.ts`) — load-both-sides, signature load, structure load.
- `whSweep.ts` `sweepMap`.

Left `Promise.all` on the **pool** (`db`) alone — that's correct, each of those gets its own connection.

**Validated** by the map-merge integration test (from #494, now runs locally against the throwaway `*_test` Postgres too) plus the full suite — **76 tests, 0 skipped, all pass** against a real DB. server tsc clean.

Off qa, independent of any open work. Logged in `backend-audit.md`.