### PR TITLE
Live kill flagging from zKillboard (Phase 1, opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,4 +111,18 @@ ALLIANCE_MAP_SHARED=false
 # NEXUM_TELEMETRY=1
 # NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
 
+# ── Live kill feed ────────────────────────────────────────────────────────────
+# Opt-in. When enabled, a single server-side consumer long-polls zKillboard's
+# RedisQ feed and flags recent high-value kills on systems currently shown on
+# live maps (pushed over the existing SSE stream). OFF unless KILL_FEED=1.
+#
+# zKillboard fair-use: keep KILL_FEED_CONTACT a reachable contact (it builds the
+# feed's User-Agent), and KILL_FEED_QUEUE_ID stable + unique to your deployment
+# so kills aren't split across restarts or shared with another instance.
+# KILL_FEED=1
+# KILL_FEED_CONTACT=you@example.com
+# KILL_FEED_QUEUE_ID=eve-nexum
+# KILL_FEED_MIN_ISK=50000000        # only flag kills at/above this ISK value
+# KILL_FEED_RECENT_SECONDS=900      # how long a flag lingers (client shows ~15m)
+
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -172,6 +172,20 @@ export const config = {
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },
+  // Live kill flagging. OFF by default (KILL_FEED=1 to opt in) — when enabled a
+  // single server-side consumer long-polls zKillboard's RedisQ feed and flags
+  // recent high-value kills on systems currently shown on live maps, pushed over
+  // the SSE stream. `contact` builds the zKill User-Agent (fair-use requires a
+  // reachable contact). `queueId` is this deployment's RedisQ queue name (keep
+  // it stable + unique so kills aren't split across restarts). `minValueIsk`
+  // filters out low-value noise; `recentSeconds` is how long a flag lives.
+  killFeed: {
+    enabled:       parseBool(process.env.KILL_FEED),
+    contact:       process.env.KILL_FEED_CONTACT?.trim() || 'gq@area404.org',
+    queueId:       process.env.KILL_FEED_QUEUE_ID?.trim() || 'eve-nexum',
+    minValueIsk:   intEnv(process.env.KILL_FEED_MIN_ISK, 50_000_000),
+    recentSeconds: intEnv(process.env.KILL_FEED_RECENT_SECONDS, 900),
+  },
   // Required in non-dev (guarded above). The dev fallback is randomised per
   // boot rather than a known literal, so a dev instance accidentally exposed
   // can't have its sessions forged with a guessable secret (sessions just

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,7 @@ import { startSdeAutoUpdate } from './services/sdeUpdate.js';
 import { startLocationPoller } from './services/locationPoll.js';
 import { startWhSweeper } from './services/whSweep.js';
 import { startConnLifetimeSweeper } from './services/connLifetimeSweep.js';
+import { startKillFeed } from './services/killFeed.js';
 import { startAccessRevalidation } from './services/accessRevalidate.js';
 import { startTelemetry } from './services/telemetry.js';
 import { telemetryRouter } from './routes/telemetry.js';
@@ -185,6 +186,7 @@ migrate()
     startWhSweeper();
     startConnLifetimeSweeper();
     startAccessRevalidation();
+    startKillFeed();
     void startTelemetry();
   })
   .catch((err) => { console.error('Migration failed:', err); process.exit(1); });

