### PR TITLE
Release v3.16.0

### DIFF
--- a/build-traefik.ps1
+++ b/build-traefik.ps1
@@ -36,7 +36,16 @@ function Invoke-Step {
 
 Invoke-Step '[1/3] git pull'             { git pull }
 Invoke-Step '[2/3] docker compose build' { docker compose @compose build }
-Invoke-Step '[3/3] docker compose up -d' { docker compose @compose up -d }
+# up -d reconciles (only changed services are recreated); --remove-orphans also
+# drops containers for services deleted from the compose files. Scoped to this
+# compose project, so a separate stack (e.g. QA) is untouched.
+Invoke-Step '[3/4] docker compose up -d' { docker compose @compose up -d --remove-orphans }
+
+# Reclaim disk from images this build superseded. Dangling-only (no -a), so it
+# never touches an in-use image. Called directly (not via Invoke-Step) so a
+# non-zero exit is non-fatal and can't fail an otherwise-good deploy.
+Write-Host '==> [4/4] prune dangling images' -ForegroundColor Cyan
+docker image prune -f
 
 Write-Host '==> done. Container status:' -ForegroundColor Green
 docker compose @compose ps

--- a/build-traefik.sh
+++ b/build-traefik.sh
@@ -36,8 +36,20 @@ main() {
   echo "==> [2/3] docker compose build"
   docker compose "${compose[@]}" build
 
-  echo "==> [3/3] docker compose up -d"
-  docker compose "${compose[@]}" up -d
+  echo "==> [3/4] docker compose up -d"
+  # up -d already reconciles: it recomputes each service's config hash and
+  # recreates only the ones whose config or image changed, leaving the rest
+  # running. --remove-orphans also drops containers for services deleted from
+  # the compose files (config-hash reconciliation doesn't cover those, so they'd
+  # otherwise linger unrouted). Scoped to this compose project, so a separate
+  # stack (e.g. QA with its own project name) is untouched.
+  docker compose "${compose[@]}" up -d --remove-orphans
+
+  # Reclaim disk from images this build superseded. Dangling-only (no -a), so it
+  # never touches an image a container is using; non-fatal so a prune hiccup
+  # can't fail an otherwise-good deploy.
+  echo "==> [4/4] prune dangling images"
+  docker image prune -f || true
 
   echo "==> done. Container status:"
   docker compose "${compose[@]}" ps

--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,9 @@ function Invoke-Step {
 
 Invoke-Step '[1/3] git pull'             { git pull }
 Invoke-Step '[2/3] docker compose build' { docker compose build }
-Invoke-Step '[3/3] docker compose up -d' { docker compose up -d }
+# up -d reconciles (only changed services are recreated); --remove-orphans also
+# drops containers for services deleted from the compose files.
+Invoke-Step '[3/3] docker compose up -d' { docker compose up -d --remove-orphans }
 
 Write-Host '==> done. Container status:' -ForegroundColor Green
 docker compose ps

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,9 @@ main() {
   docker compose build
 
   echo "==> [3/3] docker compose up -d"
-  docker compose up -d
+  # up -d reconciles (only changed services are recreated); --remove-orphans
+  # also drops containers for services deleted from the compose files.
+  docker compose up -d --remove-orphans
 
   echo "==> done. Container status:"
   docker compose ps

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "email": "gq@area404.org",
     "url": "https://area404.org"
   },
-  "version": "3.15.0",
+  "version": "3.16.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexum-web",
   "private": true,
-  "version": "3.15.0",
+  "version": "3.16.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "author": {

--- a/web/src/components/ui/LandingPage.tsx
+++ b/web/src/components/ui/LandingPage.tsx
@@ -14,6 +14,7 @@ import {
   LineSegmentsIcon,
 } from '@phosphor-icons/react';
 import { apiUrl } from '../../api/client';
+import { DISCORD_INVITE_URL } from '../../data/links';
 import { SUPPORTED_LANGUAGES, LANGUAGE_NAMES } from '../../i18n';
 import { DemoMap } from './DemoMap';
 import { LanguageSwitcher } from './LanguageSwitcher';
@@ -371,7 +372,7 @@ export function LandingPage() {
             </>
           )}
           <a
-            href="https://discord.gg/KG8SMXrhZ4"
+            href={DISCORD_INVITE_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="landing__discord-btn"
@@ -453,7 +454,7 @@ export function LandingPage() {
             {t('landing.discordCtaBody')}
           </p>
           <a
-            href="https://discord.gg/KG8SMXrhZ4"
+            href={DISCORD_INVITE_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="landing__discord-btn"

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -25,7 +25,8 @@ import { NOTIFY } from "../../utils/notificationPrefs";
 import { useResettableState } from "../../hooks/useResettableState";
 import { DEFAULT_BOOKMARK_FORMAT, BOOKMARK_TOKENS } from "../../utils/signatureBookmark";
 import { toPng } from "html-to-image";
-import { CaretLeftIcon, CaretRightIcon, GearIcon } from "@phosphor-icons/react";
+import { CaretLeftIcon, CaretRightIcon, GearIcon, DiscordLogoIcon } from "@phosphor-icons/react";
+import { DISCORD_INVITE_URL } from "../../data/links";
 import { ChainExitsSection } from "./ChainExitsSection";
 import { MapSharesSection } from "./MapSharesSection";
 import { MergeMapModal } from "./MergeMapModal";
@@ -910,6 +911,16 @@ export function MapSidebar() {
             </button>
           </div>
         </div>
+
+        <a
+          className="map-sidebar__settings-btn map-sidebar__discord-btn"
+          href={DISCORD_INVITE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <DiscordLogoIcon size={14} weight="fill" color="#5865F2" />
+          {t("actions.joinDiscord")}
+        </a>
 
         <button
           type="button"

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -36,10 +36,12 @@ import {
   ShieldStarIcon, ChartBarIcon, SlidersHorizontalIcon, FootprintsIcon,
   SignOutIcon, PlanetIcon, LinkSimpleIcon, ClockCountdownIcon, MapPinIcon,
   KeyIcon, GraphIcon, ArrowCounterClockwiseIcon, DotsSixVerticalIcon,
+  DiscordLogoIcon,
 } from '@phosphor-icons/react';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { UpdateIndicator } from './UpdateIndicator';
 import { charPortrait, typeIcon } from '../../utils/eveImages';
+import { DISCORD_INVITE_URL } from '../../data/links';
 
 interface EveStatus {
   players:    number;
@@ -515,6 +517,18 @@ export function Toolbar() {
           aria-label={t('toolbar.help')}
         >
           <QuestionIcon size={18} weight="regular" />
+        </a>
+
+        <a
+          className="toolbar__toggle toolbar__toggle--prominent toolbar__discord"
+          href={DISCORD_INVITE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-tooltip={t('actions.joinDiscord')}
+          aria-label={t('actions.joinDiscord')}
+        >
+          <DiscordLogoIcon size={18} weight="fill" color="#5865F2" />
+          <span>{t('toolbar.discord')}</span>
         </a>
 
         <button

--- a/web/src/data/links.ts
+++ b/web/src/data/links.ts
@@ -1,0 +1,3 @@
+// External links used across the app. Single source of truth so the invite
+// (top bar, settings sidebar, landing-page CTAs) can't drift out of sync.
+export const DISCORD_INVITE_URL = 'https://discord.gg/KG8SMXrhZ4';

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "Standort unbekannt"
   },
   "actions": {
+    "joinDiscord": "Discord beitreten",
     "save": "Speichern",
     "cancel": "Abbrechen",
     "delete": "Löschen",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "Karte wechseln",
     "noMap": "Keine Karte",
     "mapType": {

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -102,6 +102,7 @@
     "locationUnknown": "Location unknown"
   },
   "actions": {
+    "joinDiscord": "Join Discord",
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",
@@ -1278,6 +1279,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "Switch map",
     "noMap": "No Map",
     "mapType": {

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "Ubicación desconocida"
   },
   "actions": {
+    "joinDiscord": "Unirse a Discord",
     "save": "Guardar",
     "cancel": "Cancelar",
     "delete": "Eliminar",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "Cambiar de mapa",
     "noMap": "Sin mapa",
     "mapType": {

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "Position inconnue"
   },
   "actions": {
+    "joinDiscord": "Rejoindre Discord",
     "save": "Enregistrer",
     "cancel": "Annuler",
     "delete": "Supprimer",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "Changer de carte",
     "noMap": "Aucune carte",
     "mapType": {

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "現在地不明"
   },
   "actions": {
+    "joinDiscord": "Discordに参加",
     "save": "保存",
     "cancel": "キャンセル",
     "delete": "削除",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "マップ切り替え",
     "noMap": "マップなし",
     "mapType": {

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "위치 알 수 없음"
   },
   "actions": {
+    "joinDiscord": "Discord 참여",
     "save": "저장",
     "cancel": "취소",
     "delete": "삭제",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "지도 전환",
     "noMap": "지도 없음",
     "mapType": {

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "Localização desconhecida"
   },
   "actions": {
+    "joinDiscord": "Entrar no Discord",
     "save": "Guardar",
     "cancel": "Cancelar",
     "delete": "Eliminar",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "Mudar de mapa",
     "noMap": "Sem mapa",
     "mapType": {

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "Местоположение неизвестно"
   },
   "actions": {
+    "joinDiscord": "Присоединиться к Discord",
     "save": "Сохранить",
     "cancel": "Отмена",
     "delete": "Удалить",
@@ -1246,6 +1247,7 @@
     "kg": "{{value}} кг"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "Сменить карту",
     "noMap": "Нет карты",
     "mapType": {

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -64,6 +64,7 @@
     "locationUnknown": "位置未知"
   },
   "actions": {
+    "joinDiscord": "加入 Discord",
     "save": "保存",
     "cancel": "取消",
     "delete": "删除",
@@ -1208,6 +1209,7 @@
     "kg": "{{value}} kg"
   },
   "toolbar": {
+    "discord": "Discord",
     "switchMap": "切换地图",
     "noMap": "无地图",
     "mapType": {

--- a/web/src/styles/modal-family.css
+++ b/web/src/styles/modal-family.css
@@ -381,6 +381,13 @@
   &:hover { background: var(--surface-overlay); border-color: var(--border-accent); color: #a0ccf8; }
 }
 
+.map-sidebar__discord-btn { text-decoration: none; }
+.map-sidebar__discord-btn:hover {
+  background: rgba(88, 101, 242, 0.14);
+  border-color: #5865f2;
+  color: #c7ceff;
+}
+
 
 /* ── Wormhole type chart (whtype.info-style reference) ─────── */
 .modal.whchart {

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -176,6 +176,16 @@
   }
 }
 
+/* Discord CTA in the top bar: icon + label, Discord blurple accent. Uses the
+   base .toolbar__toggle (text-capable) + --prominent, not the icon-only variant. */
+.toolbar__discord {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
+}
+.toolbar__discord svg { display: block; }
+
 .toolbar__map-name {
   background: transparent;
   border: none;


### PR DESCRIPTION
Minor release -- a quick way into the community, plus deploy tidy-up.

**Join the Nexum Discord in one click.** There's now a **Discord** button in the top bar (next to Help) and a **Join Discord** button in the Settings menu, right under the patch notes. Both open the community Discord in a new tab -- handy for asking questions, reporting bugs, or just hanging out with other pilots. Available in every language.

**Behind the scenes:** the deploy scripts were hardened to clean up stale containers and reclaim disk from old image builds on each update. No effect on the app itself -- just keeps self-hosted servers tidier.

After merge: tag `v3.16.0` and cut the GitHub release.