### PR TITLE
chore: backend audit tier-1 (corp-move session refresh + two-sweep reconciliation)

### DIFF
--- a/server/src/services/accessRevalidate.integration.test.ts
+++ b/server/src/services/accessRevalidate.integration.test.ts
@@ -122,6 +122,10 @@ describe.skipIf(!dbReady)('revalidateActiveSessions (integration — real SQL)',
       expect(await liveSessionCount(u)).toBe(1);
       const { rows } = await db.query<{ corp_id: number }>(`SELECT corp_id FROM users WHERE id = $1`, [u]);
       expect(rows[0].corp_id).toBe(500);
+      // The live session's scope is refreshed in place (not evicted) to the new corp.
+      const sess = await db.query<{ corp: string | null }>(
+        `SELECT sess->>'userCorpId' AS corp FROM sessions WHERE (sess->>'userId')::int = $1`, [u]);
+      expect(sess.rows[0].corp).toBe('500');
     });
 
     it('falls back to stored ids on an ESI outage (no mass eviction)', async () => {

--- a/server/src/services/accessRevalidate.ts
+++ b/server/src/services/accessRevalidate.ts
@@ -11,7 +11,7 @@
 import { db } from '../db.js';
 import { config } from '../config.js';
 import { isLoginPermitted, standingsPermitLogin } from './accessGrants.js';
-import { invalidateSessionsForUser } from '../utils/sessionInvalidate.js';
+import { invalidateSessionsForUser, refreshSessionAffiliation } from '../utils/sessionInvalidate.js';
 import { audit } from './audit.js';
 import { esiFetch } from '../utils/esi.js';
 import { createLogger } from '../utils/logger.js';
@@ -114,6 +114,11 @@ export async function revalidateActiveSessions(opts: { refreshAffiliation?: bool
         await db.query(`UPDATE users SET corp_id = $1, alliance_id = $2, updated_at = NOW() WHERE id = $3`, [aff.corpId, aff.allianceId, u.id]);
         await audit({ session: {} }, u.id, characterId, 'corp_change',
           u.corpId !== null ? String(u.corpId) : null, aff.corpId !== null ? String(aff.corpId) : null);
+        // Refresh the live session's corp/alliance scope in place (don't evict —
+        // the design keeps sessions across corp moves). Without this, a pilot who
+        // changed corp keeps their old corp's map read/write scope until re-login.
+        // If they're no longer permitted at all, the eviction below still fires.
+        await refreshSessionAffiliation(u.id, aff.corpId, aff.allianceId);
       }
       corpId = aff.corpId;
       allianceId = aff.allianceId;

--- a/server/src/services/whSweep.integration.test.ts
+++ b/server/src/services/whSweep.integration.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import crypto from 'node:crypto';
+
+// Mock config (real db) so we can toggle whether the connection-lifetime sweep
+// is "enabled" — that's what decides whether whSweep defers manually-overridden
+// holes to it.
+const state = vi.hoisted(() => ({ connLifetimeSweepMinutes: 60 }));
+vi.mock('../config.js', async (importActual) => {
+  const base = (await importActual<typeof import('../config.js')>()).config as Record<string, unknown>;
+  return { config: new Proxy({}, { get: (_t, k: string) => (k === 'connLifetimeSweepMinutes' ? state.connLifetimeSweepMinutes : base[k]) }) };
+});
+
+import { ensureIntegrationDb, truncateAll, seedUser } from '../test/integrationDb.js';
+import { db } from '../db.js';
+import { sweepAll } from './whSweep.js';
+
+const dbReady = await ensureIntegrationDb();
+
+async function seedMap(userId: number): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `INSERT INTO maps (user_id, name, lazy_remove_wormholes) VALUES ($1, 'Sweep Map', TRUE) RETURNING id`, [userId]);
+  return rows[0].id;
+}
+async function seedSystem(mapId: string, name: string): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.query(`INSERT INTO map_systems (id, map_id, name, system_class) VALUES ($1, $2, $3, 'C4')`, [id, mapId, name]);
+  return id;
+}
+// A wormhole sig aged well past its type's max life (D382 = 16h).
+async function seedAgedSig(systemId: string, ageHours = 20): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `INSERT INTO map_signatures (system_id, sig_id, sig_type, wh_type, created_at)
+     VALUES ($1, $2, 'wormhole', 'D382', NOW() - ($3 || ' hours')::interval) RETURNING id`,
+    [systemId, `ABC-${Math.floor(ageHours)}`, String(ageHours)]);
+  return rows[0].id;
+}
+async function seedConn(mapId: string, srcSys: string, tgtSys: string, sigId: string, lifetimeExpiresAt: string | null): Promise<void> {
+  await db.query(
+    `INSERT INTO map_connections (id, map_id, source_id, target_id, connection_type, wh_type, source_signature_id, lifetime_expires_at)
+     VALUES ($1, $2, $3, $4, 'standard', 'D382', $5, $6)`,
+    [crypto.randomUUID(), mapId, srcSys, tgtSys, sigId, lifetimeExpiresAt]);
+}
+const sigExists = async (id: string): Promise<boolean> =>
+  (await db.query(`SELECT 1 FROM map_signatures WHERE id = $1`, [id])).rows.length > 0;
+
+describe.skipIf(!dbReady)('whSweep + connLifetime reconciliation (integration)', () => {
+  let ownerId: number;
+  beforeEach(async () => {
+    await truncateAll();
+    state.connLifetimeSweepMinutes = 60; // connLifetime sweep enabled by default
+    ownerId = await seedUser({ characterId: 900 });
+  });
+
+  it('sweeps an aged auto hole but DEFERS one with a manual lifetime override', async () => {
+    const mapId = await seedMap(ownerId);
+    const a = await seedSystem(mapId, 'A');
+    const b = await seedSystem(mapId, 'B');
+
+    const autoSig = await seedAgedSig(a, 20);   // 20h old, no override → aged out
+    await seedConn(mapId, a, b, autoSig, null);
+
+    const overriddenSig = await seedAgedSig(a, 20); // 20h old, but its connection has an override
+    await seedConn(mapId, a, b, overriddenSig, new Date(Date.now() + 10 * 3_600_000).toISOString());
+
+    await sweepAll();
+
+    expect(await sigExists(autoSig)).toBe(false);       // swept
+    expect(await sigExists(overriddenSig)).toBe(true);  // deferred to connLifetime sweep
+  });
+
+  it('sweeps BOTH when the connection-lifetime sweep is disabled (no one to defer to)', async () => {
+    state.connLifetimeSweepMinutes = 0; // disabled
+    const mapId = await seedMap(ownerId);
+    const a = await seedSystem(mapId, 'A');
+    const b = await seedSystem(mapId, 'B');
+
+    const autoSig = await seedAgedSig(a, 20);
+    await seedConn(mapId, a, b, autoSig, null);
+    const overriddenSig = await seedAgedSig(a, 20);
+    await seedConn(mapId, a, b, overriddenSig, new Date(Date.now() + 10 * 3_600_000).toISOString());
+
+    await sweepAll();
+
+    expect(await sigExists(autoSig)).toBe(false);
+    expect(await sigExists(overriddenSig)).toBe(false); // no defer target → swept too
+  });
+
+  it('leaves a fresh hole alone', async () => {
+    const mapId = await seedMap(ownerId);
+    const a = await seedSystem(mapId, 'A');
+    const fresh = await seedAgedSig(a, 2); // 2h old, well within a 16h life
+    await sweepAll();
+    expect(await sigExists(fresh)).toBe(true);
+  });
+});

