### PR TITLE
deploy: --remove-orphans on up + prune dangling images

### DIFF
--- a/build-traefik.ps1
+++ b/build-traefik.ps1
@@ -36,7 +36,16 @@ function Invoke-Step {
 
 Invoke-Step '[1/3] git pull'             { git pull }
 Invoke-Step '[2/3] docker compose build' { docker compose @compose build }
-Invoke-Step '[3/3] docker compose up -d' { docker compose @compose up -d }
+# up -d reconciles (only changed services are recreated); --remove-orphans also
+# drops containers for services deleted from the compose files. Scoped to this
+# compose project, so a separate stack (e.g. QA) is untouched.
+Invoke-Step '[3/4] docker compose up -d' { docker compose @compose up -d --remove-orphans }
+
+# Reclaim disk from images this build superseded. Dangling-only (no -a), so it
+# never touches an in-use image. Called directly (not via Invoke-Step) so a
+# non-zero exit is non-fatal and can't fail an otherwise-good deploy.
+Write-Host '==> [4/4] prune dangling images' -ForegroundColor Cyan
+docker image prune -f
 
 Write-Host '==> done. Container status:' -ForegroundColor Green
 docker compose @compose ps

--- a/build-traefik.sh
+++ b/build-traefik.sh
@@ -36,8 +36,20 @@ main() {
   echo "==> [2/3] docker compose build"
   docker compose "${compose[@]}" build
 
-  echo "==> [3/3] docker compose up -d"
-  docker compose "${compose[@]}" up -d
+  echo "==> [3/4] docker compose up -d"
+  # up -d already reconciles: it recomputes each service's config hash and
+  # recreates only the ones whose config or image changed, leaving the rest
+  # running. --remove-orphans also drops containers for services deleted from
+  # the compose files (config-hash reconciliation doesn't cover those, so they'd
+  # otherwise linger unrouted). Scoped to this compose project, so a separate
+  # stack (e.g. QA with its own project name) is untouched.
+  docker compose "${compose[@]}" up -d --remove-orphans
+
+  # Reclaim disk from images this build superseded. Dangling-only (no -a), so it
+  # never touches an image a container is using; non-fatal so a prune hiccup
+  # can't fail an otherwise-good deploy.
+  echo "==> [4/4] prune dangling images"
+  docker image prune -f || true
 
   echo "==> done. Container status:"
   docker compose "${compose[@]}" ps

--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,9 @@ function Invoke-Step {
 
 Invoke-Step '[1/3] git pull'             { git pull }
 Invoke-Step '[2/3] docker compose build' { docker compose build }
-Invoke-Step '[3/3] docker compose up -d' { docker compose up -d }
+# up -d reconciles (only changed services are recreated); --remove-orphans also
+# drops containers for services deleted from the compose files.
+Invoke-Step '[3/3] docker compose up -d' { docker compose up -d --remove-orphans }
 
 Write-Host '==> done. Container status:' -ForegroundColor Green
 docker compose ps

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,9 @@ main() {
   docker compose build
 
   echo "==> [3/3] docker compose up -d"
-  docker compose up -d
+  # up -d reconciles (only changed services are recreated); --remove-orphans
+  # also drops containers for services deleted from the compose files.
+  docker compose up -d --remove-orphans
 
   echo "==> done. Container status:"
   docker compose ps


### PR DESCRIPTION
Deploy-script hardening -- no `down`, since `up -d` already reconciles.

**Context:** `up -d` stamps each container with a config-hash, recomputes the desired config every run, and recreates only the services whose config or image actually changed (leaving the rest running). That covers the conditional `PG_HOST_BIND` overlay too -- toggling it changes the Postgres config hash, so the port is added/removed on the next `up` with no `down`. A `down` would opt out of all that: it stops Postgres for nothing and tears down the compose-defined networks (a route to the 404s the header comment warns about if Traefik attaches to a non-`external:` network here).

**Two changes:**
1. **`--remove-orphans` on every `up`** (all 4 scripts). Config-hash reconciliation doesn't cover a service *deleted* from the compose files -- its container keeps running, unrouted and invisible to `ps`. `--remove-orphans` drops it. Scoped to the compose project, so a separate stack (QA with its own project name) is untouched.
2. **Prune dangling images after a successful `up`** (prod scripts only -- `build-traefik.sh` / `.ps1`). Reclaims the layers each build supersedes on the fixed-disk host. Dangling-only (`docker image prune -f`, no `-a`), so it never touches an in-use image; non-fatal (`|| true`) so a prune hiccup can't fail an otherwise-good deploy. Dev scripts get `--remove-orphans` only.

**Not done (noted for later):** SHA-tagging images for rollback. A build that succeeds but is broken at runtime still replaces the working container, and rollback is manual. Tagging images by commit SHA instead of `latest` would give a rollback target -- a bigger change, happy to do it if/when it bites.

**Caveat:** `--remove-orphans` is per-project; it relies on the QA stack using a distinct compose project name (as QA-SETUP.md already requires). Scripts-only change; no app/server/schema impact.