--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -1,0 +1,140 @@
+import { config } from '../config.js';
+import { db } from '../db.js';
+import { createLogger } from '../utils/logger.js';
+import { activeMapIds, publishToMap } from './mapEvents.js';
+
+// Single-process consumer of zKillboard's RedisQ live feed. Long-polls the feed,
+// filters to high-value kills in systems that are currently on a live map, and
+// pushes a `kill.recent` event over the SSE stream so the client can flash the
+// system node. Opt-in (KILL_FEED=1). zKill fair-use: one consumer, a reachable
+// User-Agent contact, and backoff on failure — never a tight retry loop.
+const log = createLogger('killFeed');
+
+// ttw = long-poll wait (seconds): RedisQ holds the request open until a kill
+// arrives or the window elapses, so an idle feed paces itself with no client-side
+// delay and no busy-poll.
+const REDISQ_URL = `https://redisq.zkillboard.com/listen.php?queueID=${encodeURIComponent(config.killFeed.queueId)}&ttw=10`;
+const USER_AGENT = `Eve-Nexum/1.0 (${config.killFeed.contact})`;
+const FETCH_TIMEOUT_MS = 20_000;
+const MAX_BACKOFF_MS = 30_000;
+const MIN_CYCLE_MS = 2_000;
+const SEEN_CAP = 2000;
+
+// RedisQ payload — untrusted external input. Every field is coerced with Number()
+// at the use site; we forward only numeric ids + value + timestamp to clients,
+// never any attacker/victim name strings.
+interface RedisQResponse {
+  package: {
+    killmail?: {
+      killmail_id?:     number;
+      killmail_time?:   string;
+      solar_system_id?: number;
+      victim?:          { ship_type_id?: number };
+    };
+    zkb?: { totalValue?: number };
+  } | null;
+}
+
+// Bounded FIFO of recently-seen killmail ids — drops repeats across reconnects
+// without growing unbounded (insertion order lets us evict the oldest).
+const seen = new Set<number>();
+function markSeen(id: number): boolean {
+  if (seen.has(id)) return false;
+  seen.add(id);
+  if (seen.size > SEEN_CAP) {
+    const oldest = seen.values().next().value;
+    if (oldest !== undefined) seen.delete(oldest);
+  }
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    t.unref?.();
+  });
+}
+
+async function pollOnce(): Promise<void> {
+  const res = await fetch(REDISQ_URL, {
+    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    redirect: 'error',
+  });
+  if (!res.ok) throw new Error(`RedisQ HTTP ${res.status}`);
+
+  const body = await res.json() as RedisQResponse;
+  const km = body?.package?.killmail;
+  if (!km) return; // idle window — nothing this cycle
+
+  const killmailId    = Number(km.killmail_id);
+  const solarSystemId = Number(km.solar_system_id);
+  if (!Number.isFinite(killmailId) || !Number.isFinite(solarSystemId)) return;
+  if (!markSeen(killmailId)) return;
+
+  const totalValue = Number(body!.package!.zkb?.totalValue ?? 0);
+  if (!(totalValue >= config.killFeed.minValueIsk)) return;
+
+  // Only touch the DB when at least one map is actually being watched.
+  const live = activeMapIds();
+  if (!live.length) return;
+
+  const { rows } = await db.query<{ mapId: string }>(
+    `SELECT DISTINCT map_id AS "mapId"
+       FROM map_systems
+      WHERE eve_system_id = $1 AND map_id = ANY($2::uuid[])`,
+    [solarSystemId, live],
+  );
+  if (!rows.length) return;
+
+  const shipTypeId = Number(km.victim?.ship_type_id) || 0;
+  const parsed = km.killmail_time ? Date.parse(km.killmail_time) : NaN;
+  const atMs = Number.isFinite(parsed) ? parsed : Date.now();
+
+  for (const { mapId } of rows) {
+    publishToMap(mapId, {
+      type:        'kill.recent',
+      actor:       null,
+      eveSystemId: solarSystemId,
+      killmailId,
+      shipTypeId,
+      totalValue,
+      atMs,
+    });
+  }
+}
+
+let running = false;
+
+async function loop(): Promise<void> {
+  let backoff = 1_000;
+  while (running) {
+    const started = Date.now();
+    try {
+      await pollOnce();
+      backoff = 1_000; // success resets backoff (RedisQ ttw already paces us)
+      // Floor the request rate. RedisQ's ttw=10 normally holds the request ~10s,
+      // but if it ever returns fast (proxy, empty burst) this keeps us from
+      // busy-polling the feed — fair-use insurance, negligible for real kills.
+      const elapsed = Date.now() - started;
+      if (elapsed < MIN_CYCLE_MS) await sleep(MIN_CYCLE_MS - elapsed);
+    } catch (err) {
+      log.warn(`RedisQ poll failed (retry in ${Math.round(backoff / 1000)}s):`, err instanceof Error ? err.message : err);
+      await sleep(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    }
+  }
+}
+
+// Start the live kill feed. No-op unless KILL_FEED is set. Follows the
+// startXxx() + feature-flag-gate pattern of the other background services.
+export function startKillFeed(): void {
+  if (!config.killFeed.enabled) {
+    log.info('live kill feed disabled (KILL_FEED unset)');
+    return;
+  }
+  if (running) return;
+  running = true;
+  log.info(`live kill feed enabled (queueId="${config.killFeed.queueId}", min ${config.killFeed.minValueIsk.toLocaleString()} ISK)`);
+  void loop();
+}

--- a/server/src/services/mapEvents.ts
+++ b/server/src/services/mapEvents.ts
@@ -33,6 +33,14 @@ export function subscribeMap(mapId: string, res: Response): () => void {
   };
 }
 
