### PR TITLE
Add one-command deploy scripts + README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,38 +354,9 @@ When registering your application at [developers.eveonline.com](https://develope
 | `esi-alliances.read_contacts.v1` | Read the **alliance's** shared contact list. Requires the character to be in the alliance executor corp with the right role; almost always denied for normal members, and that's fine — the call no-ops without breaking login. |
 | `esi-fleets.read_fleet.v1` | Read the character's current fleet composition (members + their solar systems) so fleet-mates show up as purple dots on the map with a hover tooltip listing names. Member-list reads require the character to be the **fleet boss**; wing/squad commanders see "in a fleet, no member visibility" and the UI degrades silently. |
 
-**2. Build and start the stack**
-
-The server depends on the EVE Static Data Export (SDE) tables (`map_stargates`, `solar_systems`, `item_types`, …) at boot — without them, route-graph initialisation throws and the container crash-loops. A dedicated `importer` service handles this: it runs once after Postgres is healthy, downloads the SDE (~hundreds of MB from CCP, a few minutes; logs progress per table), populates the static tables, then exits. The server waits for it to finish (`service_completed_successfully`) before booting, so a single command brings everything up in the right order.
-
-```bash
-docker compose build
-docker compose up -d
-```
-
-The app will be available on port `${WEB_PORT:-80}` (defaults to `80`).
-
-The import is self-skipping: on every later `up` or restart the importer sees the static tables are already populated and exits in a second without re-downloading. So the two commands above are also your update flow — or just run one of the [one-command deploy scripts](#one-command-deploy-scripts) below. To force a re-import (e.g. after a CCP SDE drop), see [Updating the SDE](#updating-the-sde) below.
-
-The importer also stores each system's universe coordinates and CCP's 2D star-map projection (`position` / `position2D`), which power the [Seed a map from a region](#features) feature.
-
-**3. Reverse proxy (optional)**
-
-To front the stack with Traefik for TLS and a public URL, add `DOMAIN=nexum.yourdomain.com` to your `.env`, then:
-```bash
-docker compose -f docker-compose.yml -f docker-compose.traefik.yml up -d
-```
-Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-compose.traefik.yml` overlay assumes a Traefik network named `traefik-public` and a cert resolver named `letsencrypt`.
-
-> **Tip — avoid retyping the overlay.** Every `docker compose ...` command below uses the standard form. If you run with the Traefik overlay, either prefix each command with `-f docker-compose.yml -f docker-compose.traefik.yml`, or set it once per shell session:
-> ```bash
-> export COMPOSE_FILE=docker-compose.yml:docker-compose.traefik.yml
-> ```
-> After that, plain `docker compose ...` automatically loads both files. Add the export to `~/.bashrc` / `~/.zshrc` if it's the only deployment on that host.
-
 #### One-command deploy scripts
 
-Not comfortable with Docker commands? The repo ships small scripts that run the whole **pull → build → restart** cycle for you, so updating to a new release is a single command from the repo root — no need to remember the `docker compose` lines above.
+Not comfortable with Docker commands? The repo ships small scripts that run the whole **pull → build → restart** cycle for you, so both first setup and later updates are a single command from the repo root — no need to remember the `docker compose` lines below.
 
 **Use the scripts for _your_ operating system — Linux/macOS _or_ Windows, not both.** They do the same thing; the `.sh` and `.ps1` versions are just for different shells.
 
@@ -403,11 +374,40 @@ Not comfortable with Docker commands? The repo ships small scripts that run the 
 | `.\build-traefik.ps1` | **The live / public site** (fronted by Traefik) | `git pull`, then build + `up -d` with **both** compose files |
 | `.\build.ps1` | **Local / dev** (no Traefik) | `git pull`, then a plain build + `up -d` |
 
-Each script **stops if a step fails**, so a broken pull or build never restarts the site with a bad image.
+Each script **stops if a step fails**, so a broken pull or build never restarts the site with a bad image. On the **first** run it also downloads EVE's static data (a few minutes) — that's the importer described under **Build and start the stack** below; nothing is stuck.
 
-> **On your public server, always use `build-traefik`.** A plain build without the Traefik overlay 404s the live site. The plain `build` scripts are for local/dev only.
+> **On your public server, always use `build-traefik`.** A plain build without the Traefik overlay 404s the live site. The plain `build` scripts are for local/dev only. (Traefik setup is covered under **Reverse proxy** below.)
 >
 > First run on Windows may need `Set-ExecutionPolicy -Scope Process RemoteSigned`; on Linux/macOS the `.sh` files are already executable (`chmod +x` is preset).
+
+**2. Build and start the stack**
+
+The server depends on the EVE Static Data Export (SDE) tables (`map_stargates`, `solar_systems`, `item_types`, …) at boot — without them, route-graph initialisation throws and the container crash-loops. A dedicated `importer` service handles this: it runs once after Postgres is healthy, downloads the SDE (~hundreds of MB from CCP, a few minutes; logs progress per table), populates the static tables, then exits. The server waits for it to finish (`service_completed_successfully`) before booting, so a single command brings everything up in the right order.
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+The app will be available on port `${WEB_PORT:-80}` (defaults to `80`).
+
+The import is self-skipping: on every later `up` or restart the importer sees the static tables are already populated and exits in a second without re-downloading. So the two commands above are also your update flow — or just run one of the [one-command deploy scripts](#one-command-deploy-scripts) above. To force a re-import (e.g. after a CCP SDE drop), see [Updating the SDE](#updating-the-sde) below.
+
+The importer also stores each system's universe coordinates and CCP's 2D star-map projection (`position` / `position2D`), which power the [Seed a map from a region](#features) feature.
+
+**3. Reverse proxy (optional)**
+
+To front the stack with Traefik for TLS and a public URL, add `DOMAIN=nexum.yourdomain.com` to your `.env`, then:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.traefik.yml up -d
+```
+Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-compose.traefik.yml` overlay assumes a Traefik network named `traefik-public` and a cert resolver named `letsencrypt`.
+
+> **Tip — avoid retyping the overlay.** Every `docker compose ...` command below uses the standard form. If you run with the Traefik overlay, either prefix each command with `-f docker-compose.yml -f docker-compose.traefik.yml`, or set it once per shell session:
+> ```bash
+> export COMPOSE_FILE=docker-compose.yml:docker-compose.traefik.yml
+> ```
+> After that, plain `docker compose ...` automatically loads both files. Add the export to `~/.bashrc` / `~/.zshrc` if it's the only deployment on that host.
 
 App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automatically the first time the server boots — no manual step.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Docker (recommended)](#option-1--docker-recommended)
   - [Local development](#option-2--local-development)
   - [EVE developer app scopes](#eve-developer-app-scopes)
+  - [One-command deploy scripts](#one-command-deploy-scripts)
   - [Updating the SDE](#updating-the-sde)
   - [Refreshing wormhole types](#refreshing-wormhole-types)
   - [Upgrading an existing deployment](#upgrading-an-existing-deployment)
@@ -364,7 +365,7 @@ docker compose up -d
 
 The app will be available on port `${WEB_PORT:-80}` (defaults to `80`).
 
-The import is self-skipping: on every later `up` or restart the importer sees the static tables are already populated and exits in a second without re-downloading. So the two commands above are also your update flow. To force a re-import (e.g. after a CCP SDE drop), see [Updating the SDE](#updating-the-sde) below.
+The import is self-skipping: on every later `up` or restart the importer sees the static tables are already populated and exits in a second without re-downloading. So the two commands above are also your update flow — or just run one of the [one-command deploy scripts](#one-command-deploy-scripts) below. To force a re-import (e.g. after a CCP SDE drop), see [Updating the SDE](#updating-the-sde) below.
 
 The importer also stores each system's universe coordinates and CCP's 2D star-map projection (`position` / `position2D`), which power the [Seed a map from a region](#features) feature.
 
@@ -381,6 +382,21 @@ Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-comp
 > export COMPOSE_FILE=docker-compose.yml:docker-compose.traefik.yml
 > ```
 > After that, plain `docker compose ...` automatically loads both files. Add the export to `~/.bashrc` / `~/.zshrc` if it's the only deployment on that host.
+
+#### One-command deploy scripts
+
+Not comfortable with Docker commands? The repo ships small scripts that run the whole **pull → build → restart** cycle for you, so updating to a new release is a single command from the repo root — no need to remember the `docker compose` lines above.
+
+| Run this | Use it for | What it does |
+|---|---|---|
+| `./build-traefik.sh`  ·  `.\build-traefik.ps1` | **The live / public site** (fronted by Traefik) | `git pull`, then build + `up -d` with **both** compose files |
+| `./build.sh`  ·  `.\build.ps1` | **Local / dev** (no Traefik) | `git pull`, then a plain build + `up -d` |
+
+`.sh` is for Linux/macOS, `.ps1` is for Windows PowerShell. Each script **stops if a step fails**, so a broken pull or build never restarts the site with a bad image.
+
+> **On your public server, always use `build-traefik`.** A plain build without the Traefik overlay 404s the live site. The plain `build` scripts are for local/dev only.
+>
+> First run on Windows may need `Set-ExecutionPolicy -Scope Process RemoteSigned`; on Linux/macOS the `.sh` files are already executable (`chmod +x` is preset).
 
 App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automatically the first time the server boots — no manual step.
 

--- a/README.md
+++ b/README.md
@@ -387,12 +387,23 @@ Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-comp
 
 Not comfortable with Docker commands? The repo ships small scripts that run the whole **pull → build → restart** cycle for you, so updating to a new release is a single command from the repo root — no need to remember the `docker compose` lines above.
 
+**Use the scripts for _your_ operating system — Linux/macOS _or_ Windows, not both.** They do the same thing; the `.sh` and `.ps1` versions are just for different shells.
+
+**Linux / macOS** — run the `.sh` scripts:
+
 | Run this | Use it for | What it does |
 |---|---|---|
-| `./build-traefik.sh`  ·  `.\build-traefik.ps1` | **The live / public site** (fronted by Traefik) | `git pull`, then build + `up -d` with **both** compose files |
-| `./build.sh`  ·  `.\build.ps1` | **Local / dev** (no Traefik) | `git pull`, then a plain build + `up -d` |
+| `./build-traefik.sh` | **The live / public site** (fronted by Traefik) | `git pull`, then build + `up -d` with **both** compose files |
+| `./build.sh` | **Local / dev** (no Traefik) | `git pull`, then a plain build + `up -d` |
 
-`.sh` is for Linux/macOS, `.ps1` is for Windows PowerShell. Each script **stops if a step fails**, so a broken pull or build never restarts the site with a bad image.
+**Windows** — run the `.ps1` scripts in PowerShell:
+
+| Run this | Use it for | What it does |
+|---|---|---|
+| `.\build-traefik.ps1` | **The live / public site** (fronted by Traefik) | `git pull`, then build + `up -d` with **both** compose files |
+| `.\build.ps1` | **Local / dev** (no Traefik) | `git pull`, then a plain build + `up -d` |
+
+Each script **stops if a step fails**, so a broken pull or build never restarts the site with a bad image.
 
 > **On your public server, always use `build-traefik`.** A plain build without the Traefik overlay 404s the live site. The plain `build` scripts are for local/dev only.
 >

--- a/build-traefik.ps1
+++ b/build-traefik.ps1
@@ -1,0 +1,34 @@
+# Deploy nexum with the Traefik overlay: pull latest, rebuild, restart.
+#
+# BOTH compose files are required - a plain `up` without the traefik overlay
+# 404s the live site. Passing explicit -f flags also means the dev-only
+# docker-compose.override.yml is deliberately NOT loaded.
+#
+# Stops on the first failure (a failed pull/build never reaches `up`), so a
+# broken build never replaces the running site.
+#
+# Usage:  .\build-traefik.ps1
+#   (first run may need:  Set-ExecutionPolicy -Scope Process RemoteSigned)
+
+$ErrorActionPreference = 'Stop'
+
+# Run from the script's own directory (repo root), regardless of cwd.
+Set-Location -Path $PSScriptRoot
+
+$compose = @('-f', 'docker-compose.yml', '-f', 'docker-compose.traefik.yml')
+
+# External commands (git/docker) don't throw on non-zero exit, so check
+# $LASTEXITCODE after each and stop if it failed.
+function Invoke-Step {
+    param([string] $Label, [scriptblock] $Command)
+    Write-Host "==> $Label" -ForegroundColor Cyan
+    & $Command
+    if ($LASTEXITCODE -ne 0) { throw "$Label failed (exit $LASTEXITCODE)" }
+}
+
+Invoke-Step '[1/3] git pull'             { git pull }
+Invoke-Step '[2/3] docker compose build' { docker compose @compose build }
+Invoke-Step '[3/3] docker compose up -d' { docker compose @compose up -d }
+
+Write-Host '==> done. Container status:' -ForegroundColor Green
+docker compose @compose ps

--- a/build-traefik.sh
+++ b/build-traefik.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Deploy nexum with the Traefik overlay: pull latest, rebuild, restart.
+#
+# BOTH compose files are required — a plain `up` without the traefik overlay
+# 404s the live site. Passing explicit -f flags also means the dev-only
+# docker-compose.override.yml is deliberately NOT loaded.
+#
+# `set -e` matters here: if `git pull` or `build` fails, the script stops
+# BEFORE `up`, so a broken build never replaces the running site.
+#
+# Usage:  ./build-traefik.sh
+set -euo pipefail
+
+# The whole script lives inside main() so that a `git pull` which updates this
+# very file mid-run can't make bash misread the not-yet-executed lines — bash
+# has already parsed the function before main runs.
+main() {
+  # Run from the repo root (where the compose files are), regardless of cwd.
+  cd "$(dirname "$0")"
+
+  local compose=(-f docker-compose.yml -f docker-compose.traefik.yml)
+
+  echo "==> [1/3] git pull"
+  git pull
+
+  echo "==> [2/3] docker compose build"
+  docker compose "${compose[@]}" build
+
+  echo "==> [3/3] docker compose up -d"
+  docker compose "${compose[@]}" up -d
+
+  echo "==> done. Container status:"
+  docker compose "${compose[@]}" ps
+}
+
+main "$@"

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,32 @@
+# Local/dev build: pull latest, rebuild, restart - WITHOUT the Traefik overlay.
+#
+# Runs bare `docker compose`, so it loads docker-compose.yml +
+# docker-compose.override.yml (the dev override). It does NOT route through
+# Traefik, so this is for LOCAL / dev use - for the live site use
+# .\build-traefik.ps1 (a plain `up` without the overlay 404s the live site).
+#
+# Stops on the first failure (a failed pull/build never reaches `up`).
+#
+# Usage:  .\build.ps1
+#   (first run may need:  Set-ExecutionPolicy -Scope Process RemoteSigned)
+
+$ErrorActionPreference = 'Stop'
+
+# Run from the script's own directory (repo root), regardless of cwd.
+Set-Location -Path $PSScriptRoot
+
+# External commands (git/docker) don't throw on non-zero exit, so check
+# $LASTEXITCODE after each and stop if it failed.
+function Invoke-Step {
+    param([string] $Label, [scriptblock] $Command)
+    Write-Host "==> $Label" -ForegroundColor Cyan
+    & $Command
+    if ($LASTEXITCODE -ne 0) { throw "$Label failed (exit $LASTEXITCODE)" }
+}
+
+Invoke-Step '[1/3] git pull'             { git pull }
+Invoke-Step '[2/3] docker compose build' { docker compose build }
+Invoke-Step '[3/3] docker compose up -d' { docker compose up -d }
+
+Write-Host '==> done. Container status:' -ForegroundColor Green
+docker compose ps

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Local/dev build: pull latest, rebuild, restart — WITHOUT the Traefik overlay.
+#
+# Runs bare `docker compose`, so it loads docker-compose.yml +
+# docker-compose.override.yml (the dev override). It does NOT route through
+# Traefik, so this is for LOCAL / dev use — for the live site use
+# ./build-traefik.sh (a plain `up` without the overlay 404s the live site).
+#
+# `set -e` stops before `up` if `git pull` or `build` fails.
+#
+# Usage:  ./build.sh
+set -euo pipefail
+
+# Wrapped in main() so a `git pull` that updates this file mid-run can't make
+# bash misread the not-yet-executed lines (already parsed before main runs).
+main() {
+  cd "$(dirname "$0")"
+
+  echo "==> [1/3] git pull"
+  git pull
+
+  echo "==> [2/3] docker compose build"
+  docker compose build
+
+  echo "==> [3/3] docker compose up -d"
+  docker compose up -d
+
+  echo "==> done. Container status:"
+  docker compose ps
+}
+
+main "$@"


### PR DESCRIPTION
A few operators aren't native Docker users and struggle to remember the compose commands, so this bundles simple pull → build → restart scripts and documents them.

## Scripts (repo root)
| Script | Target | Compose |
|---|---|---|
| `build-traefik.sh` / `.ps1` | Live/public site | `docker-compose.yml` + `docker-compose.traefik.yml` |
| `build.sh` / `.ps1` | Local/dev | plain `docker compose` (base + override) |

Each runs `git pull`, then `build`, then `up -d`, and:
- **Stops on the first failed step** (`set -euo pipefail` in bash; `$ErrorActionPreference='Stop'` + `$LASTEXITCODE` checks in PowerShell) so a broken pull/build never restarts the site with a bad image.
- `cd`s to its own directory (repo root), so it works from any cwd.
- Bash versions are wrapped in `main()` so a `git pull` that updates the script mid-run can't make bash misread it.
- `.sh` files committed with the executable bit (100755).

## README
New **One-command deploy scripts** section under Installation (with a TOC entry and a pointer from the update-flow note). Emphasises using `build-traefik` on the public server — a plain `up` without the overlay 404s the live site.

## Notes
- Docs/tooling only — no app code touched.
- PowerShell scripts couldn't be parse-checked locally (no `pwsh` on the dev machine); bash scripts pass `bash -n`.