### PR TITLE
Release v3.11.1

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "3.11.0",
+  "version": "3.11.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -23,7 +23,84 @@ function emptyPeriod(): PeriodStats {
 type PeriodKey = 'forever' | 'year' | 'month' | 'week' | 'day';
 const PERIODS: PeriodKey[] = ['forever', 'year', 'month', 'week', 'day'];
 
-const DAILY_DAYS = 30;
+// Granularity of the activity chart per period. The chart follows the selected
+// period: last-24h is hourly, a week/month are daily, a year and all-time are
+// monthly. Every bucket reads the same append-only user_events log, so any
+// granularity is just a date_trunc away — no extra tables.
+type BucketUnit = 'hour' | 'day' | 'month';
+interface SeriesSpec { unit: BucketUnit; since: Date; count: number }
+
+// Longest all-time monthly series we'll render — bounds the array for an
+// account with years of history (the app itself is far younger, so in practice
+// "forever" is a handful of months).
+const MAX_FOREVER_MONTHS = 120;
+
+function truncUTC(d: Date, unit: BucketUnit): Date {
+  const x = new Date(d);
+  x.setUTCMilliseconds(0); x.setUTCSeconds(0); x.setUTCMinutes(0);
+  if (unit === 'day' || unit === 'month') x.setUTCHours(0);
+  if (unit === 'month') x.setUTCDate(1);
+  return x;
+}
+function addUnit(d: Date, unit: BucketUnit, i: number): Date {
+  const x = new Date(d);
+  if (unit === 'hour')     x.setUTCHours(x.getUTCHours() + i);
+  else if (unit === 'day') x.setUTCDate(x.getUTCDate() + i);
+  else                     x.setUTCMonth(x.getUTCMonth() + i);
+  return x;
+}
+// Canonical bucket key matching the SQL to_char below, in UTC. For day/month
+// buckets the truncated hour is 00, so one format string covers all three.
+function bucketKey(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}`;
+}
+function monthsBetween(a: Date, b: Date): number {
+  return (b.getUTCFullYear() - a.getUTCFullYear()) * 12 + (b.getUTCMonth() - a.getUTCMonth());
+}
+
+// The window + granularity for each period, ending at the current bucket.
+function seriesSpecs(now: Date, firstEvent: Date): Record<PeriodKey, SeriesSpec> {
+  const hour  = truncUTC(now, 'hour');
+  const day   = truncUTC(now, 'day');
+  const month = truncUTC(now, 'month');
+  const foreverCount = Math.min(MAX_FOREVER_MONTHS, monthsBetween(truncUTC(firstEvent, 'month'), month) + 1);
+  return {
+    day:     { unit: 'hour',  since: addUnit(hour,  'hour',  -23), count: 24 },
+    week:    { unit: 'day',   since: addUnit(day,   'day',    -6), count: 7  },
+    month:   { unit: 'day',   since: addUnit(day,   'day',   -29), count: 30 },
+    year:    { unit: 'month', since: addUnit(month, 'month', -11), count: 12 },
+    // Clamp the start forward if history exceeds the cap, so it still ends at
+    // the current month.
+    forever: { unit: 'month', since: addUnit(month, 'month', -(Math.max(1, foreverCount) - 1)), count: Math.max(1, foreverCount) },
+  };
+}
+
+// Dense per-bucket signature counts for one period, oldest first, current
+// bucket last. Missing buckets fill 0.
+async function bucketSeries(userId: number, spec: SeriesSpec): Promise<number[]> {
+  const { rows } = await db.query<{ bucket: string; count: string }>(
+    `SELECT to_char(date_trunc($2, created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24') AS bucket,
+            COUNT(*)::text AS count
+       FROM user_events
+      WHERE user_id = $1 AND event_type = 'signature' AND created_at >= $3
+      GROUP BY bucket`,
+    [userId, spec.unit, spec.since],
+  );
+  const byBucket = new Map<string, number>();
+  for (const r of rows) byBucket.set(r.bucket, parseInt(r.count, 10));
+  const out: number[] = [];
+  for (let i = 0; i < spec.count; i++) out.push(byBucket.get(bucketKey(addUnit(spec.since, spec.unit, i))) ?? 0);
+  return out;
+}
+
+interface Series { unit: BucketUnit; values: number[] }
+function emptySeries(): Record<PeriodKey, Series> {
+  const specs = seriesSpecs(new Date(), new Date());
+  const out = {} as Record<PeriodKey, Series>;
+  for (const p of PERIODS) out[p] = { unit: specs[p].unit, values: Array(specs[p].count).fill(0) };
+  return out;
+}
 
 router.get('/', async (req, res) => {
   const userId = req.session.userId;
@@ -35,7 +112,7 @@ router.get('/', async (req, res) => {
       forever: emptyPeriod(), year: emptyPeriod(), month: emptyPeriod(),
       week: emptyPeriod(), day: emptyPeriod(),
     };
-    return res.json({ ...empty, daily: Array(DAILY_DAYS).fill(0) });
+    return res.json({ ...empty, series: emptySeries() });
   }
 
   const now   = new Date();
@@ -45,23 +122,16 @@ router.get('/', async (req, res) => {
   const year  = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
   const bucketParams = [userId, year, month, week, day];
 
-  // Daily series window — go back DAILY_DAYS-1 days at UTC midnight so today
-  // sits in the right-most slot regardless of the current hour.
-  const dailySince = new Date(now);
-  dailySince.setUTCHours(0, 0, 0, 0);
-  dailySince.setUTCDate(dailySince.getUTCDate() - (DAILY_DAYS - 1));
-
-  // Three parallel queries. Both jumps and sigs read the append-only
-  // user_events log (event_type 'jump' / 'signature'), so the figures are a
-  // record of ACTIVITY — how much you scanned/jumped in the window — and are
-  // immune to later deletions or overwrite-paste removals. (Earlier the sig
-  // counts came from the live map_signatures table, which undercounted: a
-  // heavy scan yesterday that was since re-scanned/cleared vanished, so "this
-  // week" could read the same as "last 24h".) The sig_type recorded is the
-  // type at scan time; rows logged before the sig_type column carry NULL and
-  // bucket as 'unknown'.
-  //   daily — per-day scan count for the last DAILY_DAYS days (sparkline)
-  const [jumpRes, sigRes, dailyRes] = await Promise.all([
+  // Both jumps and sigs read the append-only user_events log (event_type
+  // 'jump' / 'signature'), so the figures are a record of ACTIVITY — how much
+  // you scanned/jumped in the window — and are immune to later deletions or
+  // overwrite-paste removals. (Earlier the sig counts came from the live
+  // map_signatures table, which undercounted: a heavy scan yesterday that was
+  // since re-scanned/cleared vanished, so "this week" could read the same as
+  // "last 24h".) The sig_type recorded is the type at scan time; rows logged
+  // before the sig_type column carry NULL and bucket as 'unknown'.
+  //   min — first signature event, so "all time" knows how many months to span.
+  const [jumpRes, sigRes, minRes] = await Promise.all([
     db.query<{ forever: string; year: string; month: string; week: string; day: string }>(
       `SELECT
          COUNT(*)::text                                  AS forever,
@@ -86,14 +156,11 @@ router.get('/', async (req, res) => {
        GROUP BY sig_type`,
       bucketParams,
     ),
-    db.query<{ bucket: string; count: string }>(
-      `SELECT date_trunc('day', created_at AT TIME ZONE 'UTC')::date::text AS bucket,
-              COUNT(*)::text                                                AS count
+    db.query<{ min: string | null }>(
+      `SELECT MIN(created_at)::text AS min
          FROM user_events
-        WHERE user_id = $1 AND event_type = 'signature'
-          AND created_at >= $2
-        GROUP BY bucket`,
-      [userId, dailySince],
+        WHERE user_id = $1 AND event_type = 'signature'`,
+      [userId],
     ),
   ]);
 
@@ -126,18 +193,15 @@ router.get('/', async (req, res) => {
     }
   }
 
-  // Build a dense DAILY_DAYS-long array, oldest first, today last.
-  const byBucket = new Map<string, number>();
-  for (const row of dailyRes.rows) byBucket.set(row.bucket, parseInt(row.count, 10));
-  const daily: number[] = [];
-  for (let i = 0; i < DAILY_DAYS; i++) {
-    const d = new Date(dailySince);
-    d.setUTCDate(d.getUTCDate() + i);
-    const key = d.toISOString().slice(0, 10);
-    daily.push(byBucket.get(key) ?? 0);
-  }
+  // One activity series per period, at the period's own granularity, so the
+  // chart follows the selected range instead of always showing 30 days.
+  const firstEvent = minRes.rows[0]?.min ? new Date(minRes.rows[0].min) : now;
+  const specs = seriesSpecs(now, firstEvent);
+  const seriesValues = await Promise.all(PERIODS.map((p) => bucketSeries(userId, specs[p])));
+  const series = {} as Record<PeriodKey, Series>;
+  PERIODS.forEach((p, i) => { series[p] = { unit: specs[p].unit, values: seriesValues[i] }; });
 
-  res.json({ ...result, daily });
+  res.json({ ...result, series });
 });
 
 export default router;

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "3.11.0",
+  "version": "3.11.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -44,6 +44,20 @@ function deriveStatus(remainingFraction: number): MassStatus {
   return 'stable';
 }
 
+// Inverse of deriveStatus: the most-remaining edge of each status band. Used
+// when the pilot picks a mass status by hand (they eyeballed the hole in-game,
+// or someone else rolled it) so the rolling calculator reflects that state
+// instead of only counting passes it saw. Each maps to the boundary — the
+// optimistic edge — of its band: destabilized = 50% left, critical = 10% left.
+const STATUS_REMAINING_FRACTION: Record<MassStatus, number> = {
+  stable:       1.0,
+  destabilized: 0.50,
+  critical:     0.10,
+};
+function massUsedForStatus(status: MassStatus, totalMass: number): number {
+  return Math.round(totalMass * (1 - STATUS_REMAINING_FRACTION[status]));
+}
+
 // Match a sig's `whLeadsTo` against the other endpoint. The dropdown can
 // store either a class abbrev ("C2") or a system name ("J123456"), so we
 // accept either.
@@ -244,6 +258,19 @@ export function ConnectionPanel() {
     update({ massUsed: 0, massStatus: 'stable' });
   };
 
+  // Picking a mass status by hand also seeds massUsed to that band's boundary,
+  // so the rolling calculator's remaining estimate reflects the chosen state
+  // (setting Critical drops "left" to ~10%, not the full bar). The previous
+  // per-pass undo history no longer matches, so clear it (keep the roll side).
+  const changeMassStatus = (status: MassStatus) => {
+    if (whSpec) update({ massStatus: status, massUsed: massUsedForStatus(status, whSpec.totalMass) });
+    else        update({ massStatus: status });
+    if (conn && stack.length) {
+      setStack([]);
+      saveSession(conn.id, { side, stack: [] });
+    }
+  };
+
   // Wormhole-only fields (type, sig link, mass / time / size, rolling calc)
   // don't apply to stargates or Ansiblex jump bridges — only 'standard' links.
   const isWormhole = conn.connectionType === 'standard';
@@ -323,7 +350,7 @@ export function ConnectionPanel() {
         <span>{t('connPanel.massStatus')}</span>
         <Select
           value={conn.massStatus ?? ''}
-          onChange={(v) => update({ massStatus: v as MassStatus })}
+          onChange={(v) => changeMassStatus(v as MassStatus)}
           options={[
             { value: 'stable', label: t('connPanel.stable') },
             { value: 'destabilized', label: t('connPanel.destabilized') },

--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -214,7 +214,13 @@ export function ConnectionPanel() {
   const addMass = (kg: number) => {
     if (!whSpec) return;
     const next = Math.max(0, massUsed + kg);
-    const nextStatus = deriveStatus((whSpec.totalMass - next) / whSpec.totalMass);
+    // Derive the status from the WORST-case remaining — the same basis as the
+    // calculator's fill bar and pass warnings — so a pass that pushes the hole
+    // into the critical band flags Critical, not just Destabilized. Deriving
+    // from nominal here lagged: the bar went red while the dropdown stayed
+    // destabilized.
+    const r = massRange(whSpec.totalMass, next);
+    const nextStatus = deriveStatus(r.worstRemaining / (r.worstTotal || 1));
     update({ massUsed: next, massStatus: nextStatus });
   };
 

--- a/web/src/components/ui/UserStatsModal.tsx
+++ b/web/src/components/ui/UserStatsModal.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { XIcon } from '@phosphor-icons/react';
-import { useStats, type StatPeriod, type SigBreakdown } from '../../hooks/useStats';
+import { useStats, type StatPeriod, type SigBreakdown, type BucketUnit } from '../../hooks/useStats';
 
 const SPARK_VB_W = 600;
 const SPARK_VB_H = 80;
 const SPARK_PAD  = { top: 6, right: 6, bottom: 18, left: 28 };
 const SPARK_COLOR = '#6ea0ff';
 
-function SigSparkline({ values }: { values: number[] }) {
+function SigSparkline({ values, unit }: { values: number[]; unit: BucketUnit }) {
   const { t } = useTranslation();
   const n      = values.length;
   const iw     = SPARK_VB_W - SPARK_PAD.left - SPARK_PAD.right;
@@ -26,10 +26,18 @@ function SigSparkline({ values }: { values: number[] }) {
 
   // Y ticks: 0, mid, max
   const yTicks = [...new Set([0, Math.round(maxVal / 2), maxVal])];
-  // X ticks: 30d ago (left) and today (right)
+  // Relative label for a bucket, given how many buckets back from the current
+  // one it sits (0 = current). Wording follows the series granularity.
+  const relLabel = (back: number): string => {
+    if (unit === 'hour')  return back === 0 ? t('time.now')       : t('time.hoursAgo',  { value: back });
+    if (unit === 'month') return back === 0 ? t('time.thisMonth') : t('time.monthsAgo', { value: back });
+    return                       back === 0 ? t('time.today')     : t('time.daysAgo',   { value: back });
+  };
+
+  // X ticks: oldest bucket (left) and current bucket (right).
   const xLabels: { x: number; label: string }[] = n > 0 ? [
-    { x: xOf(0),     label: t('time.daysAgo', { value: n - 1 }) },
-    { x: xOf(n - 1), label: t('time.today') },
+    { x: xOf(0),     label: relLabel(n - 1) },
+    { x: xOf(n - 1), label: relLabel(0) },
   ] : [];
 
   return (
@@ -94,7 +102,7 @@ function SigSparkline({ values }: { values: number[] }) {
       </svg>
       {hover && (
         <div className="stats-modal__spark-tooltip">
-          <strong>{hover.value.toLocaleString()}</strong> sigs · {n - 1 - hover.index === 0 ? t('time.today') : t('time.daysAgo', { value: n - 1 - hover.index })}
+          <strong>{hover.value.toLocaleString()}</strong> sigs · {relLabel(n - 1 - hover.index)}
         </div>
       )}
     </div>
@@ -181,10 +189,10 @@ export function UserStatsModal({ onClose }: Props) {
                 </div>
               </div>
 
-              {stats?.daily && stats.daily.some((v) => v > 0) && (
+              {stats?.series[period] && stats.series[period].values.some((v) => v > 0) && (
                 <>
-                  <h3 className="stats-modal__section-title">{t('stats.dailyActivity')}</h3>
-                  <SigSparkline values={stats.daily} />
+                  <h3 className="stats-modal__section-title">{t('stats.activity')} — {periodLabels[period]}</h3>
+                  <SigSparkline values={stats.series[period].values} unit={stats.series[period].unit} />
                 </>
               )}
 

--- a/web/src/components/ui/UserStatsModal.tsx
+++ b/web/src/components/ui/UserStatsModal.tsx
@@ -157,7 +157,7 @@ export function UserStatsModal({ onClose }: Props) {
 
         <div className="modal__header">
           <h2 className="modal__title">{t('stats.title')}</h2>
-          <button className="modal__close" onClick={onClose}><XIcon size={14} weight="bold" /></button>
+          <button className="icon-btn" onClick={onClose} aria-label={t('actions.close')}><XIcon size={16} weight="bold" /></button>
         </div>
 
         <div className="stats-modal__periods">

--- a/web/src/hooks/useStats.ts
+++ b/web/src/hooks/useStats.ts
@@ -19,9 +19,19 @@ export interface PeriodStats {
   signatures: SigBreakdown;
 }
 
+/** Chart bucket granularity for a period's activity series. */
+export type BucketUnit = 'hour' | 'day' | 'month';
+
+export interface ActivitySeries {
+  /** Bucket size: hourly (24h), daily (week/month), monthly (year/all-time). */
+  unit:   BucketUnit;
+  /** Sig counts per bucket, oldest first, current bucket last. */
+  values: number[];
+}
+
 export type StatsResponse = Record<StatPeriod, PeriodStats> & {
-  /** Sig counts per day for the last 30 days, oldest first, today last. */
-  daily: number[];
+  /** One activity series per period, at that period's own granularity. */
+  series: Record<StatPeriod, ActivitySeries>;
 };
 
 export function useStats(open: boolean) {

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1151,6 +1151,7 @@
     "loading": "Lädt…",
     "jumps": "Sprünge",
     "signatures": "Signaturen",
+    "activity": "Aktivität",
     "dailyActivity": "Tägliche Aktivität — letzte 30 Tage",
     "byType": "Signaturen nach Typ",
     "type": "Typ",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "vor {{value}}m",
     "hoursAgo": "vor {{value}}h",
     "daysAgo": "vor {{value}}t",
+    "now": "jetzt",
+    "monthsAgo": "vor {{value}} Mon.",
+    "thisMonth": "dieser Monat",
     "today": "heute"
   },
   "duration": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1221,6 +1221,7 @@
     "loading": "Loading…",
     "jumps": "Jumps",
     "signatures": "Signatures",
+    "activity": "Activity",
     "dailyActivity": "Daily activity — last 30 days",
     "byType": "Signatures by type",
     "type": "Type",
@@ -1239,6 +1240,9 @@
     "minutesAgo": "{{value}}m ago",
     "hoursAgo": "{{value}}h ago",
     "daysAgo": "{{value}}d ago",
+    "now": "now",
+    "monthsAgo": "{{value}}mo ago",
+    "thisMonth": "this month",
     "today": "today"
   },
   "duration": {

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1151,6 +1151,7 @@
     "loading": "Cargando…",
     "jumps": "Saltos",
     "signatures": "Firmas",
+    "activity": "Actividad",
     "dailyActivity": "Actividad diaria — últimos 30 días",
     "byType": "Firmas por tipo",
     "type": "Tipo",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "hace {{value}}m",
     "hoursAgo": "hace {{value}}h",
     "daysAgo": "hace {{value}}d",
+    "now": "ahora",
+    "monthsAgo": "hace {{value}} meses",
+    "thisMonth": "este mes",
     "today": "hoy"
   },
   "duration": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1151,6 +1151,7 @@
     "loading": "Chargement…",
     "jumps": "Sauts",
     "signatures": "Signatures",
+    "activity": "Activité",
     "dailyActivity": "Activité quotidienne — 30 derniers jours",
     "byType": "Signatures par type",
     "type": "Type",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "il y a {{value}}m",
     "hoursAgo": "il y a {{value}}h",
     "daysAgo": "il y a {{value}}j",
+    "now": "maintenant",
+    "monthsAgo": "il y a {{value}} mois",
+    "thisMonth": "ce mois-ci",
     "today": "aujourd'hui"
   },
   "duration": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1151,6 +1151,7 @@
     "loading": "読み込み中…",
     "jumps": "ジャンプ",
     "signatures": "シグネチャ",
+    "activity": "アクティビティ",
     "dailyActivity": "日別アクティビティ — 過去30日",
     "byType": "タイプ別シグネチャ",
     "type": "タイプ",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "{{value}}分前",
     "hoursAgo": "{{value}}時間前",
     "daysAgo": "{{value}}日前",
+    "now": "現在",
+    "monthsAgo": "{{value}}か月前",
+    "thisMonth": "今月",
     "today": "今日"
   },
   "duration": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1151,6 +1151,7 @@
     "loading": "불러오는 중…",
     "jumps": "점프",
     "signatures": "시그니처",
+    "activity": "활동",
     "dailyActivity": "일별 활동 — 지난 30일",
     "byType": "유형별 시그니처",
     "type": "유형",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "{{value}}분 전",
     "hoursAgo": "{{value}}시간 전",
     "daysAgo": "{{value}}일 전",
+    "now": "지금",
+    "monthsAgo": "{{value}}개월 전",
+    "thisMonth": "이번 달",
     "today": "오늘"
   },
   "duration": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1151,6 +1151,7 @@
     "loading": "A carregar…",
     "jumps": "Saltos",
     "signatures": "Assinaturas",
+    "activity": "Atividade",
     "dailyActivity": "Atividade diária — últimos 30 dias",
     "byType": "Assinaturas por tipo",
     "type": "Tipo",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "há {{value}}m",
     "hoursAgo": "há {{value}}h",
     "daysAgo": "há {{value}}d",
+    "now": "agora",
+    "monthsAgo": "há {{value}} meses",
+    "thisMonth": "este mês",
     "today": "hoje"
   },
   "duration": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1189,6 +1189,7 @@
     "loading": "Загрузка…",
     "jumps": "Прыжки",
     "signatures": "Сигнатуры",
+    "activity": "Активность",
     "dailyActivity": "Дневная активность — последние 30 дней",
     "byType": "Сигнатуры по типу",
     "type": "Тип",
@@ -1207,6 +1208,9 @@
     "minutesAgo": "{{value}} мин назад",
     "hoursAgo": "{{value}} ч назад",
     "daysAgo": "{{value}} дн назад",
+    "now": "сейчас",
+    "monthsAgo": "{{value}} мес. назад",
+    "thisMonth": "этот месяц",
     "today": "сегодня"
   },
   "duration": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1151,6 +1151,7 @@
     "loading": "加载中…",
     "jumps": "跳跃",
     "signatures": "信号",
+    "activity": "活动",
     "dailyActivity": "每日活动 — 最近 30 天",
     "byType": "按类型分类的信号",
     "type": "类型",
@@ -1169,6 +1170,9 @@
     "minutesAgo": "{{value}} 分钟前",
     "hoursAgo": "{{value}} 小时前",
     "daysAgo": "{{value}} 天前",
+    "now": "现在",
+    "monthsAgo": "{{value}}个月前",
+    "thisMonth": "本月",
     "today": "今天"
   },
   "duration": {

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -4,7 +4,7 @@
 
 /* ── User Stats Modal ────────────────────────────────────── */
 .stats-modal {
-  width: 560px;
+  width: min(720px, 94vw);
 }
 
 .stats-modal__periods {


### PR DESCRIPTION
## v3.11.1

**Your activity graph now matches the time range you pick.** Open your stats and the chart follows the button you press — Last 24h shows an hour-by-hour line, a week or month shows daily, and a year or all-time shows month-by-month. Before, it always showed the same fixed 30 days no matter what, and the 24h view had no graph at all.

**A roomier stats window.** The User Stats panel is wider by default, so the time-range buttons no longer run off the edge and the chart and table have space to breathe.

**Rolling calculator now tracks the hole's mass status.** Two fixes: setting a connection's Mass status to Destabilized or Critical by hand now updates the calculator's remaining-mass estimate (before, marking a hole Critical still showed it as nearly full and "safe to keep rolling"). And rolling passes now flag the hole **Critical** on their own when it enters the critical band — previously the mass bar went red but the status dropdown stayed stuck on Destabilized.

**Small polish.** The stats window's close button now matches every other window in the app.

---
Version bumped to 3.11.1 (web + server). Tag `v3.11.1` will be cut on merge.