+// Map ids that currently have at least one live SSE subscriber. A key exists in
+// `subscribers` only while its Set is non-empty (see the cleanup in the
+// unsubscribe fn above), so the keys ARE the set of actively-viewed maps. Lets
+// background producers (e.g. the kill feed) skip work for maps nobody is watching.
+export function activeMapIds(): string[] {
+  return [...subscribers.keys()];
+}
+
 // Register a transform callback for a map's events. Returns an unsubscribe fn.
 // The callback gets the event object (not an SSE frame), so the caller decides
 // what, if anything, to forward.

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -10,6 +10,7 @@ import type { MapSystem } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS, EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS } from '../../data/wormholes';
 import { useMapStore } from '../../store/mapStore';
 import { usePresenceStore } from '../../store/presenceStore';
+import { useSystemKill, RECENT_KILL_MS } from '../../store/killStore';
 import { useAccountLocations } from '../../hooks/useAccountLocations';
 import { useSovData } from '../../hooks/useSovData';
 import { useStandings } from '../../hooks/useStandings';
@@ -45,6 +46,14 @@ import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
 type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean; routeHighlighted?: boolean };
+
+// Compact ISK for the recent-kill tooltip: 1.2B / 340M / 90K.
+function iskCompact(v: number): string {
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
+  if (v >= 1_000_000)     return `${(v / 1_000_000).toFixed(0)}M`;
+  if (v >= 1_000)         return `${(v / 1_000).toFixed(0)}K`;
+  return String(Math.round(v));
+}
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();
@@ -149,6 +158,8 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const allKills        = useCurrentHourKills();
   const myKills         = sys.eveSystemId !== null ? allKills.get(sys.eveSystemId) : undefined;
   const hotKills        = !!myKills && myKills.shipKills + myKills.podKills > 0;
+  // Live "a kill just happened here" flag from the zKill feed (ephemeral, SSE).
+  const recentKill      = useSystemKill(sys.eveSystemId);
 
   // Active heatmap glow for this node — value for the selected metric,
   // normalised against the per-map max (from HeatmapContext). null = no glow
@@ -166,6 +177,9 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
     return { glow: Math.min(1, raw * heatmap.intensity), color: heatColor(raw, heatmap.colorVision !== 'off') };
   }, [heatmap.metric, heatmap.max, heatmap.intensity, heatmap.colorVision, sys.eveSystemId, allKills, fleet, user?.characterId]);
   const now             = useNow30s();
+  // The flag fades once the kill ages past the display window; the 30s ticker
+  // re-evaluates this so it drops on its own without another SSE frame.
+  const killFresh       = !!recentKill && now - recentKill.atMs < RECENT_KILL_MS;
   const [staleHours]    = useStaleThreshold();
   // staleHours === 0 is the "Never fade" sentinel: no system is ever stale.
   const isStale         = staleHours > 0 && !!sys.lastActivityAt &&
@@ -410,6 +424,17 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
       <div className="system-node__meta-row">
         <span className="system-node__class-badge">{CLASS_LABELS[sys.systemClass]}</span>
         <div className="system-node__icons">