--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -151,9 +151,17 @@ async function sweepMap(mapId: string, expired: CandidateRow[]): Promise<void> {
 }
 
 /** One sweep pass over every opted-in map. */
-async function sweepAll(): Promise<void> {
+export async function sweepAll(): Promise<void> {
   let rows: CandidateRow[];
   try {
+    // When the connection-lifetime sweep is running, it is the single authority
+    // for any connection carrying a MANUAL lifetime override (lifetime_expires_at)
+    // — it honours the override, this sig-age sweep can't see it. Defer those sigs
+    // to it, so a hole whose life was manually EXTENDED past its type max isn't
+    // collapsed early here (the two sweeps otherwise disagree). Shorter overrides
+    // are collapsed by connLifetimeSweep first anyway. When it's disabled, this
+    // sweep handles everything as before.
+    const deferOverrides = config.connLifetimeSweepMinutes > 0;
     const res = await db.query<CandidateRow>(
       `SELECT s.id, s.system_id AS "systemId", sys.map_id AS "mapId",
               s.wh_type AS "whType", s.wh_leads_to AS "whLeadsTo", s.created_at AS "createdAt",
@@ -163,8 +171,12 @@ async function sweepAll(): Promise<void> {
          JOIN maps m ON m.id = sys.map_id
         WHERE m.lazy_remove_wormholes = TRUE
           AND s.sig_type = 'wormhole'
-          AND s.created_at < NOW() - ($1 || ' hours')::interval`,
-      [String(MIN_LIFETIME_HOURS)],
+          AND s.created_at < NOW() - ($1 || ' hours')::interval
+          AND (NOT $2::boolean OR NOT EXISTS (
+                SELECT 1 FROM map_connections c
+                 WHERE (c.source_signature_id = s.id OR c.target_signature_id = s.id)
+                   AND c.lifetime_expires_at IS NOT NULL))`,
+      [String(MIN_LIFETIME_HOURS), deferOverrides],
     );
     rows = res.rows;
   } catch (err) {

--- a/server/src/utils/sessionInvalidate.ts
+++ b/server/src/utils/sessionInvalidate.ts
@@ -30,3 +30,39 @@ export async function invalidateSessionsForUser(userId: number): Promise<number>
     return 0;
   }
 }
+
+/**
+ * Refresh the corp/alliance affiliation carried in a user's LIVE sessions,
+ * in place, without evicting them. The session stores a login-time snapshot of
+ * userCorpId/userAllianceId that map read/write scope reads; when the periodic
+ * revalidation adopts a fresh affiliation from ESI (a pilot changed corp) but
+ * the user is still permitted, this keeps their session but updates its scope so
+ * they immediately see/edit the right corp's maps — rather than the old corp's
+ * until the 7-day cookie expires. Deliberately does NOT drop the session (the
+ * design keeps sessions across corp moves).
+ *
+ * The `sess` column is JSON; we cast to jsonb to set the keys, then back.
+ * Returns the number of sessions updated (0 if none / no table yet).
+ */
+export async function refreshSessionAffiliation(
+  userId: number, corpId: number | null, allianceId: number | null,
+): Promise<number> {
+  try {
+    const { rowCount } = await db.query(
+      // COALESCE to the jsonb 'null' literal: a bare to_jsonb(NULL::int) is SQL
+      // NULL, and jsonb_set(..., NULL) returns NULL — which would blow away the
+      // whole session (sess is NOT NULL). We want the JSON value null instead.
+      `UPDATE sessions
+          SET sess = jsonb_set(
+                       jsonb_set(sess::jsonb, '{userCorpId}',     COALESCE(to_jsonb($2::int), 'null'::jsonb)),
+                       '{userAllianceId}', COALESCE(to_jsonb($3::int), 'null'::jsonb)
+                     )::json
+        WHERE sess->>'userId' = $1`,
+      [String(userId), corpId, allianceId],
+    );
+    return rowCount ?? 0;
+  } catch (err) {
+    log.warn('refreshSessionAffiliation failed:', err);
+    return 0;
+  }
+}


### PR DESCRIPTION
The two most defensible deferred items, each with real-DB test coverage. Off qa, independent of the other open PRs.

## [Security] Corp-move session staleness
When the revalidation sweep adopts a fresh ESI affiliation (a pilot changed corp) but the user is **still permitted**, it now **refreshes the live session's `userCorpId`/`userAllianceId` in place** (new `refreshSessionAffiliation`) instead of leaving the login-time snapshot — so their map read/write scope reflects the new corp immediately, without a re-login. It does **not** evict the session (the existing design deliberately keeps sessions across corp moves; if they're no longer permitted at all, the eviction path still fires).

> The added test caught a real bug before merge: `to_jsonb(NULL::int)` is SQL NULL, and `jsonb_set(…, NULL)` returns NULL — which would have nulled the whole `sess` (NOT NULL → the UPDATE throws and is swallowed → silently stale). Fixed with `COALESCE(…, 'null'::jsonb)`.

## [Correctness] Two-sweep reconciliation
`whSweep` (deletes sigs by sig-age) and `connLifetimeSweep` (collapses connections by their override-aware effective expiry) could disagree on a hole with a **manual lifetime override** — `whSweep` would collapse a manually-**extended** hole early on the sig clock. `whSweep` now **defers any sig backing a connection with a `lifetime_expires_at` override to `connLifetimeSweep`**, gated on that sweep being enabled (so nothing is left uncollapsed when it's disabled). Shorter overrides were already collapsed by `connLifetimeSweep` first.

## Coverage
- New `whSweep.integration.test.ts`: auto hole swept, overridden hole deferred, both swept when connLifetime disabled, fresh hole untouched.
- Assertion added to the accessRevalidate integration test that the session scope is refreshed on a corp move.
- **Full suite: 79 tests, 0 skipped, all pass against real Postgres.** server tsc clean.