### PR TITLE
Fix: share-map Access View/Edit toggle wrapping

### DIFF
--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -943,6 +943,11 @@
   margin: 2px 0;
 }
 
+/* View / Edit is a horizontal segmented toggle — override the base button group
+   (which is a full-width vertical list) so the two options sit side by side. */
+.map-shares__access .map-sidebar__btn-group { flex-direction: row; }
+.map-shares__access .map-sidebar__btn-group-item { width: auto; }
+
 .map-shares__access-label {
   font-size: calc(12px * var(--font-scale, 1));
   color: #a8b6cc;

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -2373,7 +2373,7 @@ select.sig-toolbar-btn option {
 .wh-picker__option:hover   { background: var(--border); }
 .wh-picker__option--active { background: #1e3555; }
 
-.wh-picker__code { font-family: 'Courier New', monospace; font-weight: 700; font-size: calc(14px * var(--font-scale, 1)); color: var(--accent-light); min-width: 37px; }
+.wh-picker__code { font-family: 'Courier New', monospace; font-weight: 700; font-size: calc(14px * var(--font-scale, 1)); color: var(--accent-light); min-width: 34px; }
 .wh-picker__arrow { color: var(--text-faintest); font-size: calc(13px * var(--font-scale, 1)); }
 .wh-picker__dest  { font-size: calc(14px * var(--font-scale, 1)); font-weight: 600; }
 .wh-picker__placeholder { color: var(--text-bright); font-size: calc(14px * var(--font-scale, 1)); }


### PR DESCRIPTION
The corp/alliance share **Access** toggle (View / Edit) reused `.map-sidebar__btn-group`, which is a full-width *vertical* option list — so the two buttons stacked/wrapped. Scopes a horizontal (row, auto-width) override to `.map-shares__access` so View and Edit sit side by side. CSS-only; build clean.