+          {killFresh && recentKill && (
+            <span className="system-node__recentkill-icon">
+              <SkullIcon size={14} weight="fill" />
+              <span className="system-node__recentkill-tooltip">
+                {t('mapNode.recentKill', {
+                  value: iskCompact(recentKill.totalValue),
+                  ago: Math.max(0, Math.round((now - recentKill.atMs) / 60_000)),
+                })}
+              </span>
+            </span>
+          )}
           {hotKills && myKills && (
             <span className="system-node__kill-icon">
               <SwordIcon size={14} weight="regular" />

--- a/web/src/hooks/useMapEventStream.ts
+++ b/web/src/hooks/useMapEventStream.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useMapStore, type RemoteEvent } from '../store/mapStore';
 import { usePresenceStore, type PresenceViewer } from '../store/presenceStore';
+import { useKillStore } from '../store/killStore';
 import { apiUrl } from '../api/client';
 import { CLIENT_ID } from '../api/clientId';
 
@@ -17,6 +18,7 @@ export function useMapEventStream(): void {
     if (!activeMapId) return;
     openedOnce.current = false;
     usePresenceStore.getState().reset(); // clear last map's roster; snapshot repopulates
+    useKillStore.getState().reset();     // clear last map's kill flags
 
     const es = new EventSource(apiUrl(`/api/maps/${activeMapId}/events`), { withCredentials: true });
 
@@ -45,6 +47,16 @@ export function useMapEventStream(): void {
             return;
           case 'presence.leave':
             presence.remove(data.characterId as number);
+            return;
+          case 'kill.recent':
+            // Ephemeral, non-map state — route to the kill store, not mapStore.
+            useKillStore.getState().recordKill({
+              eveSystemId: data.eveSystemId as number,
+              killmailId:  data.killmailId as number,
+              shipTypeId:  data.shipTypeId as number,
+              totalValue:  data.totalValue as number,
+              atMs:        data.atMs as number,
+            });
             return;
         }
 

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Charakter {{id}}",
     "altLastKnown": "(zuletzt bekannt)",
     "killsTooltip": "{{ships}} Schiff · {{pods}} Pod-Kills diese Stunde",
+    "recentKill": "Kill vor {{ago}} Min. ({{value}} ISK)",
     "a0Sun": "A0-Sonne",
     "shattered": "Zerschmettert",
     "iceBelt": "Eisgürtel-System",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1732,6 +1732,7 @@
     "characterFallback": "Character {{id}}",
     "altLastKnown": "(last known)",
     "killsTooltip": "{{ships}} ship · {{pods}} pod kills this hour",
+    "recentKill": "Kill {{ago}}m ago ({{value}} ISK)",
     "a0Sun": "A0 sun",
     "shattered": "Shattered",
     "iceBelt": "Ice belt system",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Personaje {{id}}",
     "altLastKnown": "(última conocida)",
     "killsTooltip": "{{ships}} nave · {{pods}} cápsula destruidas esta hora",
+    "recentKill": "Muerte hace {{ago}} min ({{value}} ISK)",
     "a0Sun": "Sol A0",
     "shattered": "Destrozado",
     "iceBelt": "Sistema con cinturón de hielo",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Personnage {{id}}",
     "altLastKnown": "(dernière connue)",
     "killsTooltip": "{{ships}} vaisseau · {{pods}} capsule détruits cette heure",
+    "recentKill": "Kill il y a {{ago}} min ({{value}} ISK)",
     "a0Sun": "Soleil A0",
     "shattered": "Brisé",
     "iceBelt": "Système à ceinture de glace",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "キャラクター {{id}}",
     "altLastKnown": "（最後の確認）",
     "killsTooltip": "今時間 {{ships}} 艦船 · {{pods}} ポッドキル",
+    "recentKill": "{{ago}}分前のキル ({{value}} ISK)",
     "a0Sun": "A0 恒星",
     "shattered": "破壊された星系",
     "iceBelt": "アイスベルト星系",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "캐릭터 {{id}}",
     "altLastKnown": "(마지막 확인)",
     "killsTooltip": "이번 시간 {{ships}} 함선 · {{pods}} 캡슐 킬",
+    "recentKill": "{{ago}}분 전 격추 ({{value}} ISK)",
     "a0Sun": "A0 항성",
     "shattered": "파괴된 성계",
     "iceBelt": "얼음 벨트 성계",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Personagem {{id}}",
     "altLastKnown": "(última conhecida)",
     "killsTooltip": "{{ships}} nave · {{pods}} cápsula destruídas esta hora",
+    "recentKill": "Abate há {{ago}} min ({{value}} ISK)",
     "a0Sun": "Sol A0",
     "shattered": "Estilhaçado",
     "iceBelt": "Sistema com cinturão de gelo",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1700,6 +1700,7 @@
     "characterFallback": "Персонаж {{id}}",
     "altLastKnown": "(последнее изв.)",
     "killsTooltip": "{{ships}} кораблей · {{pods}} капсул убито за этот час",
+    "recentKill": "Килл {{ago}} мин назад ({{value}} ISK)",
     "a0Sun": "Звезда A0",
     "shattered": "Разрушенная",
     "iceBelt": "Система с ледяным поясом",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "角色 {{id}}",
     "altLastKnown": "（最后已知）",
     "killsTooltip": "本小时 {{ships}} 舰船 · {{pods}} 太空舱击杀",
+    "recentKill": "{{ago}} 分钟前击杀 ({{value}} ISK)",
     "a0Sun": "A0 恒星",
     "shattered": "破碎星系",
     "iceBelt": "冰带星系",

--- a/web/src/store/killStore.ts
+++ b/web/src/store/killStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+
+// Live "a kill just happened here" flags — ephemeral, fed by the SSE stream
+// (server-side zKillboard consumer). Kept out of mapStore because it isn't map
+// data and is reset on every map switch. Mirrors presenceStore's per-system
+// index so each SystemNode subscribes to just its own system and re-renders only
+// when a kill lands there.
+
+// How long a kill keeps a system flagged before the badge fades. The client
+// can't read the server's KILL_FEED_RECENT_SECONDS, so this is the display
+// window; nodes also gate on it via the shared 30s ticker.
+export const RECENT_KILL_MS = 15 * 60 * 1000;
+
+export interface KillFlag {
+  killmailId: number;
+  shipTypeId: number;
+  totalValue: number;
+  atMs:       number;
+}
+
+interface KillState {
+  // Latest kill per eveSystemId.
+  bySystem: Map<number, KillFlag>;
+  recordKill: (k: { eveSystemId: number } & KillFlag) => void;
+  reset: () => void;
+}
+
+export const useKillStore = create<KillState>((set) => ({
+  bySystem: new Map(),
+  recordKill: ({ eveSystemId, ...kill }) => set((s) => {
+    const next = new Map(s.bySystem);
+    // Opportunistically drop flags that have already aged out so the map can't
+    // grow unbounded on a busy feed.
+    const cutoff = Date.now() - RECENT_KILL_MS;
+    for (const [sysId, k] of next) if (k.atMs < cutoff) next.delete(sysId);
+    // Keep only the most recent kill for a system.
+    const existing = next.get(eveSystemId);
+    if (!existing || kill.atMs >= existing.atMs) next.set(eveSystemId, kill);
+    return { bySystem: next };
+  }),
+  reset: () => set({ bySystem: new Map() }),
+}));
+
+// Per-system selector — mirrors the presence-store slice so a node only
+// re-renders when its own system's flag changes.
+export function useSystemKill(eveSystemId: number | null | undefined): KillFlag | undefined {
+  return useKillStore((s) => (eveSystemId == null ? undefined : s.bySystem.get(eveSystemId)));
+}

--- a/web/src/styles/system-node.css
+++ b/web/src/styles/system-node.css
@@ -963,6 +963,44 @@
   z-index: 9999 !important;
 }
 
+/* Live "a kill just happened here" flag (zKill feed). Distinct from the hourly
+   kill-icon above: a pulsing red skull that draws the eye for ~15 min then the
+   node stops rendering it. */
+@keyframes recentkill-pulse {
+  0%, 100% { opacity: 1;    filter: drop-shadow(0 0 2px #ff3b3b88); }
+  50%      { opacity: 0.45; filter: drop-shadow(0 0 6px #ff3b3bcc); }
+}
+.system-node__recentkill-icon {
+  color: #ff3b3b;
+  font-size: calc(13px * var(--font-scale, 1));
+  cursor: default;
+  position: relative;
+  animation: recentkill-pulse 1.4s ease-in-out infinite;
+}
+.system-node__recentkill-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 4px 10px;
+  white-space: nowrap;
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #ff6060;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 9999;
+}
+.system-node__recentkill-icon:hover .system-node__recentkill-tooltip {
+  display: block;
+}
+.react-flow__node:has(.system-node__recentkill-icon:hover) {
+  z-index: 9999 !important;
+}
+
 .system-node__incursion-badge {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Flags recent high-value kills on systems currently shown on a live map, using zKillboard's live feed. **Off by default** -- inert until `KILL_FEED=1`.

## How it works
A single server-side consumer long-polls zKill's **RedisQ** feed (`redisq.zkillboard.com/listen.php`, `ttw=10`), which returns each killmail already resolved (system, ship, value). For each kill above a min-ISK threshold it finds which live maps show that system and fans out a `kill.recent` event over the existing SSE backbone (`publishToMap`). The client shows a ~15-minute pulsing red skull on the node, with a tooltip (time-since + ISK value), that fades on its own via the 30s ticker.

Chosen over the R2Z2 REST API (which is poll/cache, rate-limited, wrong for live) and the websocket (more moving parts); RedisQ is zKill's sanctioned live method and needs no ESI hydration.

## Server
- **`services/killFeed.ts`** (new) -- `startKillFeed()`, feature-flag gated. RedisQ long-poll loop; config-driven User-Agent + contact (fair-use); min-ISK filter; bounded dedupe (2000); growing backoff to 30s **plus a 2s min-cycle floor** so a fast-returning feed can't be busy-polled. DB is queried **only when >=1 map has a live SSE client** (new `activeMapIds()` on `mapEvents`), matching the kill's system to those maps.
- **Security:** untrusted killmail JSON is coerced to **numeric IDs only** (`Number()` + `isFinite` guards); no attacker/victim name strings are forwarded. RedisQ URL is a fixed constant (no SSRF); `redirect: 'error'`. No new inbound surface.
- **`config.ts`** -- opt-in `killFeed` group (`KILL_FEED`, `KILL_FEED_CONTACT`, `KILL_FEED_QUEUE_ID`, `KILL_FEED_MIN_ISK` default 50M, `KILL_FEED_RECENT_SECONDS` default 900). Documented in `.env.example`.
- **`index.ts`** -- `startKillFeed()` after `app.listen`.

## Client
- **`store/killStore.ts`** (new) -- transient per-system flags (mirrors `presenceStore`), reset on map switch, `useSystemKill` selector, 15-min window.
- **`useMapEventStream`** -- routes `kill.recent` to the kill store (ephemeral; not `mapStore`/`applyRemote`).
- **`SystemNode`** -- pulsing red skull badge in the icon row, freshness-gated so it fades on its own; ISK-compact tooltip.
- **i18n** -- `mapNode.recentKill` in all 9 locales (interpolation vars preserved).

## Notes
- **No schema change**, no migration; entirely in-memory/ephemeral.
- **Fair-use:** one consumer, reachable UA contact, long-poll + backoff + rate floor, stable/unique queueId. Third-party best-effort -- degrades silently when zKill is down.
- Built via fork + my review (I added the 2s rate floor and re-checked the untrusted-input handling). server + web `tsc` clean, eslint clean, i18n parity confirmed.
- **Phase 2 deferred:** corp/alliance Discord kill webhook, and a REST backfill of the last hour on map-open.

## To try it
Set `KILL_FEED=1` (and optionally `KILL_FEED_MIN_ISK`) on the server, open a map, and kills in mapped systems above the threshold will flash. Because it defaults off, this is safe to merge and enable deliberately.