### PR TITLE
Proximity alert: make the toolbar threat badge flash more visibly

### DIFF
--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -234,12 +234,33 @@
   border-color: var(--danger);
   color: #ffb0b0;
   background: rgba(224, 90, 90, 0.12);
-  animation: proximity-pulse 1.6s ease-in-out infinite;
+  animation: proximity-pulse 1.15s ease-in-out infinite;
 }
 
+/* Flash the background, border and a glowing ring together so the alert reads
+   at a glance in peripheral vision — a threat this close is worth being loud
+   about. */
 @keyframes proximity-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(224, 90, 90, 0); }
-  50%      { box-shadow: 0 0 0 4px rgba(224, 90, 90, 0.25); }
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(224, 90, 90, 0);
+    background: rgba(224, 90, 90, 0.10);
+    border-color: var(--danger);
+  }
+  50% {
+    box-shadow: 0 0 11px 3px rgba(224, 90, 90, 0.6);
+    background: rgba(224, 90, 90, 0.30);
+    border-color: #ff6a6a;
+  }
+}
+
+/* Respect reduced-motion: drop the flashing but keep a strong static ring so
+   the alert is still unmistakable. */
+@media (prefers-reduced-motion: reduce) {
+  .toolbar__proximity--alert {
+    animation: none;
+    box-shadow: 0 0 0 2px rgba(224, 90, 90, 0.45);
+    background: rgba(224, 90, 90, 0.22);
+  }
 }
 
 .toolbar__proximity-icon {


### PR DESCRIPTION
The nearest-threat badge on the top bar (e.g. **"1 jump - Incursion"**) already pulsed, but only with a faint box-shadow ring that was easy to miss.

Intensified into a proper flash: the background, border, and a glowing ring now pulse together on a faster **1.15s** cadence so a close threat catches the eye in peripheral vision.

Also adds a `prefers-reduced-motion` fallback that drops the animation but keeps a strong static ring, so the alert stays unmistakable for users who disable motion.

CSS-only, scoped to `.toolbar__proximity--alert`. `web/src/styles/sidebar.css`.