### PR TITLE
Release v3.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,14 @@ Traefik will handle TLS termination and HTTP→HTTPS redirects. The `docker-comp
 > ```
 > After that, plain `docker compose ...` automatically loads both files. Add the export to `~/.bashrc` / `~/.zshrc` if it's the only deployment on that host.
 
+**4. Reaching Postgres from the host (optional)**
+
+By default Postgres is internal to the compose network — nothing on the host can connect to it. To expose it for backups, a `psql` client, or a monitoring probe, set `PG_HOST_BIND` and add the `docker-compose.dbhost.yml` overlay:
+```bash
+PG_HOST_BIND=127.0.0.1 docker compose -f docker-compose.yml -f docker-compose.dbhost.yml up -d
+```
+It binds **loopback only** (`127.0.0.1:5432`) by default, so the port is reachable from the host machine but not from the network. `build-traefik.sh` adds this overlay automatically whenever `PG_HOST_BIND` is set, so under a secrets manager you just put `PG_HOST_BIND=127.0.0.1` in your secrets — no local compose edit. Set `PG_HOST_BIND=0.0.0.0` only if you deliberately want it on all interfaces (rarely a good idea).
+
 App-schema migrations (`users`, `maps`, `map_signatures`, etc.) layer on automatically the first time the server boots — no manual step.
 
 > **Schema ownership.** The one-shot importer (`server/scripts/setup-db.ts`) creates only the **static/SDE** schema and its indexes (`solar_systems`, `map_stargates`, `item_types`, …) — it must not depend on app columns the server migration adds later, since the importer runs *before* the server boots. **App-table indexes are owned by `server/src/migrate.ts`**, which creates them after the app columns are guaranteed to exist. (Keeping an app-table index in the importer would crash a fresh bootstrap on a missing column.)

--- a/build-traefik.ps1
+++ b/build-traefik.ps1
@@ -17,6 +17,14 @@ Set-Location -Path $PSScriptRoot
 
 $compose = @('-f', 'docker-compose.yml', '-f', 'docker-compose.traefik.yml')
 
+# Opt-in: set PG_HOST_BIND to publish Postgres on the host (loopback by
+# default - see docker-compose.dbhost.yml). Unset => Postgres stays internal to
+# the compose network. Under a secrets manager, put PG_HOST_BIND in your secrets.
+if (-not [string]::IsNullOrEmpty($env:PG_HOST_BIND)) {
+    $compose += @('-f', 'docker-compose.dbhost.yml')
+    Write-Host "==> PG_HOST_BIND=$($env:PG_HOST_BIND) set: publishing Postgres on the host" -ForegroundColor Cyan
+}
+
 # External commands (git/docker) don't throw on non-zero exit, so check
 # $LASTEXITCODE after each and stop if it failed.
 function Invoke-Step {

--- a/build-traefik.sh
+++ b/build-traefik.sh
@@ -21,6 +21,15 @@ main() {
 
   local compose=(-f docker-compose.yml -f docker-compose.traefik.yml)
 
+  # Opt-in: set PG_HOST_BIND to publish Postgres on the host (loopback by
+  # default -- see docker-compose.dbhost.yml). Unset => Postgres stays internal
+  # to the compose network. Under Infisical, put PG_HOST_BIND in your secrets
+  # and run this via `infisical run -- ./build-traefik.sh`.
+  if [[ -n "${PG_HOST_BIND:-}" ]]; then
+    compose+=(-f docker-compose.dbhost.yml)
+    echo "==> PG_HOST_BIND=${PG_HOST_BIND} set: publishing Postgres on the host"
+  fi
+
   echo "==> [1/3] git pull"
   git pull
 

--- a/docker-compose.dbhost.yml
+++ b/docker-compose.dbhost.yml
@@ -1,0 +1,19 @@
+# Optional overlay: publish Postgres to the HOST so tools on the machine
+# (backups, a psql client, a secrets-manager health check) can reach it.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dbhost.yml up -d
+#
+# Bound to loopback (127.0.0.1) by DEFAULT, so the port is reachable only from
+# the host itself -- it is NOT exposed to the LAN or the internet. Change the
+# interface with PG_HOST_BIND, e.g. PG_HOST_BIND=0.0.0.0 to expose it on all
+# interfaces (you almost certainly should NOT -- Postgres is passworded but
+# there's no reason to put it on a public interface).
+#
+# build-traefik.sh includes this overlay automatically whenever PG_HOST_BIND is
+# set in the environment, so under Infisical you just add PG_HOST_BIND=127.0.0.1
+# to your secrets and no local compose edit is needed. Combine with the Traefik
+# overlay by passing all three files (base + traefik + dbhost).
+services:
+  postgres:
+    ports:
+      - "${PG_HOST_BIND:-127.0.0.1}:5432:5432"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "3.14.1",
+  "version": "3.14.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "3.14.1",
+  "version": "3.14.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {


### PR DESCRIPTION
Patch release -- operator/deploy change only, nothing pilot-facing.

**Why:** operators running nexum behind a secrets manager (Infisical) or on a locked-down host had to hand-edit `docker-compose.yml` to reach the database from the host -- and that edit conflicted on every `git pull`, breaking deploys. This makes host DB access a supported, opt-in option so no local edits are needed.

**What changed:**
- New `docker-compose.dbhost.yml` overlay publishes Postgres to the host, **bound to loopback (`127.0.0.1`) by default** -- reachable only from the machine, never the network.
- The prod deploy scripts (`build-traefik.sh` / `build-traefik.ps1`) pick up the overlay automatically when `PG_HOST_BIND` is set, so it can be driven entirely from your secrets manager.
- Default is unchanged: without `PG_HOST_BIND`, Postgres stays internal to the compose network.

No app behaviour changes; nothing to notice in the map.

After merge: tag `v3.14.2` and cut the GitHub release.