### PR TITLE
Multibox: per-tab acting character (resolve location by explicit char id)

### DIFF
--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -132,6 +132,19 @@ characterRouter.get('/location', async (req, res) => {
 characterRouter.get('/:targetUserId/location', async (req, res) => {
   const targetUserId = Number(req.params.targetUserId);
   if (!Number.isInteger(targetUserId)) { res.status(400).json({ error: 'Invalid user id' }); return; }
+  // Your own session character is always authorised — identical to
+  // /api/character/location. The per-tab acting-character model resolves every
+  // tab's location by explicit id (including the default = your own char), so
+  // this path must work without depending on owner_id being populated.
+  if (targetUserId === req.session.userId) {
+    try {
+      res.json(await getLocationPayload(targetUserId));
+    } catch (err) {
+      log.error('Location check failed:', err);
+      res.status(500).json({ error: 'Failed to get location' });
+    }
+    return;
+  }
   const ownerId = await resolveOwnerId(req);
   if (ownerId == null) { res.status(401).json({ error: 'Not authenticated' }); return; }
   const { rows } = await db.query<{ owner_id: number | null }>(

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -83,15 +83,19 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   }, [showFleetMembers, fleet.bySystem, sys.eveSystemId, user?.characterId]);
 
   // The account's other characters (alts) located in this system — live when
-  // online, else their last known position. The active character has its own
-  // you-are-here dot, so it's excluded server-side.
+  // online, else their last known position. The character THIS TAB acts as has
+  // its own you-are-here dot, so exclude it from the alt list. The session-active
+  // character is already excluded server-side; this also drops a PINNED acting
+  // character (which the server doesn't know about), so it never shows as both a
+  // you-are-here dot and an alt dot.
   const accountLocations     = useAccountLocations();
   const [showAccountChars]   = useUserSetting<boolean>('nexum.account.showOnMap', true);
+  const actingUserId = useMapStore((s) => s.routeOrigin?.charId ?? null) ?? user?.id ?? null;
   const accountHere = useMemo(() => {
     if (!showAccountChars || sys.eveSystemId == null) return undefined;
-    const here = accountLocations.bySystem.get(sys.eveSystemId);
+    const here = accountLocations.bySystem.get(sys.eveSystemId)?.filter((c) => c.charId !== actingUserId);
     return here && here.length ? here : undefined;
-  }, [showAccountChars, accountLocations.bySystem, sys.eveSystemId]);
+  }, [showAccountChars, accountLocations.bySystem, sys.eveSystemId, actingUserId]);
 
   // Other people viewing this map who are currently in this system (presence).
   // Excludes self — the green you-are-here dot covers that. Subscribe to just

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -262,7 +262,10 @@ export function Toolbar() {
   // The character THIS TAB acts as: the per-tab pinned character (a routeOrigin
   // override) when set, else the session-active character. The avatar, name and
   // you-are-here follow it; the role badge stays on the session identity below.
-  const actingCharId = useMapStore((s) => s.routeOrigin?.charId ?? null);
+  // The character THIS TAB acts as: the per-tab pinned character, else the tab's
+  // own (session-active) character — resolved to an explicit users.id so the
+  // name/avatar always match the location (which is now resolved by the same id).
+  const actingCharId = useMapStore((s) => s.routeOrigin?.charId ?? null) ?? user?.id ?? null;
   const actingChar = actingCharId != null ? (user?.characters?.find((c) => c.id === actingCharId) ?? null) : null;
   // Ship + live system come from the same poll that drives passive location
   // tracking, so no extra ESI traffic — we just surface fields already on hand.

--- a/web/src/hooks/useCharacterLocation.ts
+++ b/web/src/hooks/useCharacterLocation.ts
@@ -3,13 +3,7 @@ import { api } from '../api/client';
 import { flushQueue } from '../store/pendingQueue';
 import { useShareMode } from '../context/ShareModeContext';
 import { useMapStore } from '../store/mapStore';
-
-// The character THIS TAB acts as: the per-tab pinned character (a routeOrigin
-// override) when one is set, otherwise null to follow the session-active
-// character via the shared active-location endpoint.
-function actingCharId(): number | null {
-  try { return useMapStore.getState().routeOrigin?.charId ?? null; } catch { return null; }
-}
+import { useAuth } from '../context/AuthContext';
 
 export interface CharacterLocationSystem {
   eveSystemId: number;
@@ -44,10 +38,19 @@ interface RawLocationResponse {
 const POLL_MS = 10_000;
 const EMPTY: CharacterLocation = { online: false, system: null, ship: null };
 
+// The users.id of the character THIS TAB currently acts as: the per-tab pinned
+// character (routeOrigin) when set, else the tab's own session-active character.
+// Kept in a module var (written by the hook, which has the auth context) so the
+// shared poll can read it. Location is ALWAYS resolved by explicit id via
+// /api/character/:id/location — never the session-global /api/character/location
+// — so a tab's location always matches the character it displays, even when
+// another tab has switched the session identity out from under it.
+let currentActingId: number | null = null;
+
 let moduleCache: { charId: number | null; data: CharacterLocation; fetchedAt: number } | null = null;
 let inflight: Promise<CharacterLocation> | null = null;
-// The acting char id the current in-flight request is for — so an in-flight
-// fetch is only reused when it's for the SAME character, not a stale one.
+// The acting char id the in-flight request is for — so we only reuse it when
+// it's still the character we want, not a stale one.
 let inflightCharId: number | null = null;
 const subscribers = new Set<(d: CharacterLocation) => void>();
 let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -56,19 +59,18 @@ function notify(d: CharacterLocation) {
   subscribers.forEach(fn => fn(d));
 }
 
-function load() {
-  const charId = actingCharId();
-  // Reuse an in-flight request only when it's for the character we still want.
+function load(): Promise<CharacterLocation> {
+  const charId = currentActingId;
+  if (charId == null) return Promise.resolve(moduleCache?.data ?? EMPTY);
   if (inflight && inflightCharId === charId) return inflight;
-  const url = charId == null ? '/api/character/location' : '/api/character/' + charId + '/location';
   inflightCharId = charId;
-  inflight = api<RawLocationResponse>(url)
+  inflight = api<RawLocationResponse>(`/api/character/${charId}/location`)
     .then(r => {
       const data: CharacterLocation = { online: r.online, system: r.system, ship: r.ship ?? null };
       inflight = null;
       // The acting character may have changed while this was in flight — if so,
-      // discard the result rather than caching/broadcasting a stale char.
-      if (actingCharId() !== charId) return data;
+      // discard rather than caching/broadcasting a stale character's location.
+      if (currentActingId !== charId) return data;
       moduleCache = { charId, data, fetchedAt: Date.now() };
       // Successful round-trip — give the offline-write queue a chance to drain.
       flushQueue();
@@ -82,23 +84,23 @@ function load() {
   return inflight;
 }
 
+/**
+ * The live location of the character THIS TAB acts as (pinned character, else
+ * the session-active one). A single shared poll; re-points and re-fetches
+ * whenever the acting character changes.
+ */
 export function useCharacterLocation(): CharacterLocation {
   const { isShareMode } = useShareMode();
-  const actingId = useMapStore((s) => s.routeOrigin?.charId ?? null);
+  const { user } = useAuth();
+  const routeCharId = useMapStore((s) => s.routeOrigin?.charId ?? null);
+  // Explicit acting id: a pin, else this tab's own character. Null only before
+  // auth has loaded.
+  const effective = routeCharId ?? user?.id ?? null;
   const [data, setData] = useState<CharacterLocation>(moduleCache?.data ?? EMPTY);
 
   useEffect(() => {
-    // No session in share mode — nothing to poll and nobody to be located.
     if (isShareMode) return;
-
     subscribers.add(setData);
-    const now = Date.now();
-    // Serve the cache synchronously only when it's for the acting character and
-    // still fresh; otherwise fetch. Read the live acting id (not the render-time
-    // `actingId`) so this effect needn't re-run on every character switch — the
-    // dedicated effect below handles switches.
-    if (moduleCache && moduleCache.charId === actingCharId() && now - moduleCache.fetchedAt < POLL_MS) setData(moduleCache.data);
-    else load();
     if (!pollTimer) pollTimer = setInterval(load, POLL_MS);
     return () => {
       subscribers.delete(setData);
@@ -109,14 +111,18 @@ export function useCharacterLocation(): CharacterLocation {
     };
   }, [isShareMode]);
 
-  // Switching the pinned (acting) character must re-fetch right away rather than
-  // waiting for the next poll tick. Invalidate a stale-char cache first so no
-  // consumer briefly reads the previous character's location.
+  // Point the shared poll at the effective acting character and fetch right away
+  // whenever it changes (pin toggled, or the session identity changed).
   useEffect(() => {
     if (isShareMode) return;
-    if (moduleCache && moduleCache.charId !== actingId) moduleCache = null;
-    load();
-  }, [actingId, isShareMode]);
+    currentActingId = effective;
+    if (moduleCache && moduleCache.charId === effective && Date.now() - moduleCache.fetchedAt < POLL_MS) {
+      setData(moduleCache.data);
+    } else {
+      if (moduleCache && moduleCache.charId !== effective) moduleCache = null;
+      load();
+    }
+  }, [effective, isShareMode]);
 
   return isShareMode ? EMPTY : data;
 }

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useMapStore, getPlacementCell, registerPlacementFix } from '../store/mapStore';
 import { useCharacterLocation } from './useCharacterLocation';
 import { useCanEdit } from './useCanEdit';
+import { useAuth } from '../context/AuthContext';
 import { readUserSetting } from './useUserSetting';
 import { pickHandles } from '../components/map/edgeUtils';
 import { maybeConfirmWhJump } from './whJumpConfirm';
@@ -259,7 +260,11 @@ export function applyTrackedJump(
  */
 export function useLocationTracking(enabled: boolean) {
   const location = useCharacterLocation();
-  const followedId = useMapStore((s) => s.routeOrigin?.charId ?? null);
+  const { user } = useAuth();
+  // The effective acting character (pin, else this tab's own character). Any
+  // change to it must reset the jump refs below, so the new character's system
+  // isn't linked back to the previous character's as a bogus connection.
+  const followedId = useMapStore((s) => s.routeOrigin?.charId ?? null) ?? user?.id ?? null;
   const canEdit  = useCanEdit();
   const lastEveSystemId = useRef<number | null>(null);
   const lastMapSystemId = useRef<string | null>(null);


### PR DESCRIPTION
Completes the per-tab multibox work (the final, working version). Sits on top of the earlier per-tab groundwork already on qa (#536/#537/#538); this commit is the fix that makes it actually correct.

### The bug it fixes
A browser has one login session = one session-active character. When a tab had **no pin**, its location was fetched from the session-global `/api/character/location`, which returns whatever character the *server session* is — so a second tab showed the wrong character's location ("addelee @ Emsar") and center-on-me landed wrong.

### The fix
- **`useCharacterLocation`** now ALWAYS resolves by an explicit character id (`routeOrigin.charId ?? user.id`) via `/api/character/:id/location` — that character's own token returns its own real location, so a tab's name and location always agree, regardless of what another tab did to the login. The shared poll re-points and re-fetches when the acting character changes (cache keyed by char, in-flight requests discarded on switch).
- **Server:** `/api/character/:id/location` gains an explicit fast-path for your own session character, so the default never depends on `owner_id` being populated.
- **Toolbar** name/avatar/last-known resolve the same way (`?? user.id`), so they match the location.
- **SystemNode** excludes the acting character (pin or own) from the on-map alt dots, so a pinned character isn't shown as both a you-are-here dot and an alt dot.
- **useLocationTracking** resets its jump refs on any effective-acting-character change (not just an explicit pin), so switching a tab's character never draws a phantom cross-character connection.

### Multibox workflow
Log in as one character, leave that tab on default, and pin the *other* character in its tab (the 📍 focus button). Both tabs track live onto their own maps with correct location + center-on-me, no cross-talk.

**Needs the server deployed with the web build** (the own-character fast-path is a server change). `tsc` clean (server + web), server tests pass, lint 0 errors. No new i18n.