### PR TITLE
Fix: rolling calculator mass-status consistency (manual set + auto-critical)

### DIFF
--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -44,6 +44,20 @@ function deriveStatus(remainingFraction: number): MassStatus {
   return 'stable';
 }
 
+// Inverse of deriveStatus: the most-remaining edge of each status band. Used
+// when the pilot picks a mass status by hand (they eyeballed the hole in-game,
+// or someone else rolled it) so the rolling calculator reflects that state
+// instead of only counting passes it saw. Each maps to the boundary — the
+// optimistic edge — of its band: destabilized = 50% left, critical = 10% left.
+const STATUS_REMAINING_FRACTION: Record<MassStatus, number> = {
+  stable:       1.0,
+  destabilized: 0.50,
+  critical:     0.10,
+};
+function massUsedForStatus(status: MassStatus, totalMass: number): number {
+  return Math.round(totalMass * (1 - STATUS_REMAINING_FRACTION[status]));
+}
+
 // Match a sig's `whLeadsTo` against the other endpoint. The dropdown can
 // store either a class abbrev ("C2") or a system name ("J123456"), so we
 // accept either.
@@ -244,6 +258,19 @@ export function ConnectionPanel() {
     update({ massUsed: 0, massStatus: 'stable' });
   };
 
+  // Picking a mass status by hand also seeds massUsed to that band's boundary,
+  // so the rolling calculator's remaining estimate reflects the chosen state
+  // (setting Critical drops "left" to ~10%, not the full bar). The previous
+  // per-pass undo history no longer matches, so clear it (keep the roll side).
+  const changeMassStatus = (status: MassStatus) => {
+    if (whSpec) update({ massStatus: status, massUsed: massUsedForStatus(status, whSpec.totalMass) });
+    else        update({ massStatus: status });
+    if (conn && stack.length) {
+      setStack([]);
+      saveSession(conn.id, { side, stack: [] });
+    }
+  };
+
   // Wormhole-only fields (type, sig link, mass / time / size, rolling calc)
   // don't apply to stargates or Ansiblex jump bridges — only 'standard' links.
   const isWormhole = conn.connectionType === 'standard';
@@ -323,7 +350,7 @@ export function ConnectionPanel() {
         <span>{t('connPanel.massStatus')}</span>
         <Select
           value={conn.massStatus ?? ''}
-          onChange={(v) => update({ massStatus: v as MassStatus })}
+          onChange={(v) => changeMassStatus(v as MassStatus)}
           options={[
             { value: 'stable', label: t('connPanel.stable') },
             { value: 'destabilized', label: t('connPanel.destabilized') },

--- a/web/src/components/ui/ConnectionPanel.tsx
+++ b/web/src/components/ui/ConnectionPanel.tsx
@@ -214,7 +214,13 @@ export function ConnectionPanel() {
   const addMass = (kg: number) => {
     if (!whSpec) return;
     const next = Math.max(0, massUsed + kg);
-    const nextStatus = deriveStatus((whSpec.totalMass - next) / whSpec.totalMass);
+    // Derive the status from the WORST-case remaining — the same basis as the
+    // calculator's fill bar and pass warnings — so a pass that pushes the hole
+    // into the critical band flags Critical, not just Destabilized. Deriving
+    // from nominal here lagged: the bar went red while the dropdown stayed
+    // destabilized.
+    const r = massRange(whSpec.totalMass, next);
+    const nextStatus = deriveStatus(r.worstRemaining / (r.worstTotal || 1));
     update({ massUsed: next, massStatus: nextStatus });
   };
 


### PR DESCRIPTION
Two related bugs in the connection panel's rolling calculator, both from the mass **status** and the mass **used** figure being derived on different bases.

## 1. Manual status change didn't touch the calculator
Setting the **Mass status** dropdown to Destabilized/Critical wrote only `conn.massStatus`; the calculator reads `conn.massUsed`, so a hole marked Critical still showed the full ~1.8-2.2 B kg "left" and "safe to keep rolling".

**Fix:** picking a status by hand now seeds `massUsed` to that band's most-remaining boundary — Destabilized = 50% left, Critical = 10% left (the in-game nominal meaning) — via `massUsedForStatus` (inverse of `deriveStatus`). Stale undo stack is cleared (roll side kept). Unknown WH type (no `totalMass`) just sets the status.

## 2. Passes auto-flagged Destabilized but never Critical
Rolling passes derived the saved status from **nominal** remaining, while the calculator's fill bar + pass warnings use **worst-case** remaining. So a hole rolled until the bar went solid-red critical still showed **Destabilized** in the dropdown — it flagged <50% on time but never reached Critical.

**Fix:** `addMass` now derives the status from the same worst-case basis as the bar (`massRange().worstRemaining / worstTotal`, matching the existing `fillStatus`), so a pass into the critical band flags Critical and the dropdown tracks the bar.

`tsc` clean, lint 0 errors. No i18n changes.