### PR TITLE
Fix: Select dropdown doesn't open in the settings modal (portal it)

### DIFF
--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode, KeyboardEvent } from 'react';
+import { createPortal } from 'react-dom';
 import { CaretDownIcon, CaretUpIcon, CheckIcon } from '@phosphor-icons/react';
 import { usePopover } from '../../hooks/usePopover';
 import styles from './Select.module.css';
@@ -143,7 +144,7 @@ export function Select<V extends string = string>({
         </span>
       </button>
 
-      {open && (
+      {open && createPortal(
         <div
           ref={dropdownRef}
           className={styles.dropdown}
@@ -179,7 +180,8 @@ export function Select<V extends string = string>({
               );
             })}
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );


### PR DESCRIPTION
**Bug:** every dropdown in the settings modal fails to open correctly after the themed-Select rollout.

**Cause:** the Select rendered its dropdown inline in the component tree. That's fine in the sidebar, but the settings section is a portalled overlay with its own stacking + overflow context, which the inline dropdown couldn't escape.

**Fix:** render the dropdown into `document.body` via `createPortal`, the standard pattern for a reusable dropdown that must work inside modals. It stays `position: fixed` at the `usePopover`-computed viewport coords (so it still opens right under the trigger, above everything), and the outside-click + keyboard handling is unchanged — `dropdownRef` still points at the portalled node, and React portal event-bubbling keeps the modal's own click-outside from firing.

Build + lint clean. Please verify the settings-modal dropdowns (e.g. connection thickness) open correctly.