### PR TITLE
Fix placement never using the up/left slots (snap-rounding)

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -67,8 +67,15 @@ export function findFreePosition(
   direction: PlacementDirection,
   snap: boolean,
 ): { x: number; y: number } {
+  // When snap-to-grid is on and the source isn't grid-aligned, `place()` rounds
+  // each candidate up to GRID/2 toward its neighbours. The up/left cardinal
+  // slots sit at an exact box boundary, so that rounding tips them into a false
+  // collision and the ring silently skips those directions — nothing ever lands
+  // above/left of the source. Relax the collision margin by that rounding
+  // tolerance so every slot stays reachable; the step spacing is unchanged.
+  const collideGap = snap ? Math.max(0, gap - GRID / 2) : gap;
   const collides = (x: number, y: number) =>
-    systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, gap));
+    systems.some((s) => boxesOverlap(x, y, s.position.x, s.position.y, w, h, collideGap));
 
   // Grid-aligned step: a whole node footprint rounded up to the grid plus the
   // fixed gap, so spacing is consistent instead of drifting with node width.


### PR DESCRIPTION
Follow-up to the "Add adjacent" feature: systems never landed **above** (or left of) the source -- the whole top half stayed empty even though the up slot is the 4th in the ring.

**Root cause (reproduced deterministically):** `findFreePosition` silently skipped the north/west cardinal slots whenever **snap-to-grid is on AND the source node is not grid-aligned**. `place()` rounds each candidate up to `GRID/2` toward its neighbours; the up/left slots sit at an *exact* box boundary, so that nudge trips a false collision. The ring then falls through to the down/right diagonals -- so nothing ever lands above/left. (Snap-off placement was already perfect, which is why it only showed up sometimes.)

**Fix:** relax the collision margin by the snap rounding tolerance (`GRID/2`) when snapping, so an exactly-adjacent snapped candidate is not read as overlapping. Verified in isolation: the ring is restored to `E, S, W, N, SE, SW, NW, NE`.

- **Step spacing unchanged** -- nodes still sit a full gap apart; only the collision *rejection* threshold is relaxed by 10px.
- **Snap off: identical behaviour** (tolerance is 0).
- Fixes the **shared** placement used by live jump-tracking too, which had the same latent bug.

No schema change, no server change, no i18n. `tsc` + eslint clean.

**Test:** on a map where the home/source system is off-grid with snap-to-grid on, right-click a k-space system and add several neighbours -- they should now fill above the source too, following your placement direction.