### PR TITLE
Release v3.10.0 — Themed dropdowns everywhere

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "3.9.0",
+  "version": "3.10.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/AnomalyPane.tsx
+++ b/web/src/components/ui/AnomalyPane.tsx
@@ -10,6 +10,7 @@ import { useClickOutside } from '../../hooks/useClickOutside';
 import type { Anomaly, AnomType } from '../../types';
 import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
 import { NotesEditor } from './NotesEditor';
+import { Select } from './Select';
 import { XIcon, ColumnsIcon } from '@phosphor-icons/react';
 import { toast } from './Toaster';
 import { duration, DASH } from '../../i18n/format';
@@ -502,19 +503,16 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
             />
             <span>{t('anomalies.overwriteToggle')}</span>
           </label>
-          <select
-            className="sig-toolbar-btn"
-            value={overwriteDelay}
-            onChange={(e) => setOverwriteDelay(Number(e.target.value))}
-            aria-label={t('anomalies.removeDelayLabel')}
-            data-tooltip={t('anomalies.removeDelayTooltip')}
-          >
-            {OVERWRITE_DELAY_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {s === 0 ? t('anomalies.removeDelayInstant') : formatDelay(s)}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={String(overwriteDelay)}
+            onChange={(v) => setOverwriteDelay(Number(v))}
+            ariaLabel={t('anomalies.removeDelayLabel')}
+            title={t('anomalies.removeDelayTooltip')}
+            options={OVERWRITE_DELAY_OPTIONS.map((s) => ({
+              value: String(s),
+              label: s === 0 ? t('anomalies.removeDelayInstant') : formatDelay(s),
+            }))}
+          />
           {selected.size > 0 && (
             <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteSelected}>
               {t('anomalies.deleteSelected', { count: selected.size })}
@@ -663,15 +661,16 @@ export function AnomalyPane({ systemId }: { systemId: string }) {
                   />
                 </td>
                 <td>
-                  <select
-                    className={`sig-select sig-select--type sig-select--type-${anom.anomType}`}
+                  <Select
+                    className="sig-type-select"
                     value={anom.anomType}
-                    onChange={(e) => updateAnom(anom.id, { anomType: e.target.value as AnomType })}
-                  >
-                    {ANOM_TYPE_OPTIONS.map((at) => (
-                      <option key={at} value={at}>{anomTypeLabel(at)}</option>
-                    ))}
-                  </select>
+                    onChange={(v) => updateAnom(anom.id, { anomType: v as AnomType })}
+                    options={ANOM_TYPE_OPTIONS.map((at) => ({
+                      value: at,
+                      text:  anomTypeLabel(at),
+                      label: <span className={`sig-select--type-${at}`}>{anomTypeLabel(at)}</span>,
+                    }))}
+                  />
                 </td>
                 <td>
                   <input

--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -11,6 +11,7 @@ import type { Signature, SigType } from '../../types';
 import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
 import { NotesEditor } from './NotesEditor';
 import { WormholeTypePicker } from './WormholeTypePicker';
+import { Select } from './Select';
 import { XIcon, CopyIcon, ColumnsIcon } from '@phosphor-icons/react';
 import { LeadsToDropdown } from './LeadsToDropdown';
 import { toast } from './Toaster';
@@ -152,7 +153,7 @@ function formatDelay(sec: number): string {
 // Order the type-filter chips most-useful-first. Covers every SigType.
 const SIG_TYPE_FILTER_ORDER: SigType[] = ['wormhole', 'data', 'relic', 'gas', 'ore', 'combat', 'unknown'];
 
-// Signature-type <select> options, alphabetical by label. Used for both the
+// Signature-type Select options, alphabetical by label. Used for both the
 // per-row type picker and the bulk "set type" dropdown.
 const SIG_TYPE_OPTIONS: SigType[] = ['combat', 'data', 'gas', 'ore', 'relic', 'unknown', 'wormhole'];
 
@@ -774,36 +775,30 @@ export function SignaturePane({ systemId }: { systemId: string }) {
             />
             <span>{t('signatures.overwriteToggle')}</span>
           </label>
-          <select
-            className="sig-toolbar-btn"
-            value={overwriteDelay}
-            onChange={(e) => setOverwriteDelay(Number(e.target.value))}
-            aria-label={t('signatures.removeDelayLabel')}
-            data-tooltip={t('signatures.removeDelayTooltip')}
-          >
-            {OVERWRITE_DELAY_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {s === 0 ? t('signatures.removeDelayInstant') : formatDelay(s)}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={String(overwriteDelay)}
+            onChange={(v) => setOverwriteDelay(Number(v))}
+            ariaLabel={t('signatures.removeDelayLabel')}
+            title={t('signatures.removeDelayTooltip')}
+            options={OVERWRITE_DELAY_OPTIONS.map((s) => ({
+              value: String(s),
+              label: s === 0 ? t('signatures.removeDelayInstant') : formatDelay(s),
+            }))}
+          />
           {selected.size > 0 && (
             <>
-              <select
-                className="sig-toolbar-btn"
+              <Select
                 value=""
-                onChange={(e) => {
-                  if (!e.target.value) return;
-                  setSelectedType(e.target.value as SigType);
-                  e.target.value = '';
-                }}
-                aria-label={t('signatures.setTypeAria')}
-              >
-                <option value="">{t('signatures.setType', { count: selected.size })}</option>
-                {SIG_TYPE_OPTIONS.map((type) => (
-                  <option key={type} value={type}>{t(`sigType.${type}`)}</option>
-                ))}
-              </select>
+                onChange={(v) => { if (v) setSelectedType(v as SigType); }}
+                ariaLabel={t('signatures.setTypeAria')}
+                placeholder={t('signatures.setType', { count: selected.size })}
+                showCheck={false}
+                options={SIG_TYPE_OPTIONS.map((type) => ({
+                  value: type,
+                  text:  t(`sigType.${type}`),
+                  label: <span className={`sig-select--type-${type}`}>{t(`sigType.${type}`)}</span>,
+                }))}
+              />
               <button className="sig-toolbar-btn sig-toolbar-btn--danger" onClick={deleteSelected}>
                 {t('signatures.deleteSelected', { count: selected.size })}
               </button>
@@ -983,15 +978,18 @@ export function SignaturePane({ systemId }: { systemId: string }) {
                       {sigTypeLabel(sig.sigType)}
                     </span>
                   ) : (
-                    <select
-                      className={`sig-select sig-select--type sig-select--type-${sig.sigType}`}
+                    <Select
+                      className="sig-type-select"
                       value={sig.sigType}
-                      onChange={(e) => updateSig(sig.id, { sigType: e.target.value as SigType })}
-                    >
-                      {SIG_TYPE_OPTIONS.map((st) => (
-                        <option key={st} value={st}>{sigTypeLabel(st)}</option>
-                      ))}
-                    </select>
+                      onChange={(v) => updateSig(sig.id, { sigType: v as SigType })}
+                      options={SIG_TYPE_OPTIONS.map((st) => ({
+                        value: st,
+                        text:  sigTypeLabel(st),
+                        // Reuse the existing per-type colour classes so the value
+                        // stays tinted by type in the trigger and the list.
+                        label: <span className={`sig-select--type-${st}`}>{sigTypeLabel(st)}</span>,
+                      }))}
+                    />
                   )}
                 </td>
                 <td className="sig-td--wh">

--- a/web/src/components/ui/StructuresPane.tsx
+++ b/web/src/components/ui/StructuresPane.tsx
@@ -7,6 +7,7 @@ import { useShareMode } from '../../context/ShareModeContext';
 import type { Structure, StructureType } from '../../types';
 import { NotesEditor } from './NotesEditor';
 import { ConfirmModal, shouldSkipConfirm } from './ConfirmModal';
+import { Select } from './Select';
 import { ContextMenu } from './ContextMenu';
 import { XIcon, PathIcon, MapPinSimpleIcon } from '@phosphor-icons/react';
 import { setDestination, addWaypoint } from '../../api/waypoint';
@@ -282,15 +283,15 @@ export function StructuresPane({ systemId }: { systemId: string }) {
                     {isShareMode ? (
                       <span className="sig-text">{typeLabel(s.structureType)}</span>
                     ) : (
-                      <select
-                        className="sig-select"
+                      <Select
+                        className="sig-type-select"
                         value={s.structureType}
-                        onChange={(e) => updateStructure(s.id, { structureType: e.target.value as StructureType })}
-                      >
-                        {(Object.keys(STRUCTURE_TYPE_LABELS) as StructureType[]).map((st) => (
-                          <option key={st} value={st}>{typeLabel(st)}</option>
-                        ))}
-                      </select>
+                        onChange={(v) => updateStructure(s.id, { structureType: v as StructureType })}
+                        options={(Object.keys(STRUCTURE_TYPE_LABELS) as StructureType[]).map((st) => ({
+                          value: st,
+                          label: typeLabel(st),
+                        }))}
+                      />
                     )}
                   </td>
                   <td>

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -2107,6 +2107,11 @@
   &--leadsto { color: #78a0c0; font-size: calc(13px * var(--font-scale, 1)); }
 }
 
+/* Full-width themed <Select> in the sig/anomaly/structure type cells (the old
+   native .sig-select was width:100%). Type tinting now comes from the option
+   labels reusing .sig-select--type-*, so this is layout only. */
+.sig-type-select { width: 100%; }
+
 .sig-toolbar-btn {
   background: transparent;
   border: 1px solid var(--border-accent);


### PR DESCRIPTION
Promotes the final native-`<select>` migration batch (sig / anomaly / structure panes) from `release` to `main`. **MINOR** bump **3.9.0 → 3.10.0** (both `web/` and `server/package.json`).

On merge, cut the GitHub release **v3.10.0** with the patch notes below.

---

## 📋 Patch notes (v3.10.0 GitHub release body)

## v3.10.0 — Themed dropdowns everywhere

Finishes the dropdown refresh started in 3.9.0. The signature, anomaly and structure panes now use the same dark, on-theme dropdowns as the rest of nexum — no more plain grey system menus anywhere in the app.

- The **signature / anomaly type pickers** keep their colour cue: each type stays tinted (wormhole blue, combat red, and so on) in both the closed value and the open list.
- Same keyboard support as the other dropdowns (arrow keys, type-ahead, Esc).

That's the whole app on one consistent dropdown now. No functional changes — everything behaves exactly as before.

---

## 💬 Discord announcement (ready to post)

> 🎨 **nexum v3.10.0 — Themed dropdowns everywhere**
>
> Wrapping up the dropdown refresh from last release: the **signature, anomaly and structure** panes now use the same dark, on-theme dropdowns as the rest of the app.
>
> • 🎯 The signature / anomaly **type pickers** keep their colour cue — each type stays tinted (wormhole blue, combat red, etc.) in both the selected value and the list.
> • ⌨️ Same keyboard support as the other dropdowns.
>
> That's the entire app on one consistent, tidy dropdown now. No functional changes. Fly safe o7

---

### Release checklist
- [x] Version bumped to 3.10.0 (web + server)
- [ ] Merge to `main`
- [ ] Cut GitHub release `v3.10.0` (tag `v3.10.0`) using the patch notes above
- [ ] Post the Discord announcement
