### PR TITLE
UI polish: unified red controls, watchlist dropdowns, chain text size

### DIFF
--- a/web/src/components/ui/ClassPicker.tsx
+++ b/web/src/components/ui/ClassPicker.tsx
@@ -38,13 +38,11 @@ export function ClassPicker({ value, onChange, classes }: Props) {
         ref={btnRef}
         type="button"
         className={`wh-picker__btn${open ? ' wh-picker__btn--open' : ''}`}
+        style={{ fontFamily: 'inherit', fontWeight: 600 }}
         onClick={openAt}
       >
         <span className="wh-picker__btn-inner">
-          {/* Reuse .wh-picker__code (monospace, min-width) so the class value
-              lines up exactly like the wormhole-type picker's code; keep the
-              per-class colour inline. */}
-          <span className="wh-picker__code" style={{ color: CLASS_COLORS[value] }}>
+          <span style={{ color: CLASS_COLORS[value], fontSize: 'calc(13px * var(--font-scale, 1))' }}>
             {CLASS_LABELS[value] ?? value}
           </span>
         </span>

--- a/web/src/components/ui/ClassPicker.tsx
+++ b/web/src/components/ui/ClassPicker.tsx
@@ -38,11 +38,13 @@ export function ClassPicker({ value, onChange, classes }: Props) {
         ref={btnRef}
         type="button"
         className={`wh-picker__btn${open ? ' wh-picker__btn--open' : ''}`}
-        style={{ fontFamily: 'inherit', fontWeight: 600 }}
         onClick={openAt}
       >
         <span className="wh-picker__btn-inner">
-          <span style={{ color: CLASS_COLORS[value], fontSize: 'calc(13px * var(--font-scale, 1))' }}>
+          {/* Reuse .wh-picker__code (monospace, min-width) so the class value
+              lines up exactly like the wormhole-type picker's code; keep the
+              per-class colour inline. */}
+          <span className="wh-picker__code" style={{ color: CLASS_COLORS[value] }}>
             {CLASS_LABELS[value] ?? value}
           </span>
         </span>

--- a/web/src/components/ui/ClosestSystemsPane.tsx
+++ b/web/src/components/ui/ClosestSystemsPane.tsx
@@ -5,7 +5,7 @@ import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from 
 import type { DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { MapPinSimpleIcon, PathIcon, XIcon, PlusIcon, HouseIcon } from '@phosphor-icons/react';
+import { MapPinSimpleIcon, PathIcon, XIcon, PlusIcon, HouseIcon, TrashIcon } from '@phosphor-icons/react';
 import { useShallow } from 'zustand/react/shallow';
 import { useRoute, type RouteEntry } from '../../hooks/useRoute';
 import { useEsiSearch } from '../../hooks/useEsiSearch';
@@ -143,7 +143,7 @@ function Row({ item, route, isOpen, onToggle, onRemove, routeMode }: RowProps) {
             aria-label={t('closest.removeFromList')}
             data-tooltip={t('closest.removeFromList')}
           >
-            <XIcon size={14} weight="regular" color="#e25a5a" />
+            <TrashIcon size={14} weight="regular" color="#e05a5a" />
           </button>
         )}
       </div>

--- a/web/src/styles/panes.css
+++ b/web/src/styles/panes.css
@@ -157,8 +157,9 @@
 }
 .chain-item__name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chain-item__hops { flex: none; color: var(--text-subtle); font-size: calc(11px * var(--font-scale, 1)); }
-.chain-item__del { flex: none; margin-right: 4px; color: var(--text-subtle); }
-.chain-item__del:hover { color: var(--cv-conn-expired); }
+/* Always-red delete trash, matching the closest-systems + watchlist removes. */
+.chain-item__del { flex: none; margin-right: 4px; color: var(--danger); }
+.chain-item__del:hover { color: var(--danger); }
 
 /* Reverse-direction toggle. Muted like the other row icons; lights up in the
    accent colour while the chain is being viewed reversed. */

--- a/web/src/styles/panes.css
+++ b/web/src/styles/panes.css
@@ -210,7 +210,7 @@
 .chain-step__systems:hover { color: #fff; }
 .chain-step__via {
   display: flex; align-items: center; gap: 5px;
-  font-size: calc(11px * var(--font-scale, 1)); color: var(--text-subtle);
+  font-size: calc(12px * var(--font-scale, 1)); color: var(--text-subtle);
 }
 .chain-step__warp { display: inline-flex; align-items: center; gap: 4px; }
 .chain-step__wh {
@@ -223,7 +223,7 @@
 .chain-step__meta {
   display: flex; flex-wrap: wrap; gap: 4px 12px;
   padding-left: 16px;
-  font-size: calc(10px * var(--font-scale, 1)); color: var(--text-subtle);
+  font-size: calc(12px * var(--font-scale, 1)); color: var(--text-subtle);
 }
 
 /* Per-end "backing signature" link controls in the connection panel. */

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -1118,6 +1118,8 @@
 }
 .watchlist__group-btn:hover:not(:disabled) { color: #a0ccf8; }
 .watchlist__group-btn:disabled { opacity: 0.4; cursor: default; }
+/* The group-delete trash is always red (matches the closest-systems remove). */
+.watchlist__group-btn--del { color: var(--danger); }
 .watchlist__group-btn--del:hover:not(:disabled) { color: var(--danger); }
 .watchlist__group .watchlist__list { padding: 8px 6px; margin-top: 0; }
 

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -1248,9 +1248,13 @@
   background: var(--surface-base);
   border: 1px solid var(--border);
   border-radius: 4px;
-  padding: 3px 6px;
-  font-size: calc(11px * var(--font-scale, 1));
-  color: #9fb0d0;
+  /* Match the criteria dropdowns (.watchlist__by) so "Match all" is the same
+     size as the Contains / Leads to selects below it. Asymmetric padding: room
+     for the text on the left, tight on the right so the native <select> arrow
+     stays near the edge. */
+  padding: 4px 2px 4px 8px;
+  font-size: calc(12px * var(--font-scale, 1));
+  color: var(--text-primary);
   cursor: pointer;
   outline: none;
 }
@@ -1262,8 +1266,9 @@
   background: none;
   border: 1px dashed #2a3550;
   border-radius: 4px;
-  padding: 3px 8px;
-  font-size: calc(11px * var(--font-scale, 1));
+  /* Same height/type size as the criteria dropdowns above it. */
+  padding: 4px 8px;
+  font-size: calc(12px * var(--font-scale, 1));
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -1304,7 +1309,11 @@
 }
 
 .watchlist__marker { width: 82px; }
-.watchlist__by { flex: 1; min-width: 80px; }
+/* Contains / Leads to selects: roomier text on the left, tight on the right so
+   the native <select> arrow sits near the edge — matching .watchlist__combine so
+   all the criteria dropdowns look uniform. (The shared marker rule keeps its
+   tight 4px 2px, tuned for the fixed-width markers.) */
+.watchlist__by { flex: 1; min-width: 80px; padding: 4px 2px 4px 8px; }
 
 .watchlist__char-label {
   flex: 1;

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -2384,7 +2384,7 @@ select.sig-toolbar-btn option {
 .wh-picker__option:hover   { background: var(--border); }
 .wh-picker__option--active { background: #1e3555; }
 
-.wh-picker__code { font-family: 'Courier New', monospace; font-weight: 700; font-size: calc(14px * var(--font-scale, 1)); color: var(--accent-light); min-width: 44px; }
+.wh-picker__code { font-family: 'Courier New', monospace; font-weight: 700; font-size: calc(14px * var(--font-scale, 1)); color: var(--accent-light); min-width: 37px; }
 .wh-picker__arrow { color: var(--text-faintest); font-size: calc(13px * var(--font-scale, 1)); }
 .wh-picker__dest  { font-size: calc(14px * var(--font-scale, 1)); font-weight: 600; }
 .wh-picker__placeholder { color: var(--text-bright); font-size: calc(14px * var(--font-scale, 1)); }

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -853,7 +853,7 @@
   display: inline-flex; align-items: center; justify-content: center;
   background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 0;
 }
-.map-shares__chip-remove:hover { color: #e06a6a; }
+.map-shares__chip-remove:hover { color: var(--danger); }
 .map-shares__grant-login {
   display: flex;
   align-items: center;
@@ -922,7 +922,7 @@
 .map-shares__revoke {
   background: transparent;
   border: 1px solid #3a2030;
-  color: #d88a8a;
+  color: var(--danger);
   border-radius: 3px;
   padding: 2px 4px;
   cursor: pointer;
@@ -1220,7 +1220,7 @@
   border-radius: 4px;
   padding: 4px 8px;
   font-size: calc(11px * var(--font-scale, 1));
-  color: #d88a8a;
+  color: var(--danger);
   cursor: pointer;
 }
 .watchlist__delete-full:hover {
@@ -1429,7 +1429,7 @@
 .watchlist__remove {
   background: transparent;
   border: 1px solid #3a2030;
-  color: #d88a8a;
+  color: var(--danger);
   border-radius: 4px;
   padding: 3px 5px;
   cursor: pointer;
@@ -1765,7 +1765,7 @@
   gap: 4px;
   background: transparent;
   border: 1px solid #3a2030;
-  color: #d88a8a;
+  color: var(--danger);
   border-radius: 4px;
   padding: 3px 8px;
   font-size: calc(12px * var(--font-scale, 1));


### PR DESCRIPTION
UI consistency / polish pass on the sidebar (Closest Systems / Watchlist / Saved chains).

## Red remove/delete controls — all one red
Every destructive control now uses the same `--danger` red:
- **Closest Systems** "remove from list" — red X → red **trash can**.
- **Watchlist** "delete group" trash — now always red (was red-on-hover).
- **Saved chains** delete trash — now always red, same `--danger`.
- Unified the muted `#d88a8a` (criteria remove, "Remove from watchlist", content-filter clear, map-share revoke) and a stray `#e06a6a` to `--danger`.

(The add-system **cancel** X in Closest Systems stays an X — it cancels the search, not a remove.)

## Watchlist criteria dropdowns
- **"Match all/any"** sized to match the Contains/Leads to selects (font 11→12px, colour, padding).
- **Contains / Leads to** given asymmetric padding (roomier left for the text, tight right so the native `<select>` arrow stays near the edge).
- **"+ Add criteria"** sized to match the dropdowns.
- **D382 / C2 value dropdowns** now line up — tightened `.wh-picker__code` min-width 44→37px so the wormhole-code column no longer sits wider than the class value.

## Saved chains
- **"Warp to" / Type / Size** text enlarged (11px/10px → 12px) — it was hard to read.

Build + lint clean throughout.
