### PR TITLE
release: promote backend audit series (qa -> release)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ changes.md
 # Local-only Compose overrides (e.g. publishing Postgres to the host for yarn-dev)
 docker-compose.override.yml
 
-# Local frontend audit working notes (not committed)
+# Local audit working notes (not committed)
 frontend-audit.md
+backend-audit.md

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,24 +1,37 @@
 import { createHash, randomBytes } from 'node:crypto';
 
+// Comma-separated list of positive integer IDs from an env value (CORP_ID,
+// ALLIANCE_ID). Blanks and non-positive/non-integer entries are dropped.
+function parseIdList(raw: string | undefined): number[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => parseInt(s, 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
+// Boolean env flag — 1 / true / yes (case-insensitive), else false.
+function parseBool(raw: string | undefined): boolean {
+  return /^(1|true|yes)$/i.test(raw ?? '');
+}
+
+// Bounded integer env with a default and minimum; falls back to `def` when
+// unset/NaN/out of range.
+function intEnv(raw: string | undefined, def: number, min = 0): number {
+  const n = parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n >= min ? n : def;
+}
+
 // CORP_ID accepts a comma-separated list of corporation IDs. Any member of
 // any listed corp is allowed to log in.
-const CORP_IDS: number[] = (process.env.CORP_ID ?? '')
-  .split(',')
-  .map((s) => s.trim())
-  .filter(Boolean)
-  .map((s) => parseInt(s, 10))
-  .filter((n) => Number.isInteger(n) && n > 0);
+const CORP_IDS: number[] = parseIdList(process.env.CORP_ID);
 
 // ALLIANCE_ID accepts a comma-separated list of alliance IDs, mirroring
 // CORP_ID. Any member of any listed alliance is allowed to log in, and the
 // list doubles as the coalition set for alliance-map sharing. Lets a whole
 // alliance be permitted without enumerating every member corp.
-const ALLIANCE_IDS: number[] = (process.env.ALLIANCE_ID ?? '')
-  .split(',')
-  .map((s) => s.trim())
-  .filter(Boolean)
-  .map((s) => parseInt(s, 10))
-  .filter((n) => Number.isInteger(n) && n > 0);
+const ALLIANCE_IDS: number[] = parseIdList(process.env.ALLIANCE_ID);
 
 const ADMIN_CHAR_ID = process.env.ADMIN_CHAR_ID ? parseInt(process.env.ADMIN_CHAR_ID, 10) : null;
 const REPORTS_CHAR_ID = process.env.RV_REPORT_ID ? parseInt(process.env.RV_REPORT_ID, 10) : null;
@@ -28,13 +41,13 @@ const CORP_MAP_TIME = parseInt(process.env.CORP_MAP_TIME ?? '30', 10);
 // of which corp created it. When false (default), corp maps are visible only
 // to members of the corp that created them — Corp A's chain is invisible to
 // Corp B even if they share the deployment.
-const CORP_MAP_SHARED = /^(1|true|yes)$/i.test(process.env.CORP_MAP_SHARED ?? '');
+const CORP_MAP_SHARED = parseBool(process.env.CORP_MAP_SHARED);
 
 // Alliance-map counterpart of CORP_MAP_SHARED. When true, every member of any
 // listed alliance sees every alliance map (coalition mode). When false
 // (default), an alliance map is visible only to members of the alliance that
 // owns it.
-const ALLIANCE_MAP_SHARED = /^(1|true|yes)$/i.test(process.env.ALLIANCE_MAP_SHARED ?? '');
+const ALLIANCE_MAP_SHARED = parseBool(process.env.ALLIANCE_MAP_SHARED);
 
 // A restricted (non-solo) deployment — corp OR alliance gated — needs a
 // bootstrap admin so someone can always administer it.
@@ -147,24 +160,15 @@ export const config = {
   // a standing drifting below threshold, or leaving an admitted corp). Restricted
   // deployments only. Default 60; set to 0 to disable the periodic sweep (an
   // admin settings change still sweeps immediately).
-  accessRevalidateMinutes: (() => {
-    const n = parseInt(process.env.ACCESS_REVALIDATE_MINUTES ?? '60', 10);
-    return Number.isFinite(n) && n >= 0 ? n : 60;
-  })(),
+  accessRevalidateMinutes: intEnv(process.env.ACCESS_REVALIDATE_MINUTES, 60),
   // Cadence (minutes) of the lazy wormhole-removal sweep, which deletes aged-out
   // WH sigs (and quarantines the connections they backed) on maps that have
   // opted in. Default 15; set to 0 to disable the sweep globally.
-  lazyWhSweepMinutes:  (() => {
-    const n = parseInt(process.env.LAZY_WH_SWEEP_MINUTES ?? '15', 10);
-    return Number.isFinite(n) && n >= 0 ? n : 15;
-  })(),
+  lazyWhSweepMinutes:  intEnv(process.env.LAZY_WH_SWEEP_MINUTES, 15),
   // Cadence (minutes) of the connection-lifetime sweep, which re-buckets each
   // wormhole connection's time status (fresh / <1d / <4h / <1h / expired) from
   // its age so holes visibly decay on their own. Default 60; 0 disables it.
-  connLifetimeSweepMinutes: (() => {
-    const n = parseInt(process.env.CONN_LIFETIME_SWEEP_MINUTES ?? '60', 10);
-    return Number.isFinite(n) && n >= 0 ? n : 60;
-  })(),
+  connLifetimeSweepMinutes: intEnv(process.env.CONN_LIFETIME_SWEEP_MINUTES, 60),
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },

--- a/server/src/data/whLifetimes.ts
+++ b/server/src/data/whLifetimes.ts
@@ -25,7 +25,7 @@ const WH_LIFETIME_HOURS: Record<string, number> = {
 // The longest lifetime any wormhole can have. K162 (the reverse side of a hole)
 // carries no type-specific lifetime of its own — we can't know the originating
 // hole's type — so it's aged against this conservative maximum.
-export const MAX_WH_LIFETIME_HOURS = 48;
+const MAX_WH_LIFETIME_HOURS = 48;
 
 /**
  * Maximum lifetime in hours for a wormhole sig of the given type code, or

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -596,6 +596,14 @@ export async function migrate() {
       ON map_systems (map_id, eve_system_id)
       WHERE eve_system_id IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_map_connections_map   ON map_connections (map_id);
+    -- FK referencing columns on map_connections. Postgres does NOT auto-index a
+    -- referencing side, so without these every map_signatures DELETE (the wh /
+    -- lifetime sweeps run these on a timer) and every map_systems DELETE / map
+    -- cascade seq-scans the whole map_connections table to find referencing rows.
+    CREATE INDEX IF NOT EXISTS idx_map_connections_source     ON map_connections (source_id);
+    CREATE INDEX IF NOT EXISTS idx_map_connections_target     ON map_connections (target_id);
+    CREATE INDEX IF NOT EXISTS idx_map_connections_source_sig ON map_connections (source_signature_id);
+    CREATE INDEX IF NOT EXISTS idx_map_connections_target_sig ON map_connections (target_signature_id);
     CREATE INDEX IF NOT EXISTS idx_map_signatures_system ON map_signatures (system_id);
     CREATE INDEX IF NOT EXISTS idx_map_structures_system ON map_structures (system_id);
     CREATE INDEX IF NOT EXISTS idx_user_events_user      ON user_events (user_id, created_at);

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -246,6 +246,10 @@ adminRouter.patch('/users/:id/role', async (req, res) => {
   const newRole = role as Role;
   await db.query(`UPDATE users SET role = $1, updated_at = NOW() WHERE id = $2`, [newRole, userId]);
   await audit(req, userId, target.character_id, 'role_change', target.role, newRole);
+  // A live session carries a login-time role snapshot; drop the user's sessions so
+  // the change takes effect immediately (a demotion otherwise keeps its old map
+  // write access until re-login / the 7-day cookie TTL). Matches the block handler.
+  await invalidateSessionsForUser(userId);
 
   res.json({ ok: true });
 });

--- a/server/src/routes/apiV1.ts
+++ b/server/src/routes/apiV1.ts
@@ -54,7 +54,7 @@ apiV1Router.get('/maps', async (req, res) => {
 // reason to leak.
 apiV1Router.get('/maps/:mapId', async (req, res) => {
   const { mapId } = req.params;
-  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
+  if (!(await requireMapRead(res, mapId, req))) return;
   const full = await loadFullMap(mapId);
   if (!full) { res.status(404).json({ error: 'Map not found' }); return; }
   const {
@@ -66,11 +66,19 @@ apiV1Router.get('/maps/:mapId', async (req, res) => {
   res.json(safe);
 });
 
+// Confirm the caller can read this map, else 404 (response sent). Returns false
+// when denied — mirrors the maps.ts requireMapWrite guard shape.
+async function requireMapRead(res: Response, mapId: string, req: Request): Promise<boolean> {
+  if (await getMapAccess(mapId, req)) return true;
+  res.status(404).json({ error: 'Map not found' });
+  return false;
+}
+
 // Per-system intel. Each guards access on the map, then confirms the system
 // belongs to it (cross-map IDOR + malformed-uuid guard) before loading.
 async function systemScope(req: Request, res: Response): Promise<boolean> {
   const { mapId, systemId } = req.params;
-  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return false; }
+  if (!(await requireMapRead(res, mapId, req))) return false;
   if (!(await isSystemInMap(systemId, mapId))) { res.status(404).json({ error: 'System not found' }); return false; }
   return true;
 }
@@ -102,7 +110,7 @@ apiV1Router.get('/maps/:mapId/events', async (req, res) => {
     return;
   }
   const { mapId } = req.params;
-  if (!(await getMapAccess(mapId, req))) { res.status(404).json({ error: 'Map not found' }); return; }
+  if (!(await requireMapRead(res, mapId, req))) return;
   streamMapEvents(req, res, mapId);
 });
 

--- a/server/src/routes/maps.merge.integration.test.ts
+++ b/server/src/routes/maps.merge.integration.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import crypto from 'node:crypto';
+
+import { ensureIntegrationDb, truncateAll, seedUser } from '../test/integrationDb.js';
+import { db } from '../db.js';
+import { mapsRouter } from './maps.js';
+
+const dbReady = await ensureIntegrationDb();
+
+// Bare app: the real mapsRouter (incl. requireAuth + the real access checks)
+// behind a fake session. Personal maps owned by the session user need no config
+// overrides — the owner passes requireMapWrite regardless of role.
+function makeApp(userId: number) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as express.Request & { session: Record<string, unknown> }).session =
+      { userId, characterId: 900, role: 'full', userCorpId: null, userAllianceId: null };
+    next();
+  });
+  app.use('/api/maps', mapsRouter);
+  return app;
+}
+
+async function seedMap(userId: number, name: string): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `INSERT INTO maps (user_id, name) VALUES ($1, $2) RETURNING id`, [userId, name]);
+  return rows[0].id;
+}
+async function seedSystem(mapId: string, eveId: number, name: string, notes = ''): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.query(
+    `INSERT INTO map_systems (id, map_id, eve_system_id, name, system_class, notes)
+     VALUES ($1, $2, $3, $4, 'C4', $5)`, [id, mapId, eveId, name, notes]);
+  return id;
+}
+async function seedSig(systemId: string, sigId: string, o: {
+  sigType?: string; name?: string; notes?: string; whType?: string; whLeadsTo?: string;
+} = {}): Promise<void> {
+  await db.query(
+    `INSERT INTO map_signatures (system_id, sig_id, sig_type, name, notes, wh_type, wh_leads_to)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [systemId, sigId, o.sigType ?? 'unknown', o.name ?? '', o.notes ?? '', o.whType ?? '', o.whLeadsTo ?? '']);
+}
+async function seedStruct(systemId: string, userId: number, o: {
+  name: string; structureType?: string; ownerCorp?: string; eveId?: number | null; notes?: string; ownerCorpId?: number | null;
+}): Promise<void> {
+  await db.query(
+    `INSERT INTO map_structures (system_id, name, structure_type, owner_corp, eve_id, notes, owner_corp_id, created_by_user_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+    [systemId, o.name, o.structureType ?? 'unknown', o.ownerCorp ?? '', o.eveId ?? null, o.notes ?? '', o.ownerCorpId ?? null, userId]);
+}
+
+describe.skipIf(!dbReady)('map merge (integration)', () => {
+  let ownerId: number;
+  let app: express.Express;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ownerId = await seedUser({ characterId: 900, role: 'full' });
+    app = makeApp(ownerId);
+  });
+
+  it('folds sigs, structures and notes into the matched system — set-based UPDATEs + inserts', async () => {
+    const EVE = 31000005;
+    const destMap = await seedMap(ownerId, 'Dest Map');
+    const srcMap  = await seedMap(ownerId, 'Source Map');
+
+    // Same system on both maps (matched by eve_system_id).
+    const destSys = await seedSystem(destMap, EVE, 'J131110', '');        // blank note
+    const srcSys  = await seedSystem(srcMap,  EVE, 'J131110', 'keep me'); // note to fold in
+
+    // ABC-123 collides (blank on dest, filled on source) → dest UPDATED.
+    await seedSig(destSys, 'ABC-123');
+    await seedSig(srcSys,  'ABC-123', { sigType: 'wormhole', name: 'K162', notes: 'src sig', whType: 'K162', whLeadsTo: 'C4' });
+    // DEF-456 only on source → INSERTED on dest.
+    await seedSig(srcSys, 'DEF-456', { sigType: 'wormhole', whType: 'D382', whLeadsTo: 'C2' });
+
+    // Structure eve_id 1001 collides → UPDATED; eve_id 2002 new → INSERTED.
+    await seedStruct(destSys, ownerId, { name: 'Astra', eveId: 1001 });
+    await seedStruct(srcSys,  ownerId, { name: 'Astrahus', structureType: 'astrahus', ownerCorp: 'CorpX', ownerCorpId: 98000001, eveId: 1001, notes: 'src struct' });
+    await seedStruct(srcSys,  ownerId, { name: 'Fort', structureType: 'fortizar', eveId: 2002 });
+
+    const res = await request(app).post(`/api/maps/${destMap}/merge`).send({ sourceId: srcMap });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      added:   { systems: 0, connections: 0, signatures: 1, structures: 1 },
+      updated: { signatures: 1, structures: 1, systemNotes: 1 },
+    });
+
+    // Note UPDATE (unnest) landed.
+    const sys = await db.query<{ notes: string }>(`SELECT notes FROM map_systems WHERE id = $1`, [destSys]);
+    expect(sys.rows[0].notes).toBe('keep me');
+
+    // Sig collision UPDATED with the source's fields.
+    const sig = await db.query<{ sig_type: string; name: string; notes: string; wh_type: string; wh_leads_to: string }>(
+      `SELECT sig_type, name, notes, wh_type, wh_leads_to FROM map_signatures WHERE system_id = $1 AND sig_id = 'ABC-123'`, [destSys]);
+    expect(sig.rows[0]).toMatchObject({ sig_type: 'wormhole', name: 'K162', notes: 'src sig', wh_type: 'K162', wh_leads_to: 'C4' });
+
+    // New sig INSERTED with from_merge = TRUE (excluded from scan stats).
+    const newSig = await db.query<{ wh_type: string; from_merge: boolean }>(
+      `SELECT wh_type, from_merge FROM map_signatures WHERE system_id = $1 AND sig_id = 'DEF-456'`, [destSys]);
+    expect(newSig.rows[0]).toMatchObject({ wh_type: 'D382', from_merge: true });
+
+    // Structure collision UPDATED (incl. the int/bigint columns).
+    const st = await db.query<{ name: string; structure_type: string; owner_corp: string; owner_corp_id: number; notes: string }>(
+      `SELECT name, structure_type, owner_corp, owner_corp_id, notes FROM map_structures WHERE system_id = $1 AND eve_id = 1001`, [destSys]);
+    expect(st.rows[0]).toMatchObject({ name: 'Astrahus', structure_type: 'astrahus', owner_corp: 'CorpX', owner_corp_id: 98000001, notes: 'src struct' });
+
+    // New structure INSERTED.
+    const newSt = await db.query<{ name: string }>(`SELECT name FROM map_structures WHERE system_id = $1 AND eve_id = 2002`, [destSys]);
+    expect(newSt.rows[0].name).toBe('Fort');
+
+    // The matched system was deduped, not duplicated.
+    const cnt = await db.query<{ n: number }>(`SELECT COUNT(*)::int AS n FROM map_systems WHERE map_id = $1`, [destMap]);
+    expect(cnt.rows[0].n).toBe(1);
+  });
+
+  it('honours include flags — notes/structures off leaves them untouched', async () => {
+    const EVE = 31000006;
+    const destMap = await seedMap(ownerId, 'Dest');
+    const srcMap  = await seedMap(ownerId, 'Src');
+    const destSys = await seedSystem(destMap, EVE, 'J111', '');
+    const srcSys  = await seedSystem(srcMap,  EVE, 'J111', 'note');
+    await seedSig(srcSys, 'GHI-789', { whType: 'A239' });
+    await seedStruct(srcSys, ownerId, { name: 'SkipMe', eveId: 3003 });
+
+    const res = await request(app).post(`/api/maps/${destMap}/merge`)
+      .send({ sourceId: srcMap, include: { signatures: true, structures: false, notes: false } });
+    expect(res.status).toBe(200);
+    expect(res.body.updated.systemNotes).toBe(0);
+    expect(res.body.added.structures).toBe(0);
+    expect(res.body.added.signatures).toBe(1);
+
+    const sys = await db.query<{ notes: string }>(`SELECT notes FROM map_systems WHERE id = $1`, [destSys]);
+    expect(sys.rows[0].notes).toBe(''); // note NOT folded in
+
+    const sig = await db.query(`SELECT 1 FROM map_signatures WHERE system_id = $1 AND sig_id = 'GHI-789'`, [destSys]);
+    expect(sig.rows).toHaveLength(1);
+    const st = await db.query(`SELECT 1 FROM map_structures WHERE system_id = $1`, [destSys]);
+    expect(st.rows).toHaveLength(0); // structures skipped
+  });
+
+  it('rejects a merge into a map the caller does not own (404)', async () => {
+    const other   = await seedUser({ characterId: 901 });
+    const destMap = await seedMap(other, 'Not Yours');
+    const srcMap  = await seedMap(ownerId, 'Mine');
+    const res = await request(app).post(`/api/maps/${destMap}/merge`).send({ sourceId: srcMap });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1328,29 +1328,31 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
     await client.query('BEGIN');
 
     // ── Load both sides ─────────────────────────────────────────────────
-    const [destSysRes, destConnRes, srcSysRes, srcConnRes] = await Promise.all([
-      client.query<{ id: string; eveSystemId: number | null; name: string; notes: string; x: number; y: number }>(
-        `SELECT id, eve_system_id AS "eveSystemId", name, notes, position_x AS x, position_y AS y
-           FROM map_systems WHERE map_id = $1`, [destId]),
-      client.query<{ sourceId: string; targetId: string }>(
-        `SELECT source_id AS "sourceId", target_id AS "targetId" FROM map_connections WHERE map_id = $1`, [destId]),
-      client.query<{
-        id: string; eveSystemId: number | null; name: string; systemClass: string; effect: string;
-        statics: string[]; regionName: string | null; npcType: string | null; x: number; y: number;
-        status: string; notes: string;
-      }>(
-        `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
-                region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y, status, notes
-           FROM map_systems WHERE map_id = $1`, [sourceId]),
-      client.query<{
-        sourceId: string; targetId: string; sourceHandle: string | null; targetHandle: string | null;
-        connectionType: string; massStatus: string | null; timeStatus: string | null; size: string; whType: string | null;
-      }>(
-        `SELECT source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
-                target_handle AS "targetHandle", connection_type AS "connectionType",
-                mass_status AS "massStatus", time_status AS "timeStatus", size, wh_type AS "whType"
-           FROM map_connections WHERE map_id = $1`, [sourceId]),
-    ]);
+    // Sequential awaits, not Promise.all: these all run on the ONE pooled
+    // transaction client, which node-pg already serialises — and the concurrent
+    // form ("client.query while the client is executing a query") is deprecated
+    // and removed in pg@9. Same in-transaction snapshot either way.
+    const destSysRes = await client.query<{ id: string; eveSystemId: number | null; name: string; notes: string; x: number; y: number }>(
+      `SELECT id, eve_system_id AS "eveSystemId", name, notes, position_x AS x, position_y AS y
+         FROM map_systems WHERE map_id = $1`, [destId]);
+    const destConnRes = await client.query<{ sourceId: string; targetId: string }>(
+      `SELECT source_id AS "sourceId", target_id AS "targetId" FROM map_connections WHERE map_id = $1`, [destId]);
+    const srcSysRes = await client.query<{
+      id: string; eveSystemId: number | null; name: string; systemClass: string; effect: string;
+      statics: string[]; regionName: string | null; npcType: string | null; x: number; y: number;
+      status: string; notes: string;
+    }>(
+      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
+              region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y, status, notes
+         FROM map_systems WHERE map_id = $1`, [sourceId]);
+    const srcConnRes = await client.query<{
+      sourceId: string; targetId: string; sourceHandle: string | null; targetHandle: string | null;
+      connectionType: string; massStatus: string | null; timeStatus: string | null; size: string; whType: string | null;
+    }>(
+      `SELECT source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
+              target_handle AS "targetHandle", connection_type AS "connectionType",
+              mass_status AS "massStatus", time_status AS "timeStatus", size, wh_type AS "whType"
+         FROM map_connections WHERE map_id = $1`, [sourceId]);
 
     if (srcSysRes.rows.length > MAX_IMPORT_SYSTEMS) {
       await client.query('ROLLBACK');
@@ -1526,15 +1528,13 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
     // ── Signatures: upsert by sig_id within the destination system ───────
     let addedSignatures = 0, updatedSignatures = 0;
     if (include.signatures && srcSysIds.length > 0) {
-      const [srcSigs, destSigs] = await Promise.all([
-        client.query<{ systemId: string; sigId: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string }>(
-          `SELECT system_id AS "systemId", sig_id AS "sigId", sig_type AS "sigType", name, notes,
-                  wh_type AS "whType", wh_leads_to AS "whLeadsTo"
-             FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]),
-        client.query<{ id: string; systemId: string; sigId: string }>(
-          `SELECT id, system_id AS "systemId", sig_id AS "sigId"
-             FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [destSysIds]),
-      ]);
+      const srcSigs = await client.query<{ systemId: string; sigId: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string }>(
+        `SELECT system_id AS "systemId", sig_id AS "sigId", sig_type AS "sigType", name, notes,
+                wh_type AS "whType", wh_leads_to AS "whLeadsTo"
+           FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]);
+      const destSigs = await client.query<{ id: string; systemId: string; sigId: string }>(
+        `SELECT id, system_id AS "systemId", sig_id AS "sigId"
+           FROM map_signatures WHERE system_id = ANY($1::uuid[])`, [destSysIds]);
       const destSigMap = new Map<string, string>(); // `${destSysId}|${sigIdLower}` → dest sig id
       for (const ds of destSigs.rows) {
         const k = ds.sigId.trim().toLowerCase();
@@ -1587,15 +1587,13 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
     // ── Structures: upsert by eve_id, falling back to name, per system ───
     let addedStructures = 0, updatedStructures = 0;
     if (include.structures && srcSysIds.length > 0) {
-      const [srcStructs, destStructs] = await Promise.all([
-        client.query<{ systemId: string; name: string; structureType: string; ownerCorp: string; eveId: string | null; notes: string; ownerCorpId: number | null }>(
-          `SELECT system_id AS "systemId", name, structure_type AS "structureType", owner_corp AS "ownerCorp",
-                  eve_id AS "eveId", notes, owner_corp_id AS "ownerCorpId"
-             FROM map_structures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]),
-        client.query<{ id: string; systemId: string; name: string; eveId: string | null }>(
-          `SELECT id, system_id AS "systemId", name, eve_id AS "eveId"
-             FROM map_structures WHERE system_id = ANY($1::uuid[])`, [destSysIds]),
-      ]);
+      const srcStructs = await client.query<{ systemId: string; name: string; structureType: string; ownerCorp: string; eveId: string | null; notes: string; ownerCorpId: number | null }>(
+        `SELECT system_id AS "systemId", name, structure_type AS "structureType", owner_corp AS "ownerCorp",
+                eve_id AS "eveId", notes, owner_corp_id AS "ownerCorpId"
+           FROM map_structures WHERE system_id = ANY($1::uuid[])`, [srcSysIds]);
+      const destStructs = await client.query<{ id: string; systemId: string; name: string; eveId: string | null }>(
+        `SELECT id, system_id AS "systemId", name, eve_id AS "eveId"
+           FROM map_structures WHERE system_id = ANY($1::uuid[])`, [destSysIds]);
       const byEve  = new Map<string, string>(); // `${destSysId}|${eveId}`     → id
       const byName = new Map<string, string>(); // `${destSysId}|${nameLower}` → id
       for (const d of destStructs.rows) {

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -13,7 +13,7 @@ import { resolveEntityNames } from '../services/entityNames.js';
 import { audit } from '../services/audit.js';
 import { publishToMap } from '../services/mapEvents.js';
 import { streamMapEvents } from '../services/mapStream.js';
-import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures } from '../services/mapRead.js';
+import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures, CONNECTION_COLS } from '../services/mapRead.js';
 import {
   createSignature, updateSignature, deleteSignature,
   createAnomaly, updateAnomaly, deleteAnomaly,
@@ -1920,7 +1920,8 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
     const { rows } = await db.query(
       `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass", effect, statics,
               region_name AS "regionName", npc_type AS "npcType", position_x AS x, position_y AS y,
-              status, intel, is_home AS "isHome", locked, notes, alias,
+              status, intel, is_home AS "isHome", locked, notes,
+              labels, custom_labels AS "customLabels", tag, alias,
               (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
               last_activity_at AS "lastActivityAt"
          FROM map_systems WHERE id = $1 AND map_id = $2`,
@@ -2155,13 +2156,7 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
   await touchMap(mapId);
   // Re-read the canonical row so remote clients get the full MapConnection shape.
   db.query(
-    `SELECT id, source_id AS "sourceId", target_id AS "targetId", source_handle AS "sourceHandle",
-            target_handle AS "targetHandle", connection_type AS "connectionType", mass_status AS "massStatus",
-            time_status AS "timeStatus", size, wh_type AS "type", COALESCE(mass_used, 0)::float8 AS "massUsed",
-            eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
-            source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId",
-            created_at AS "createdAt"
-       FROM map_connections WHERE id = $1 AND map_id = $2`,
+    `SELECT ${CONNECTION_COLS} FROM map_connections WHERE id = $1 AND map_id = $2`,
     [id, mapId],
   ).then(({ rows }) => {
     if (rows[0]) publishToMap(mapId, { type: 'connection.add', actor: req.get('x-client-id') ?? null, connection: rows[0] });
@@ -2814,6 +2809,21 @@ mapsRouter.post('/:mapId/shares', async (req, res) => {
     res.status(403).json({
       error: 'standing_not_positive',
       message: 'Your deployment does not hold this entity at positive standing (contacts must be synced and standing must be > 0).',
+    });
+    return;
+  }
+
+  // Granting login access widens the deployment's login allow-list. corp/alliance
+  // targets are validated by the positive-standing gate above; an individual
+  // CHARACTER grant has no such gate (requiresPositiveStanding is false for
+  // characters), so restrict it to admins — matching the admin-only allow-list
+  // endpoint. Without this, any member (even readonly) could self-admit an
+  // arbitrary character into a restricted deployment via a map share.
+  if (alsoGrantLogin === true && config.restrictedMode && kind === 'character'
+      && !isAdmin(req.session.role ?? 'readonly')) {
+    res.status(403).json({
+      error: 'forbidden',
+      message: 'Only an admin can grant login access to an individual character.',
     });
     return;
   }

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1541,16 +1541,16 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
         if (k) destSigMap.set(`${ds.systemId}|${k}`, ds.id);
       }
       const sigPh: string[] = []; const sigVals: unknown[] = [];
+      // Collisions are collected and flushed as one set-based UPDATE (below)
+      // instead of a query per row inside the transaction.
+      const sigUp: { id: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string }[] = [];
       for (const sg of srcSigs.rows) {
         const destSysId = idMap.get(sg.systemId);
         if (!destSysId) continue;
         const k = sg.sigId.trim().toLowerCase();
         const existing = k ? destSigMap.get(`${destSysId}|${k}`) : undefined;
         if (existing) {
-          await client.query(
-            `UPDATE map_signatures SET sig_type=$1, name=$2, notes=$3, wh_type=$4, wh_leads_to=$5, updated_at=NOW() WHERE id=$6`,
-            [sg.sigType, sg.name, sg.notes, sg.whType, sg.whLeadsTo, existing],
-          );
+          sigUp.push({ id: existing, sigType: sg.sigType, name: sg.name, notes: sg.notes, whType: sg.whType, whLeadsTo: sg.whLeadsTo });
           updatedSignatures++;
         } else {
           const base = sigVals.length;
@@ -1561,6 +1561,20 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
           sigVals.push(destSysId, sg.sigId, sg.sigType, sg.name, sg.notes, sg.whType, sg.whLeadsTo, req.session.userId, true);
           addedSignatures++;
         }
+      }
+      if (sigUp.length > 0) {
+        // One UPDATE for every collision — unnest of per-column arrays (6 params
+        // total, no param-cap / no per-row round-trips).
+        await client.query(
+          `UPDATE map_signatures AS m
+              SET sig_type = v.sig_type, name = v.name, notes = v.notes,
+                  wh_type = v.wh_type, wh_leads_to = v.wh_leads_to, updated_at = NOW()
+             FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[])
+                  AS v(id, sig_type, name, notes, wh_type, wh_leads_to)
+            WHERE m.id = v.id`,
+          [sigUp.map(u => u.id), sigUp.map(u => u.sigType), sigUp.map(u => u.name),
+           sigUp.map(u => u.notes), sigUp.map(u => u.whType), sigUp.map(u => u.whLeadsTo)],
+        );
       }
       if (sigPh.length > 0) {
         await client.query(
@@ -1590,6 +1604,7 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
         if (nk) byName.set(`${d.systemId}|${nk}`, d.id);
       }
       const stPh: string[] = []; const stVals: unknown[] = [];
+      const stUp: { id: string; name: string; structureType: string; ownerCorp: string; ownerCorpId: number | null; eveId: string | null; notes: string }[] = [];
       for (const st of srcStructs.rows) {
         const destSysId = idMap.get(st.systemId);
         if (!destSysId) continue;
@@ -1599,10 +1614,7 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
           if (nk) existing = byName.get(`${destSysId}|${nk}`);
         }
         if (existing) {
-          await client.query(
-            `UPDATE map_structures SET name=$1, structure_type=$2, owner_corp=$3, owner_corp_id=$4, eve_id=$5, notes=$6, updated_at=NOW() WHERE id=$7`,
-            [st.name, st.structureType, st.ownerCorp, st.ownerCorpId, st.eveId, st.notes, existing],
-          );
+          stUp.push({ id: existing, name: st.name, structureType: st.structureType, ownerCorp: st.ownerCorp, ownerCorpId: st.ownerCorpId, eveId: st.eveId, notes: st.notes });
           updatedStructures++;
         } else {
           const base = stVals.length;
@@ -1610,6 +1622,18 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
           stVals.push(destSysId, st.name, st.structureType, st.ownerCorp, st.eveId, st.notes, req.session.userId, st.ownerCorpId);
           addedStructures++;
         }
+      }
+      if (stUp.length > 0) {
+        await client.query(
+          `UPDATE map_structures AS m
+              SET name = v.name, structure_type = v.structure_type, owner_corp = v.owner_corp,
+                  owner_corp_id = v.owner_corp_id, eve_id = v.eve_id, notes = v.notes, updated_at = NOW()
+             FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[], $5::int[], $6::bigint[], $7::text[])
+                  AS v(id, name, structure_type, owner_corp, owner_corp_id, eve_id, notes)
+            WHERE m.id = v.id`,
+          [stUp.map(u => u.id), stUp.map(u => u.name), stUp.map(u => u.structureType), stUp.map(u => u.ownerCorp),
+           stUp.map(u => u.ownerCorpId), stUp.map(u => u.eveId), stUp.map(u => u.notes)],
+        );
       }
       if (stPh.length > 0) {
         await client.query(
@@ -1619,9 +1643,14 @@ mapsRouter.post('/:mapId/merge', async (req, res) => {
       }
     }
 
-    // ── Apply queued system-note merges ──────────────────────────────────
-    for (const nm of noteMerges) {
-      await client.query(`UPDATE map_systems SET notes = $1 WHERE id = $2`, [nm.notes, nm.destSysId]);
+    // ── Apply queued system-note merges (one set-based UPDATE) ────────────
+    if (noteMerges.length > 0) {
+      await client.query(
+        `UPDATE map_systems AS m SET notes = v.notes
+           FROM unnest($1::uuid[], $2::text[]) AS v(id, notes)
+          WHERE m.id = v.id`,
+        [noteMerges.map((nm) => nm.destSysId), noteMerges.map((nm) => nm.notes)],
+      );
     }
 
     // ── Audit: one row per corp map involved (inside the transaction) ────

--- a/server/src/routes/share.ts
+++ b/server/src/routes/share.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { db } from '../db.js';
 import { onMapEvent } from '../services/mapEvents.js';
+import { CONNECTION_COLS } from '../services/mapRead.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('share');
@@ -176,15 +177,7 @@ shareRouter.get('/:token', async (req, res) => {
         [mapId],
       ),
       db.query(
-        `SELECT id, source_id AS "sourceId", target_id AS "targetId",
-                source_handle AS "sourceHandle", target_handle AS "targetHandle",
-                connection_type AS "connectionType", mass_status AS "massStatus",
-                time_status AS "timeStatus", size, wh_type AS "type",
-                COALESCE(mass_used, 0)::float8 AS "massUsed",
-                eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
-                source_signature_id AS "sourceSignatureId", target_signature_id AS "targetSignatureId",
-                created_at AS "createdAt"
-         FROM map_connections ${connectionWhere}`,
+        `SELECT ${CONNECTION_COLS} FROM map_connections ${connectionWhere}`,
         [mapId],
       ),
       includeSigs

--- a/server/src/routes/standings.ts
+++ b/server/src/routes/standings.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { db } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
-import { refreshStandingsForUser } from '../services/standings.js';
+import { refreshStandingsForUser, loadOrgContacts } from '../services/standings.js';
 import { revalidateActiveSessions } from '../services/accessRevalidate.js';
 import { decryptToken } from '../utils/tokenCrypto.js';
 import { createLogger } from '../utils/logger.js';
@@ -31,26 +31,16 @@ standingsRouter.get('/me', async (req, res) => {
   if (!userRows.length) { res.status(404).json({ error: 'User not found' }); return; }
   const { character_id, corp_id, alliance_id } = userRows[0];
 
-  const [charRows, corpRows, allianceRows, refreshRows] = await Promise.all([
+  const [charRows, corpContacts, allianceContacts, refreshRows] = await Promise.all([
     db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
       `SELECT contact_kind, contact_id, standing
        FROM character_standings WHERE character_id = $1`,
       [character_id],
     ),
-    corp_id !== null
-      ? db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
-          `SELECT contact_kind, contact_id, standing
-           FROM corp_standings WHERE corp_id = $1`,
-          [corp_id],
-        )
-      : Promise.resolve({ rows: [] as Array<{ contact_kind: ContactKind; contact_id: number; standing: number }> }),
-    alliance_id !== null
-      ? db.query<{ contact_kind: ContactKind; contact_id: number; standing: number }>(
-          `SELECT contact_kind, contact_id, standing
-           FROM alliance_standings WHERE alliance_id = $1`,
-          [alliance_id],
-        )
-      : Promise.resolve({ rows: [] as Array<{ contact_kind: ContactKind; contact_id: number; standing: number }> }),
+    // Corp/alliance buckets go through the shared read cache — these lists are
+    // shared across members and re-fetched by everyone on every poll.
+    corp_id !== null ? loadOrgContacts('corp', corp_id) : Promise.resolve([]),
+    alliance_id !== null ? loadOrgContacts('alliance', alliance_id) : Promise.resolve([]),
     db.query<{ owner_kind: string; last_fetched_at: string }>(
       `SELECT owner_kind, last_fetched_at FROM standings_refresh
        WHERE (owner_kind = 'character' AND owner_id = $1)
@@ -60,7 +50,7 @@ standingsRouter.get('/me', async (req, res) => {
     ),
   ]);
 
-  function toMap(rows: Array<{ contact_kind: ContactKind; contact_id: number; standing: number }>): Record<string, number> {
+  function toMap(rows: Array<{ contact_kind: string; contact_id: number; standing: number }>): Record<string, number> {
     const out: Record<string, number> = {};
     for (const r of rows) out[`${r.contact_kind}:${r.contact_id}`] = r.standing;
     return out;
@@ -74,8 +64,8 @@ standingsRouter.get('/me', async (req, res) => {
     corpId:      corp_id,
     allianceId:  alliance_id,
     character:   toMap(charRows.rows),
-    corp:        toMap(corpRows.rows),
-    alliance:    toMap(allianceRows.rows),
+    corp:        toMap(corpContacts),
+    alliance:    toMap(allianceContacts),
     refreshedAt,
   });
 });

--- a/server/src/services/accessRevalidate.integration.test.ts
+++ b/server/src/services/accessRevalidate.integration.test.ts
@@ -122,6 +122,10 @@ describe.skipIf(!dbReady)('revalidateActiveSessions (integration — real SQL)',
       expect(await liveSessionCount(u)).toBe(1);
       const { rows } = await db.query<{ corp_id: number }>(`SELECT corp_id FROM users WHERE id = $1`, [u]);
       expect(rows[0].corp_id).toBe(500);
+      // The live session's scope is refreshed in place (not evicted) to the new corp.
+      const sess = await db.query<{ corp: string | null }>(
+        `SELECT sess->>'userCorpId' AS corp FROM sessions WHERE (sess->>'userId')::int = $1`, [u]);
+      expect(sess.rows[0].corp).toBe('500');
     });
 
     it('falls back to stored ids on an ESI outage (no mass eviction)', async () => {

--- a/server/src/services/accessRevalidate.ts
+++ b/server/src/services/accessRevalidate.ts
@@ -11,7 +11,7 @@
 import { db } from '../db.js';
 import { config } from '../config.js';
 import { isLoginPermitted, standingsPermitLogin } from './accessGrants.js';
-import { invalidateSessionsForUser } from '../utils/sessionInvalidate.js';
+import { invalidateSessionsForUser, refreshSessionAffiliation } from '../utils/sessionInvalidate.js';
 import { audit } from './audit.js';
 import { esiFetch } from '../utils/esi.js';
 import { createLogger } from '../utils/logger.js';
@@ -114,6 +114,11 @@ export async function revalidateActiveSessions(opts: { refreshAffiliation?: bool
         await db.query(`UPDATE users SET corp_id = $1, alliance_id = $2, updated_at = NOW() WHERE id = $3`, [aff.corpId, aff.allianceId, u.id]);
         await audit({ session: {} }, u.id, characterId, 'corp_change',
           u.corpId !== null ? String(u.corpId) : null, aff.corpId !== null ? String(aff.corpId) : null);
+        // Refresh the live session's corp/alliance scope in place (don't evict —
+        // the design keeps sessions across corp moves). Without this, a pilot who
+        // changed corp keeps their old corp's map read/write scope until re-login.
+        // If they're no longer permitted at all, the eviction below still fires.
+        await refreshSessionAffiliation(u.id, aff.corpId, aff.allianceId);
       }
       corpId = aff.corpId;
       allianceId = aff.allianceId;

--- a/server/src/services/appSettings.ts
+++ b/server/src/services/appSettings.ts
@@ -2,7 +2,7 @@
 // per-user ui_settings blob — these are instance-wide and admin-managed.
 import { db } from '../db.js';
 
-export async function getSetting(key: string): Promise<string | null> {
+async function getSetting(key: string): Promise<string | null> {
   const { rows } = await db.query<{ value: string }>(
     `SELECT value FROM app_settings WHERE key = $1`,
     [key],

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -8,6 +8,23 @@ import { config } from '../config.js';
 
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
+// The full MapConnection column projection, single-sourced so every shape that
+// reaches a client — the full map load, the share view, and the connection.add
+// broadcast re-read — stays identical (they used to be three hand-copied lists
+// that could drift, notably the "type" vs "whType" alias). A fixed constant,
+// never interpolated with user input.
+export const CONNECTION_COLS = `
+  id, source_id AS "sourceId", target_id AS "targetId",
+  source_handle AS "sourceHandle", target_handle AS "targetHandle",
+  connection_type AS "connectionType", mass_status AS "massStatus",
+  time_status AS "timeStatus", size, wh_type AS "type",
+  COALESCE(mass_used, 0)::float8 AS "massUsed",
+  eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
+  source_signature_id AS "sourceSignatureId",
+  target_signature_id AS "targetSignatureId",
+  created_at AS "createdAt"
+`;
+
 export interface VisibleMapsParams {
   userId:         number;
   ownerId:        number | null;
@@ -105,16 +122,7 @@ export async function loadFullMap(mapId: string) {
       [mapId],
     ),
     db.query(
-      `SELECT id, source_id AS "sourceId", target_id AS "targetId",
-              source_handle AS "sourceHandle", target_handle AS "targetHandle",
-              connection_type AS "connectionType", mass_status AS "massStatus",
-              time_status AS "timeStatus", size, wh_type AS "type",
-              COALESCE(mass_used, 0)::float8 AS "massUsed",
-              eol_at AS "eolAt", lifetime_expires_at AS "lifetimeExpiresAt", broken,
-              source_signature_id AS "sourceSignatureId",
-              target_signature_id AS "targetSignatureId",
-              created_at AS "createdAt"
-       FROM map_connections WHERE map_id = $1`,
+      `SELECT ${CONNECTION_COLS} FROM map_connections WHERE map_id = $1`,
       [mapId],
     ),
     db.query(

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -111,14 +111,16 @@ export async function loadFullMap(mapId: string) {
       [mapId],
     ),
     db.query(
-      `SELECT id, eve_system_id AS "eveSystemId", name, system_class AS "systemClass",
-              effect, statics, region_name AS "regionName", npc_type AS "npcType",
-              position_x AS x, position_y AS y,
-              status, intel, is_home AS "isHome", locked, notes,
-              labels, custom_labels AS "customLabels", tag, alias,
-              (SELECT ss.security::float8 FROM solar_systems ss WHERE ss.id = map_systems.eve_system_id) AS "security",
-              last_activity_at AS "lastActivityAt"
-       FROM map_systems WHERE map_id = $1`,
+      `SELECT ms.id, ms.eve_system_id AS "eveSystemId", ms.name, ms.system_class AS "systemClass",
+              ms.effect, ms.statics, ms.region_name AS "regionName", ms.npc_type AS "npcType",
+              ms.position_x AS x, ms.position_y AS y,
+              ms.status, ms.intel, ms.is_home AS "isHome", ms.locked, ms.notes,
+              ms.labels, ms.custom_labels AS "customLabels", ms.tag, ms.alias,
+              ss.security::float8 AS "security",
+              ms.last_activity_at AS "lastActivityAt"
+       FROM map_systems ms
+       LEFT JOIN solar_systems ss ON ss.id = ms.eve_system_id
+       WHERE ms.map_id = $1`,
       [mapId],
     ),
     db.query(

--- a/server/src/services/standings.ts
+++ b/server/src/services/standings.ts
@@ -11,6 +11,33 @@ const log = createLogger('standings');
 // here just makes the server work harder for no fresher data.
 const REFRESH_TTL_MS = 6 * 60 * 60 * 1000;
 
+// ── Corp/alliance contact-bucket read cache ──────────────────────────────────
+// The corp/alliance buckets are shared across every member and change only on a
+// Contact-Manager sync, but /api/standings/me is hit per map load/poll by every
+// member — a big corp's thousands of contacts would otherwise be re-queried and
+// re-materialised for each member on each poll. Cache them briefly, keyed by
+// kind:id, invalidated on write (below) so a fresh sync is seen at once; the TTL
+// bounds staleness for any write path that forgets to invalidate.
+export type OrgContactRow = { contact_kind: string; contact_id: number; standing: number };
+const CONTACT_TTL_MS = 60_000;
+const orgContactCache = new Map<string, { rows: OrgContactRow[]; at: number }>();
+
+export async function loadOrgContacts(kind: 'corp' | 'alliance', id: number): Promise<OrgContactRow[]> {
+  const key = `${kind}:${id}`;
+  const hit = orgContactCache.get(key);
+  if (hit && Date.now() - hit.at < CONTACT_TTL_MS) return hit.rows;
+  const sql = kind === 'corp'
+    ? `SELECT contact_kind, contact_id, standing FROM corp_standings WHERE corp_id = $1`
+    : `SELECT contact_kind, contact_id, standing FROM alliance_standings WHERE alliance_id = $1`;
+  const { rows } = await db.query<OrgContactRow>(sql, [id]);
+  orgContactCache.set(key, { rows, at: Date.now() });
+  return rows;
+}
+
+function invalidateOrgContacts(kind: 'corp' | 'alliance', id: number): void {
+  orgContactCache.delete(`${kind}:${id}`);
+}
+
 type ContactKind = 'character' | 'corporation' | 'alliance' | 'faction';
 
 interface EsiContact {
@@ -149,6 +176,7 @@ export async function refreshStandingsForUser(params: {
       if (Array.isArray(r)) {
         log.info(`corp ${corpId}: fetched ${r.length} corp contacts (via character ${characterId})`);
         await replaceStandings('corp_standings', 'corp_id', corpId, r, userId);
+        invalidateOrgContacts('corp', corpId);
         await markRefreshed('corp', corpId);
       } else {
         log.info(`corp ${corpId}: contacts fetch returned ${r.status} (${r.error}) — character ${characterId} likely lacks Contact Manager role or the read_contacts scope`);
@@ -167,6 +195,7 @@ export async function refreshStandingsForUser(params: {
       if (Array.isArray(r)) {
         log.info(`alliance ${allianceId}: fetched ${r.length} alliance contacts (via character ${characterId})`);
         await replaceStandings('alliance_standings', 'alliance_id', allianceId, r, userId);
+        invalidateOrgContacts('alliance', allianceId);
         await markRefreshed('alliance', allianceId);
       } else {
         log.info(`alliance ${allianceId}: contacts fetch returned ${r.status} (${r.error}) — character ${characterId} likely lacks alliance-executor role or the read_contacts scope`);

--- a/server/src/services/whSweep.integration.test.ts
+++ b/server/src/services/whSweep.integration.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import crypto from 'node:crypto';
+
+// Mock config (real db) so we can toggle whether the connection-lifetime sweep
+// is "enabled" — that's what decides whether whSweep defers manually-overridden
+// holes to it.
+const state = vi.hoisted(() => ({ connLifetimeSweepMinutes: 60 }));
+vi.mock('../config.js', async (importActual) => {
+  const base = (await importActual<typeof import('../config.js')>()).config as Record<string, unknown>;
+  return { config: new Proxy({}, { get: (_t, k: string) => (k === 'connLifetimeSweepMinutes' ? state.connLifetimeSweepMinutes : base[k]) }) };
+});
+
+import { ensureIntegrationDb, truncateAll, seedUser } from '../test/integrationDb.js';
+import { db } from '../db.js';
+import { sweepAll } from './whSweep.js';
+
+const dbReady = await ensureIntegrationDb();
+
+async function seedMap(userId: number): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `INSERT INTO maps (user_id, name, lazy_remove_wormholes) VALUES ($1, 'Sweep Map', TRUE) RETURNING id`, [userId]);
+  return rows[0].id;
+}
+async function seedSystem(mapId: string, name: string): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.query(`INSERT INTO map_systems (id, map_id, name, system_class) VALUES ($1, $2, $3, 'C4')`, [id, mapId, name]);
+  return id;
+}
+// A wormhole sig aged well past its type's max life (D382 = 16h).
+async function seedAgedSig(systemId: string, ageHours = 20): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `INSERT INTO map_signatures (system_id, sig_id, sig_type, wh_type, created_at)
+     VALUES ($1, $2, 'wormhole', 'D382', NOW() - ($3 || ' hours')::interval) RETURNING id`,
+    [systemId, `ABC-${Math.floor(ageHours)}`, String(ageHours)]);
+  return rows[0].id;
+}
+async function seedConn(mapId: string, srcSys: string, tgtSys: string, sigId: string, lifetimeExpiresAt: string | null): Promise<void> {
+  await db.query(
+    `INSERT INTO map_connections (id, map_id, source_id, target_id, connection_type, wh_type, source_signature_id, lifetime_expires_at)
+     VALUES ($1, $2, $3, $4, 'standard', 'D382', $5, $6)`,
+    [crypto.randomUUID(), mapId, srcSys, tgtSys, sigId, lifetimeExpiresAt]);
+}
+const sigExists = async (id: string): Promise<boolean> =>
+  (await db.query(`SELECT 1 FROM map_signatures WHERE id = $1`, [id])).rows.length > 0;
+
+describe.skipIf(!dbReady)('whSweep + connLifetime reconciliation (integration)', () => {
+  let ownerId: number;
+  beforeEach(async () => {
+    await truncateAll();
+    state.connLifetimeSweepMinutes = 60; // connLifetime sweep enabled by default
+    ownerId = await seedUser({ characterId: 900 });
+  });
+
+  it('sweeps an aged auto hole but DEFERS one with a manual lifetime override', async () => {
+    const mapId = await seedMap(ownerId);
+    const a = await seedSystem(mapId, 'A');
+    const b = await seedSystem(mapId, 'B');
+
+    const autoSig = await seedAgedSig(a, 20);   // 20h old, no override → aged out
+    await seedConn(mapId, a, b, autoSig, null);
+
+    const overriddenSig = await seedAgedSig(a, 20); // 20h old, but its connection has an override
+    await seedConn(mapId, a, b, overriddenSig, new Date(Date.now() + 10 * 3_600_000).toISOString());
+
+    await sweepAll();
+
+    expect(await sigExists(autoSig)).toBe(false);       // swept
+    expect(await sigExists(overriddenSig)).toBe(true);  // deferred to connLifetime sweep
+  });
+
+  it('sweeps BOTH when the connection-lifetime sweep is disabled (no one to defer to)', async () => {
+    state.connLifetimeSweepMinutes = 0; // disabled
+    const mapId = await seedMap(ownerId);
+    const a = await seedSystem(mapId, 'A');
+    const b = await seedSystem(mapId, 'B');
+
+    const autoSig = await seedAgedSig(a, 20);
+    await seedConn(mapId, a, b, autoSig, null);
+    const overriddenSig = await seedAgedSig(a, 20);
+    await seedConn(mapId, a, b, overriddenSig, new Date(Date.now() + 10 * 3_600_000).toISOString());
+
+    await sweepAll();
+
+    expect(await sigExists(autoSig)).toBe(false);
+    expect(await sigExists(overriddenSig)).toBe(false); // no defer target → swept too
+  });
+
+  it('leaves a fresh hole alone', async () => {
+    const mapId = await seedMap(ownerId);
+    const a = await seedSystem(mapId, 'A');
+    const fresh = await seedAgedSig(a, 2); // 2h old, well within a 16h life
+    await sweepAll();
+    expect(await sigExists(fresh)).toBe(true);
+  });
+});

--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -151,9 +151,17 @@ async function sweepMap(mapId: string, expired: CandidateRow[]): Promise<void> {
 }
 
 /** One sweep pass over every opted-in map. */
-async function sweepAll(): Promise<void> {
+export async function sweepAll(): Promise<void> {
   let rows: CandidateRow[];
   try {
+    // When the connection-lifetime sweep is running, it is the single authority
+    // for any connection carrying a MANUAL lifetime override (lifetime_expires_at)
+    // — it honours the override, this sig-age sweep can't see it. Defer those sigs
+    // to it, so a hole whose life was manually EXTENDED past its type max isn't
+    // collapsed early here (the two sweeps otherwise disagree). Shorter overrides
+    // are collapsed by connLifetimeSweep first anyway. When it's disabled, this
+    // sweep handles everything as before.
+    const deferOverrides = config.connLifetimeSweepMinutes > 0;
     const res = await db.query<CandidateRow>(
       `SELECT s.id, s.system_id AS "systemId", sys.map_id AS "mapId",
               s.wh_type AS "whType", s.wh_leads_to AS "whLeadsTo", s.created_at AS "createdAt",
@@ -163,8 +171,12 @@ async function sweepAll(): Promise<void> {
          JOIN maps m ON m.id = sys.map_id
         WHERE m.lazy_remove_wormholes = TRUE
           AND s.sig_type = 'wormhole'
-          AND s.created_at < NOW() - ($1 || ' hours')::interval`,
-      [String(MIN_LIFETIME_HOURS)],
+          AND s.created_at < NOW() - ($1 || ' hours')::interval
+          AND (NOT $2::boolean OR NOT EXISTS (
+                SELECT 1 FROM map_connections c
+                 WHERE (c.source_signature_id = s.id OR c.target_signature_id = s.id)
+                   AND c.lifetime_expires_at IS NOT NULL))`,
+      [String(MIN_LIFETIME_HOURS), deferOverrides],
     );
     rows = res.rows;
   } catch (err) {

--- a/server/src/services/whSweep.ts
+++ b/server/src/services/whSweep.ts
@@ -93,14 +93,14 @@ async function sweepMap(mapId: string, expired: CandidateRow[]): Promise<void> {
   try {
     await client.query('BEGIN');
 
-    const [sysRes, connRes] = await Promise.all([
-      client.query<SysRow>(
-        `SELECT id, name, system_class AS "systemClass" FROM map_systems WHERE map_id = $1`, [mapId]),
-      client.query<ConnRow>(
-        `SELECT id, source_id AS "sourceId", target_id AS "targetId", wh_type AS "type",
-                connection_type AS "connectionType", broken
-           FROM map_connections WHERE map_id = $1`, [mapId]),
-    ]);
+    // Sequential, not Promise.all — concurrent queries on one pooled tx client
+    // are serialised by node-pg anyway and the parallel form is deprecated (pg@9).
+    const sysRes = await client.query<SysRow>(
+      `SELECT id, name, system_class AS "systemClass" FROM map_systems WHERE map_id = $1`, [mapId]);
+    const connRes = await client.query<ConnRow>(
+      `SELECT id, source_id AS "sourceId", target_id AS "targetId", wh_type AS "type",
+              connection_type AS "connectionType", broken
+         FROM map_connections WHERE map_id = $1`, [mapId]);
 
     await client.query(`DELETE FROM map_signatures WHERE id = ANY($1::uuid[])`, [expiredIds]);
 

--- a/server/src/utils/apiKeys.ts
+++ b/server/src/utils/apiKeys.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash, timingSafeEqual } from 'node:crypto';
+import { randomBytes, createHash } from 'node:crypto';
 
 // External API keys. Unlike the EVE OAuth tokens (encrypted at rest so they can
 // be decrypted and replayed to ESI — see tokenCrypto.ts), an API key is only
@@ -29,12 +29,3 @@ export function generateApiKey(): GeneratedKey {
   return { raw, hash: hashApiKey(raw), prefix: raw.slice(0, PREFIX_LEN) };
 }
 
-// Constant-time compare of two sha-256 hex digests. Lookup is by the unique
-// token_hash column; this is defence-in-depth against timing oracles on the
-// off chance a non-indexed compare path is ever added.
-export function hashesEqual(a: string, b: string): boolean {
-  const ba = Buffer.from(a, 'utf8');
-  const bb = Buffer.from(b, 'utf8');
-  if (ba.length !== bb.length) return false;
-  return timingSafeEqual(ba, bb);
-}

--- a/server/src/utils/sessionInvalidate.ts
+++ b/server/src/utils/sessionInvalidate.ts
@@ -30,3 +30,39 @@ export async function invalidateSessionsForUser(userId: number): Promise<number>
     return 0;
   }
 }
+
+/**
+ * Refresh the corp/alliance affiliation carried in a user's LIVE sessions,
+ * in place, without evicting them. The session stores a login-time snapshot of
+ * userCorpId/userAllianceId that map read/write scope reads; when the periodic
+ * revalidation adopts a fresh affiliation from ESI (a pilot changed corp) but
+ * the user is still permitted, this keeps their session but updates its scope so
+ * they immediately see/edit the right corp's maps — rather than the old corp's
+ * until the 7-day cookie expires. Deliberately does NOT drop the session (the
+ * design keeps sessions across corp moves).
+ *
+ * The `sess` column is JSON; we cast to jsonb to set the keys, then back.
+ * Returns the number of sessions updated (0 if none / no table yet).
+ */
+export async function refreshSessionAffiliation(
+  userId: number, corpId: number | null, allianceId: number | null,
+): Promise<number> {
+  try {
+    const { rowCount } = await db.query(
+      // COALESCE to the jsonb 'null' literal: a bare to_jsonb(NULL::int) is SQL
+      // NULL, and jsonb_set(..., NULL) returns NULL — which would blow away the
+      // whole session (sess is NOT NULL). We want the JSON value null instead.
+      `UPDATE sessions
+          SET sess = jsonb_set(
+                       jsonb_set(sess::jsonb, '{userCorpId}',     COALESCE(to_jsonb($2::int), 'null'::jsonb)),
+                       '{userAllianceId}', COALESCE(to_jsonb($3::int), 'null'::jsonb)
+                     )::json
+        WHERE sess->>'userId' = $1`,
+      [String(userId), corpId, allianceId],
+    );
+    return rowCount ?? 0;
+  } catch (err) {
+    log.warn('refreshSessionAffiliation failed:', err);
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

Promotes the backend audit series from `qa` to `release`. 12 commits / 6 merged PRs, server-side only -- no web changes.

## Included PRs

- #490 -- backend audit batch 1 (access-grant hardening, FK indexes, projection single-source)
- #492 -- backend audit batch 2 (standings `/me` cache + merge set-based UPDATEs)
- #493 -- backend audit batch 3 (loadFullMap LEFT JOIN + config/apiV1 DRY)
- #494 -- test: map-merge integration test (safety net for the batch-2 set-based UPDATEs)
- #495 -- backend audit batch 5 (fix deprecated concurrent-query-on-one-tx-client, pg@9)
- #496 -- backend audit tier-1 (corp-move session refresh + two-sweep reconciliation)

## Scope

19 files, +541 / -161. Touches auth/session invalidation, access revalidation, standings,
map read/merge, share links, API keys, and the WH sweep. Two new integration test suites
(`maps.merge`, `whSweep`).

## Deploy notes

- **New migration**: `server/src/migrate.ts` adds four FK indexes on `map_connections`
  (`source_id`, `target_id`, `source_signature_id`, `target_signature_id`). All
  `CREATE INDEX IF NOT EXISTS`, additive and idempotent -- but they build against a live
  table, so expect a brief lock on first boot after deploy.
- **Security-sensitive**: session invalidation (`utils/sessionInvalidate.ts`), access
  revalidation, share-link and API-key handling all changed. Worth a CodeQL pass before merge.
- No version bump here -- version stays at 3.4.0; bump happens on the release -> main merge.

## Test plan

- [ ] CI green (tsc, eslint, unit + DB integration suites)
- [ ] CodeQL clean
- [ ] Smoke on QA: login, map load, corp-move session refresh, share link, WH sweep