### PR TITLE
Live kill feed (flag + kill log + Discord) on zKill R2Z2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,17 +112,16 @@ ALLIANCE_MAP_SHARED=false
 # NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
 
 # ── Live kill feed ────────────────────────────────────────────────────────────
-# Opt-in. When enabled, a single server-side consumer long-polls zKillboard's
-# RedisQ feed and flags recent high-value kills on systems currently shown on
+# Opt-in. When enabled, a single server-side consumer reads zKillboard's R2Z2
+# ephemeral feed and flags recent high-value kills on systems currently shown on
 # live maps (pushed over the existing SSE stream). OFF unless KILL_FEED=1.
 #
-# zKillboard fair-use: keep KILL_FEED_CONTACT a reachable contact (it builds the
-# feed's User-Agent), and KILL_FEED_QUEUE_ID stable + unique to your deployment
-# so kills aren't split across restarts or shared with another instance.
+# zKillboard fair-use: keep KILL_FEED_CONTACT a reachable contact — it builds the
+# feed's User-Agent, and a blank UA is Cloudflare-blocked.
 # KILL_FEED=1
 # KILL_FEED_CONTACT=you@example.com
-# KILL_FEED_QUEUE_ID=eve-nexum
 # KILL_FEED_MIN_ISK=50000000        # only flag kills at/above this ISK value
 # KILL_FEED_RECENT_SECONDS=900      # how long a flag lingers (client shows ~15m)
+# KILL_FEED_BACKFILL_MAX_SYSTEMS=30 # cap systems queried for the kill-log backfill
 
 

--- a/.env.example
+++ b/.env.example
@@ -111,4 +111,18 @@ ALLIANCE_MAP_SHARED=false
 # NEXUM_TELEMETRY=1
 # NEXUM_TELEMETRY_URL=https://eve-nexum.com/api/telemetry
 
+# ── Live kill feed ────────────────────────────────────────────────────────────
+# Opt-in. When enabled, a single server-side consumer long-polls zKillboard's
+# RedisQ feed and flags recent high-value kills on systems currently shown on
+# live maps (pushed over the existing SSE stream). OFF unless KILL_FEED=1.
+#
+# zKillboard fair-use: keep KILL_FEED_CONTACT a reachable contact (it builds the
+# feed's User-Agent), and KILL_FEED_QUEUE_ID stable + unique to your deployment
+# so kills aren't split across restarts or shared with another instance.
+# KILL_FEED=1
+# KILL_FEED_CONTACT=you@example.com
+# KILL_FEED_QUEUE_ID=eve-nexum
+# KILL_FEED_MIN_ISK=50000000        # only flag kills at/above this ISK value
+# KILL_FEED_RECENT_SECONDS=900      # how long a flag lingers (client shows ~15m)
+
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -173,18 +173,20 @@ export const config = {
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },
   // Live kill flagging. OFF by default (KILL_FEED=1 to opt in) — when enabled a
-  // single server-side consumer long-polls zKillboard's RedisQ feed and flags
+  // single server-side consumer reads zKillboard's R2Z2 ephemeral feed and flags
   // recent high-value kills on systems currently shown on live maps, pushed over
   // the SSE stream. `contact` builds the zKill User-Agent (fair-use requires a
-  // reachable contact). `queueId` is this deployment's RedisQ queue name (keep
-  // it stable + unique so kills aren't split across restarts). `minValueIsk`
-  // filters out low-value noise; `recentSeconds` is how long a flag lives.
+  // reachable contact; a blank UA is Cloudflare-blocked). `minValueIsk` filters
+  // out low-value noise; `recentSeconds` is how long a flag lives.
   killFeed: {
     enabled:       parseBool(process.env.KILL_FEED),
     contact:       process.env.KILL_FEED_CONTACT?.trim() || 'gq@area404.org',
-    queueId:       process.env.KILL_FEED_QUEUE_ID?.trim() || 'eve-nexum',
     minValueIsk:   intEnv(process.env.KILL_FEED_MIN_ISK, 50_000_000),
     recentSeconds: intEnv(process.env.KILL_FEED_RECENT_SECONDS, 900),
+    // Kill-log backfill: how many of a map's systems to query zKill for on
+    // panel-open. Capped so a huge chain can't fan out into a burst of zKill
+    // REST calls (fair-use). Extra systems are skipped (logged), not queried.
+    backfillMaxSystems: intEnv(process.env.KILL_FEED_BACKFILL_MAX_SYSTEMS, 30),
   },
   // Required in non-dev (guarded above). The dev fallback is randomised per
   // boot rather than a known literal, so a dev instance accidentally exposed

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -172,6 +172,20 @@ export const config = {
   sdeAutoUpdate:       SDE_AUTO_UPDATE,
   sdeCheckUtc:         SDE_CHECK_UTC,
   telemetry:           { enabled: TELEMETRY_ENABLED, url: TELEMETRY_URL },
+  // Live kill flagging. OFF by default (KILL_FEED=1 to opt in) — when enabled a
+  // single server-side consumer long-polls zKillboard's RedisQ feed and flags
+  // recent high-value kills on systems currently shown on live maps, pushed over
+  // the SSE stream. `contact` builds the zKill User-Agent (fair-use requires a
+  // reachable contact). `queueId` is this deployment's RedisQ queue name (keep
+  // it stable + unique so kills aren't split across restarts). `minValueIsk`
+  // filters out low-value noise; `recentSeconds` is how long a flag lives.
+  killFeed: {
+    enabled:       parseBool(process.env.KILL_FEED),
+    contact:       process.env.KILL_FEED_CONTACT?.trim() || 'gq@area404.org',
+    queueId:       process.env.KILL_FEED_QUEUE_ID?.trim() || 'eve-nexum',
+    minValueIsk:   intEnv(process.env.KILL_FEED_MIN_ISK, 50_000_000),
+    recentSeconds: intEnv(process.env.KILL_FEED_RECENT_SECONDS, 900),
+  },
   // Required in non-dev (guarded above). The dev fallback is randomised per
   // boot rather than a known literal, so a dev instance accidentally exposed
   // can't have its sessions forged with a guessable secret (sessions just

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,7 @@ import { startSdeAutoUpdate } from './services/sdeUpdate.js';
 import { startLocationPoller } from './services/locationPoll.js';
 import { startWhSweeper } from './services/whSweep.js';
 import { startConnLifetimeSweeper } from './services/connLifetimeSweep.js';
+import { startKillFeed } from './services/killFeed.js';
 import { startAccessRevalidation } from './services/accessRevalidate.js';
 import { startTelemetry } from './services/telemetry.js';
 import { telemetryRouter } from './routes/telemetry.js';
@@ -185,6 +186,7 @@ migrate()
     startWhSweeper();
     startConnLifetimeSweeper();
     startAccessRevalidation();
+    startKillFeed();
     void startTelemetry();
   })
   .catch((err) => { console.error('Migration failed:', err); process.exit(1); });

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -205,6 +205,14 @@ export async function migrate() {
     ALTER TABLE corp_discord_settings     ADD COLUMN IF NOT EXISTS exits_min_security REAL NOT NULL DEFAULT 0.45;
     ALTER TABLE alliance_discord_settings ADD COLUMN IF NOT EXISTS exits_min_security REAL NOT NULL DEFAULT 0.45;
 
+    -- Kill alerts (zKill live feed): per-org webhook + a minimum ISK value the
+    -- kill must clear to notify. NULL webhook = kill alerts off for the org;
+    -- kill_min_isk default 0 = notify for every kill the feed already surfaces.
+    ALTER TABLE corp_discord_settings     ADD COLUMN IF NOT EXISTS kill_webhook TEXT;
+    ALTER TABLE alliance_discord_settings ADD COLUMN IF NOT EXISTS kill_webhook TEXT;
+    ALTER TABLE corp_discord_settings     ADD COLUMN IF NOT EXISTS kill_min_isk BIGINT NOT NULL DEFAULT 0;
+    ALTER TABLE alliance_discord_settings ADD COLUMN IF NOT EXISTS kill_min_isk BIGINT NOT NULL DEFAULT 0;
+
     CREATE TABLE IF NOT EXISTS map_systems (
       id            UUID        PRIMARY KEY,
       map_id        UUID        NOT NULL REFERENCES maps(id) ON DELETE CASCADE,

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -697,18 +697,20 @@ interface WhSettingsRow {
   whTypes: string[]; whClasses: string[]; whSizes: string[];
   connectionsWebhook: string | null; chainsWebhook: string | null;
   exitsMinSecurity: number;
+  killWebhook: string | null; killMinIsk: string; // kill_min_isk is BIGINT -> string
 }
 const WH_SETTINGS_COLS = `all_regions AS "allRegions", regions, notify_chains AS "notifyChains",
                           wh_types AS "whTypes", wh_classes AS "whClasses", wh_sizes AS "whSizes",
                           connections_webhook AS "connectionsWebhook", chains_webhook AS "chainsWebhook",
-                          exits_min_security AS "exitsMinSecurity"`;
+                          exits_min_security AS "exitsMinSecurity",
+                          kill_webhook AS "killWebhook", kill_min_isk AS "killMinIsk"`;
 
 // GET /api/admin/discord — current settings + this org's maps with their
 // excluded state (excluded = NOT discord_notify).
 adminRouter.get('/discord', async (req, res) => {
   const scope = resolveDiscordScope(req);
   if (!scope) {
-    res.json({ scope: null, allRegions: true, regions: [], notifyChains: true, whTypes: [], whClasses: [], whSizes: [], connectionsWebhook: '', chainsWebhook: '', exitsMinSecurity: 0.45, maps: [] });
+    res.json({ scope: null, allRegions: true, regions: [], notifyChains: true, whTypes: [], whClasses: [], whSizes: [], connectionsWebhook: '', chainsWebhook: '', exitsMinSecurity: 0.45, killWebhook: '', killMinIsk: 0, maps: [] });
     return;
   }
   // Literal SQL per branch (no interpolated identifiers) so the settings table /
@@ -734,6 +736,8 @@ adminRouter.get('/discord', async (req, res) => {
     connectionsWebhook: row?.connectionsWebhook ?? '',
     chainsWebhook:      row?.chainsWebhook ?? '',
     exitsMinSecurity:   row?.exitsMinSecurity ?? 0.45,
+    killWebhook:        row?.killWebhook ?? '',
+    killMinIsk:         Number(row?.killMinIsk ?? 0),
     maps:         maps.rows,
   });
 });
@@ -747,9 +751,17 @@ adminRouter.put('/discord', async (req, res) => {
     allRegions?: unknown; regions?: unknown; notifyChains?: unknown;
     whTypes?: unknown; whClasses?: unknown; whSizes?: unknown;
     connectionsWebhook?: unknown; chainsWebhook?: unknown; exitsMinSecurity?: unknown;
+    killWebhook?: unknown; killMinIsk?: unknown;
   };
   const allRegions   = body.allRegions !== false;   // default true
   const notifyChains = body.notifyChains !== false; // default true
+
+  // Minimum kill ISK for the Discord kill alert. Non-negative integer; default 0
+  // (notify for every kill the feed surfaces). Always written like the security
+  // threshold above (not a secret).
+  const killMinIsk = typeof body.killMinIsk === 'number' && Number.isFinite(body.killMinIsk) && body.killMinIsk >= 0
+    ? Math.floor(body.killMinIsk)
+    : 0;
 
   // Minimum k-space exit security for the rich exit embed. A finite number
   // clamped to EVE's [-1.0, 1.0] range; default 0.45 (high-sec) when absent or
@@ -771,7 +783,8 @@ adminRouter.put('/discord', async (req, res) => {
   };
   const conn  = resolveWebhook(body.connectionsWebhook);
   const chain = resolveWebhook(body.chainsWebhook);
-  if (conn.bad || chain.bad) {
+  const kill  = resolveWebhook(body.killWebhook);
+  if (conn.bad || chain.bad || kill.bad) {
     res.status(400).json({ error: 'Webhook must be a Discord webhook URL (https://discord.com/api/webhooks/…)' });
     return;
   }
@@ -797,11 +810,11 @@ adminRouter.put('/discord', async (req, res) => {
 
   // On an existing row, only overwrite a webhook column when the field was
   // provided (CASE on the `provided` flag); otherwise keep the stored value.
-  const params = [scope.id, allRegions, regions, notifyChains, whTypes, whClasses, whSizes, conn.value, chain.value, conn.provided, chain.provided, exitsMinSecurity];
+  const params = [scope.id, allRegions, regions, notifyChains, whTypes, whClasses, whSizes, conn.value, chain.value, conn.provided, chain.provided, exitsMinSecurity, kill.value, kill.provided, killMinIsk];
   if (scope.kind === 'alliance') {
     await db.query(
-      `INSERT INTO alliance_discord_settings (alliance_id, all_regions, regions, notify_chains, wh_types, wh_classes, wh_sizes, connections_webhook, chains_webhook, exits_min_security, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $12, NOW())
+      `INSERT INTO alliance_discord_settings (alliance_id, all_regions, regions, notify_chains, wh_types, wh_classes, wh_sizes, connections_webhook, chains_webhook, exits_min_security, kill_webhook, kill_min_isk, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $12, $13, $15, NOW())
        ON CONFLICT (alliance_id) DO UPDATE
          SET all_regions = EXCLUDED.all_regions, regions = EXCLUDED.regions,
              notify_chains = EXCLUDED.notify_chains, wh_types = EXCLUDED.wh_types,
@@ -809,13 +822,15 @@ adminRouter.put('/discord', async (req, res) => {
              connections_webhook = CASE WHEN $10 THEN EXCLUDED.connections_webhook ELSE alliance_discord_settings.connections_webhook END,
              chains_webhook      = CASE WHEN $11 THEN EXCLUDED.chains_webhook      ELSE alliance_discord_settings.chains_webhook END,
              exits_min_security = EXCLUDED.exits_min_security,
+             kill_webhook = CASE WHEN $14 THEN EXCLUDED.kill_webhook ELSE alliance_discord_settings.kill_webhook END,
+             kill_min_isk = EXCLUDED.kill_min_isk,
              updated_at = NOW()`,
       params,
     );
   } else {
     await db.query(
-      `INSERT INTO corp_discord_settings (corp_id, all_regions, regions, notify_chains, wh_types, wh_classes, wh_sizes, connections_webhook, chains_webhook, exits_min_security, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $12, NOW())
+      `INSERT INTO corp_discord_settings (corp_id, all_regions, regions, notify_chains, wh_types, wh_classes, wh_sizes, connections_webhook, chains_webhook, exits_min_security, kill_webhook, kill_min_isk, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $12, $13, $15, NOW())
        ON CONFLICT (corp_id) DO UPDATE
          SET all_regions = EXCLUDED.all_regions, regions = EXCLUDED.regions,
              notify_chains = EXCLUDED.notify_chains, wh_types = EXCLUDED.wh_types,
@@ -823,11 +838,13 @@ adminRouter.put('/discord', async (req, res) => {
              connections_webhook = CASE WHEN $10 THEN EXCLUDED.connections_webhook ELSE corp_discord_settings.connections_webhook END,
              chains_webhook      = CASE WHEN $11 THEN EXCLUDED.chains_webhook      ELSE corp_discord_settings.chains_webhook END,
              exits_min_security = EXCLUDED.exits_min_security,
+             kill_webhook = CASE WHEN $14 THEN EXCLUDED.kill_webhook ELSE corp_discord_settings.kill_webhook END,
+             kill_min_isk = EXCLUDED.kill_min_isk,
              updated_at = NOW()`,
       params,
     );
   }
-  res.json({ ok: true, allRegions, regions, notifyChains, whTypes, whClasses, whSizes, exitsMinSecurity });
+  res.json({ ok: true, allRegions, regions, notifyChains, whTypes, whClasses, whSizes, exitsMinSecurity, killMinIsk });
 });
 
 // PATCH /api/admin/maps/:id/discord — exclude / re-include one of the org's

--- a/server/src/routes/killboard.ts
+++ b/server/src/routes/killboard.ts
@@ -126,67 +126,51 @@ async function fetchEsi(killmailId: number, hash: string): Promise<EsiKillmail |
   return promise;
 }
 
-router.get('/:systemId(\\d+)', async (req, res) => {
-  // The route pattern already constrains this to digits, but parse to a bounded
-  // integer and build the upstream URL from the NUMBER (not the raw string) so
-  // no attacker-controlled text can ever reach the outbound request (SSRF).
-  const idNum = Number(req.params.systemId);
-  if (!Number.isInteger(idNum) || idNum <= 0 || idNum > 100_000_000) {
-    return res.status(400).json({ error: 'Invalid system id' });
-  }
-  const systemId = String(idNum);
+// Fetch (and cache) every kill in a system over the past `pastSeconds`, hydrated
+// from ESI and decorated with resolved char/corp/alliance names. Shared by the
+// killboard route (24h) and the kill-log backfill (1h). SSRF-safe: the URL is
+// built from the bounded NUMBER, never raw text. Cache is keyed by
+// system:pastSeconds so the two windows don't clobber each other.
+export async function fetchSystemKills(systemId: number, pastSeconds: number): Promise<KillEntry[]> {
+  if (!Number.isInteger(systemId) || systemId <= 0 || systemId > 100_000_000) return [];
+  const secs = Number.isInteger(pastSeconds) && pastSeconds > 0 && pastSeconds <= 604_800 ? pastSeconds : 86_400;
+  const key = `${systemId}:${secs}`;
 
-  // Fresh cache hit — return immediately. peek() falls back to any stale entry
-  // we can still serve from when the upstream is unhappy.
-  const fresh = cache.get(systemId);
-  if (fresh) return res.json(fresh.value);
-  const stale = cache.peek(systemId);
+  const fresh = cache.get(key);
+  if (fresh) return fresh.value;
+  const stale = cache.peek(key);
 
-  // zKillboard: every kill in the past 24h, NPC flag intact on each row.
-  // We used to pass `npc/0/` to exclude NPCs at the API level, but that
-  // made the client-side toggle ineffective — the server now hands back
-  // everything and the killboard pane decides whether to render NPC kills
-  // based on the user's preference.
-  const zkbUrl = `https://zkillboard.com/api/kills/solarSystemID/${idNum}/pastSeconds/86400/`;
-  const zkbHeaders: Record<string, string> = {
-    'User-Agent': ZKB_AGENT,
-    Accept:       'application/json',
-  };
+  const zkbUrl = `https://zkillboard.com/api/kills/solarSystemID/${systemId}/pastSeconds/${secs}/`;
+  const zkbHeaders: Record<string, string> = { 'User-Agent': ZKB_AGENT, Accept: 'application/json' };
   const cachedEtag = typeof stale?.meta?.etag === 'string' ? stale.meta.etag : undefined;
   if (cachedEtag) zkbHeaders['If-None-Match'] = cachedEtag;
 
   try {
     const zkbRes = await fetch(zkbUrl, { headers: zkbHeaders, signal: withTimeout(FETCH_TIMEOUT_MS) });
 
-    // zKillboard says nothing changed — refresh the TTL on the existing entry
-    // and return it.
+    // Nothing changed — refresh the TTL on the existing entry and return it.
     if (zkbRes.status === 304 && stale) {
-      cache.set(systemId, stale.value, stale.meta);
-      return res.json(stale.value);
+      cache.set(key, stale.value, stale.meta);
+      return stale.value;
     }
-
     if (!zkbRes.ok) {
-      if (stale) return res.json(stale.value);
+      if (stale) return stale.value;
       log.warn(`zKillboard returned ${zkbRes.status} for system ${systemId}`);
-      return res.json([]);
+      return [];
     }
 
     const zkbBody = (await zkbRes.json()) as ZkbEntry[];
-
     if (!Array.isArray(zkbBody)) {
-      if (stale) return res.json(stale.value);
+      if (stale) return stale.value;
       log.warn(`Unexpected response from zKillboard for system ${systemId}`);
-      return res.json([]);
+      return [];
     }
 
     const etag = zkbRes.headers.get('etag') ?? undefined;
 
-    // Fetch full killmail details from ESI in parallel. ESI concurrency is
-    // capped at ESI_MAX_CONCURRENT so a busy system (Jita, active null)
-    // queues rather than thundering CCP.
-    const esiResults = await Promise.all(
-      zkbBody.map((k) => fetchEsi(k.killmail_id, k.zkb.hash)),
-    );
+    // Hydrate full killmails from ESI in parallel (capped at ESI_MAX_CONCURRENT
+    // so a busy system queues rather than thundering CCP).
+    const esiResults = await Promise.all(zkbBody.map((k) => fetchEsi(k.killmail_id, k.zkb.hash)));
 
     const kills = zkbBody
       .map((zkb, i) => {
@@ -210,9 +194,7 @@ router.get('/:systemId(\\d+)', async (req, res) => {
       })
       .filter((k): k is KillEntry => k !== null);
 
-    // Resolve every char/corp/alliance ID in one batch and decorate the
-    // entries in-place with human names. Cache hits stay zero-cost; misses
-    // pay one bounded ESI call per unique missing entity, ever.
+    // Resolve every char/corp/alliance ID in one batch and decorate in place.
     const nameIds: number[] = [];
     for (const k of kills) {
       nameIds.push(k.victim.character_id!, k.victim.corporation_id!, k.victim.alliance_id!);
@@ -232,13 +214,23 @@ router.get('/:systemId(\\d+)', async (req, res) => {
       }
     }
 
-    cache.set(systemId, kills, etag ? { etag } : undefined);
-    return res.json(kills);
+    cache.set(key, kills, etag ? { etag } : undefined);
+    return kills;
   } catch (err) {
     log.warn(`Failed to reach zKillboard for system ${systemId}:`, (err as Error).message);
-    if (stale) return res.json(stale.value);
-    return res.json([]);
+    if (stale) return stale.value;
+    return [];
   }
+}
+
+router.get('/:systemId(\\d+)', async (req, res) => {
+  // The route pattern already constrains this to digits, but parse to a bounded
+  // integer so no attacker-controlled text can ever reach the outbound request.
+  const idNum = Number(req.params.systemId);
+  if (!Number.isInteger(idNum) || idNum <= 0 || idNum > 100_000_000) {
+    return res.status(400).json({ error: 'Invalid system id' });
+  }
+  return res.json(await fetchSystemKills(idNum, 86_400));
 });
 
 // GET /:systemId/last — the timestamp of the most recent kill in the system,

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -25,6 +25,9 @@ import { notifyDiscord, k162Embed, connectionEmbed, chainEmbed, kspaceExitEmbed 
 import { shortestRoutes } from '../services/routeGraph.js';
 import { whSizeForCode } from './wormholes.js';
 import { effectiveExpiryMs, lifeBucket } from '../data/whLifetimes.js';
+import { esiLimiter } from '../middleware/rateLimits.js';
+import { fetchSystemKills } from './killboard.js';
+import { resolveSystemMeta, resolveShipTypeName, type KillRow } from '../services/killFeed.js';
 
 const log = createLogger('maps');
 const discordLog = createLogger('discord');
@@ -1945,6 +1948,74 @@ mapsRouter.get('/:mapId/events', async (req, res) => {
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
   // Shared with the API-key stream at /api/v1/maps/:id/events.
   streamMapEvents(req, res, mapId);
+});
+
+// GET /api/maps/:mapId/kills/backfill — recent (last hour) high-value kills in
+// the map's systems, to seed the kill-log panel on open. Access-checked and
+// rate-limited (esiLimiter) since it fans out to zKill; the system count is
+// capped so a huge chain can't burst the feed. Returns KillRow[] newest-first.
+mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
+  const { mapId } = req.params;
+  const access = await getMapAccess(mapId, req);
+  if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
+
+  const { rows } = await db.query<{ eveSystemId: number }>(
+    `SELECT DISTINCT eve_system_id AS "eveSystemId"
+       FROM map_systems WHERE map_id = $1 AND eve_system_id IS NOT NULL`,
+    [mapId],
+  );
+  let systemIds = rows.map((r) => r.eveSystemId);
+  const cap = config.killFeed.backfillMaxSystems;
+  if (systemIds.length > cap) {
+    log.warn(`kill backfill: map ${mapId} has ${systemIds.length} systems, capping to ${cap}`);
+    systemIds = systemIds.slice(0, cap);
+  }
+  if (!systemIds.length) { res.json([]); return; }
+
+  // Per-system fetch is cached + ESI-concurrency-capped inside fetchSystemKills.
+  const perSystemFetch = async (sysId: number): Promise<KillRow[]> => {
+    const kills = (await fetchSystemKills(sysId, 3600))
+      .filter((k) => k.zkb.totalValue >= config.killFeed.minValueIsk);
+    if (!kills.length) return [];
+    const meta = await resolveSystemMeta(sysId);
+    return Promise.all(kills.map(async (k): Promise<KillRow> => ({
+      killmailId:  k.killmail_id,
+      atMs:        Date.parse(k.killmail_time) || Date.now(),
+      eveSystemId: sysId,
+      systemName:  meta.systemName,
+      regionName:  meta.regionName,
+      shipTypeId:  k.victim.ship_type_id,
+      shipTypeName: await resolveShipTypeName(k.victim.ship_type_id),
+      totalValue:  k.zkb.totalValue,
+      victimCharacterId:   k.victim.character_id ?? null,
+      victimName:          k.victim.character_name ?? null,
+      victimCorporationId: k.victim.corporation_id ?? null,
+      victimCorpName:      k.victim.corporation_name ?? null,
+    })));
+  };
+  // Bound the per-system zKill REST fan-out: fetchSystemKills caps the ESI
+  // hydration internally, but the outer list calls would otherwise all fire at
+  // once (up to backfillMaxSystems), bursting zKill on a cold cache. Process in
+  // small chunks so at most BACKFILL_CONCURRENCY systems hit zKill together.
+  const BACKFILL_CONCURRENCY = 5;
+  const perSystem: KillRow[][] = [];
+  for (let i = 0; i < systemIds.length; i += BACKFILL_CONCURRENCY) {
+    const chunk = systemIds.slice(i, i + BACKFILL_CONCURRENCY);
+    perSystem.push(...await Promise.all(chunk.map(perSystemFetch)));
+  }
+
+  // Merge, dedupe by killmail id, newest first, cap the response.
+  const seen = new Set<number>();
+  const merged: KillRow[] = [];
+  for (const list of perSystem) {
+    for (const row of list) {
+      if (seen.has(row.killmailId)) continue;
+      seen.add(row.killmailId);
+      merged.push(row);
+    }
+  }
+  merged.sort((a, b) => b.atMs - a.atMs);
+  res.json(merged.slice(0, 50));
 });
 
 // POST /api/maps/:mapId/presence — a viewer reports its current location.

--- a/server/src/services/discord.ts
+++ b/server/src/services/discord.ts
@@ -160,6 +160,33 @@ export function connectionEmbed(p: {
   };
 }
 
+// Compact ISK for the kill embed: 1.2B / 340M / 90K.
+function iskCompact(v: number): string {
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
+  if (v >= 1_000_000)     return `${Math.round(v / 1_000_000)}M`;
+  if (v >= 1_000)         return `${Math.round(v / 1_000)}K`;
+  return String(Math.round(v));
+}
+
+// A kill in a mapped system (zKill live feed). Names are resolved server-side
+// from ids; the killmail link lets readers drill into zKillboard.
+export function killEmbed(p: {
+  killmailId: number; systemName: string; regionName: string | null;
+  shipTypeName: string; totalValue: number;
+  victimName: string | null; victimCorpName: string | null; atMs: number;
+}): DiscordEmbed {
+  return {
+    title:       `💀 Kill in ${p.systemName}`,
+    description: `**${p.victimName ?? 'Unknown'}** [${p.victimCorpName ?? '?'}] lost a **${p.shipTypeName || 'ship'}**\n[View on zKillboard](https://zkillboard.com/kill/${p.killmailId}/)`,
+    color:       RED,
+    fields: [
+      { name: 'Value',  value: `${iskCompact(p.totalValue)} ISK`, inline: true },
+      { name: 'System', value: p.regionName ? `${p.systemName} (${p.regionName})` : p.systemName, inline: true },
+    ],
+    timestamp: new Date(p.atMs).toISOString(),
+  };
+}
+
 // Richer form of the new-connection notification for a freshly revealed k-space
 // exit reachable from the map's home: the security band, the chain path out to
 // it, and how far the nearest trade hub is by stargate. Same connections

--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -1,0 +1,140 @@
+import { config } from '../config.js';
+import { db } from '../db.js';
+import { createLogger } from '../utils/logger.js';
+import { activeMapIds, publishToMap } from './mapEvents.js';
+
+// Single-process consumer of zKillboard's RedisQ live feed. Long-polls the feed,
+// filters to high-value kills in systems that are currently on a live map, and
+// pushes a `kill.recent` event over the SSE stream so the client can flash the
+// system node. Opt-in (KILL_FEED=1). zKill fair-use: one consumer, a reachable
+// User-Agent contact, and backoff on failure — never a tight retry loop.
+const log = createLogger('killFeed');
+
+// ttw = long-poll wait (seconds): RedisQ holds the request open until a kill
+// arrives or the window elapses, so an idle feed paces itself with no client-side
+// delay and no busy-poll.
+const REDISQ_URL = `https://redisq.zkillboard.com/listen.php?queueID=${encodeURIComponent(config.killFeed.queueId)}&ttw=10`;
+const USER_AGENT = `Eve-Nexum/1.0 (${config.killFeed.contact})`;
+const FETCH_TIMEOUT_MS = 20_000;
+const MAX_BACKOFF_MS = 30_000;
+const MIN_CYCLE_MS = 2_000;
+const SEEN_CAP = 2000;
+
+// RedisQ payload — untrusted external input. Every field is coerced with Number()
+// at the use site; we forward only numeric ids + value + timestamp to clients,
+// never any attacker/victim name strings.
+interface RedisQResponse {
+  package: {
+    killmail?: {
+      killmail_id?:     number;
+      killmail_time?:   string;
+      solar_system_id?: number;
+      victim?:          { ship_type_id?: number };
+    };
+    zkb?: { totalValue?: number };
+  } | null;
+}
+
+// Bounded FIFO of recently-seen killmail ids — drops repeats across reconnects
+// without growing unbounded (insertion order lets us evict the oldest).
+const seen = new Set<number>();
+function markSeen(id: number): boolean {
+  if (seen.has(id)) return false;
+  seen.add(id);
+  if (seen.size > SEEN_CAP) {
+    const oldest = seen.values().next().value;
+    if (oldest !== undefined) seen.delete(oldest);
+  }
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    t.unref?.();
+  });
+}
+
+async function pollOnce(): Promise<void> {
+  const res = await fetch(REDISQ_URL, {
+    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    redirect: 'error',
+  });
+  if (!res.ok) throw new Error(`RedisQ HTTP ${res.status}`);
+
+  const body = await res.json() as RedisQResponse;
+  const km = body?.package?.killmail;
+  if (!km) return; // idle window — nothing this cycle
+
+  const killmailId    = Number(km.killmail_id);
+  const solarSystemId = Number(km.solar_system_id);
+  if (!Number.isFinite(killmailId) || !Number.isFinite(solarSystemId)) return;
+  if (!markSeen(killmailId)) return;
+
+  const totalValue = Number(body!.package!.zkb?.totalValue ?? 0);
+  if (!(totalValue >= config.killFeed.minValueIsk)) return;
+
+  // Only touch the DB when at least one map is actually being watched.
+  const live = activeMapIds();
+  if (!live.length) return;
+
+  const { rows } = await db.query<{ mapId: string }>(
+    `SELECT DISTINCT map_id AS "mapId"
+       FROM map_systems
+      WHERE eve_system_id = $1 AND map_id = ANY($2::uuid[])`,
+    [solarSystemId, live],
+  );
+  if (!rows.length) return;
+
+  const shipTypeId = Number(km.victim?.ship_type_id) || 0;
+  const parsed = km.killmail_time ? Date.parse(km.killmail_time) : NaN;
+  const atMs = Number.isFinite(parsed) ? parsed : Date.now();
+
+  for (const { mapId } of rows) {
+    publishToMap(mapId, {
+      type:        'kill.recent',
+      actor:       null,
+      eveSystemId: solarSystemId,
+      killmailId,
+      shipTypeId,
+      totalValue,
+      atMs,
+    });
+  }
+}
+
+let running = false;
+
+async function loop(): Promise<void> {
+  let backoff = 1_000;
+  while (running) {
+    const started = Date.now();
+    try {
+      await pollOnce();
+      backoff = 1_000; // success resets backoff (RedisQ ttw already paces us)
+      // Floor the request rate. RedisQ's ttw=10 normally holds the request ~10s,
+      // but if it ever returns fast (proxy, empty burst) this keeps us from
+      // busy-polling the feed — fair-use insurance, negligible for real kills.
+      const elapsed = Date.now() - started;
+      if (elapsed < MIN_CYCLE_MS) await sleep(MIN_CYCLE_MS - elapsed);
+    } catch (err) {
+      log.warn(`RedisQ poll failed (retry in ${Math.round(backoff / 1000)}s):`, err instanceof Error ? err.message : err);
+      await sleep(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    }
+  }
+}
+
+// Start the live kill feed. No-op unless KILL_FEED is set. Follows the
+// startXxx() + feature-flag-gate pattern of the other background services.
+export function startKillFeed(): void {
+  if (!config.killFeed.enabled) {
+    log.info('live kill feed disabled (KILL_FEED unset)');
+    return;
+  }
+  if (running) return;
+  running = true;
+  log.info(`live kill feed enabled (queueId="${config.killFeed.queueId}", min ${config.killFeed.minValueIsk.toLocaleString()} ISK)`);
+  void loop();
+}

--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -2,37 +2,94 @@ import { config } from '../config.js';
 import { db } from '../db.js';
 import { createLogger } from '../utils/logger.js';
 import { activeMapIds, publishToMap } from './mapEvents.js';
+import { resolveEntityNames } from './entityNames.js';
+import { notifyDiscord, killEmbed } from './discord.js';
 
-// Single-process consumer of zKillboard's RedisQ live feed. Long-polls the feed,
-// filters to high-value kills in systems that are currently on a live map, and
-// pushes a `kill.recent` event over the SSE stream so the client can flash the
-// system node. Opt-in (KILL_FEED=1). zKill fair-use: one consumer, a reachable
-// User-Agent contact, and backoff on failure — never a tight retry loop.
+// A single decorated kill, shared by the live SSE `kill.recent` event and the
+// REST backfill (routes/maps.ts). Every display name is resolved by US from a
+// numeric id (resolveEntityNames + SDE) — no zKill-supplied string is ever
+// forwarded (ESI killmails carry only ids anyway).
+export interface KillRow {
+  killmailId:          number;
+  atMs:                number;
+  eveSystemId:         number;
+  systemName:          string;
+  regionName:          string | null;
+  shipTypeId:          number;
+  shipTypeName:        string;
+  totalValue:          number;
+  victimCharacterId:   number | null;
+  victimName:          string | null;
+  victimCorporationId: number | null;
+  victimCorpName:      string | null;
+}
+
+// Static SDE lookups, cached in-process (system/region and ship-type names never
+// change between SDE re-seeds). Shared by the live consumer and the backfill.
+const systemMetaCache = new Map<number, { systemName: string; regionName: string | null }>();
+export async function resolveSystemMeta(id: number): Promise<{ systemName: string; regionName: string | null }> {
+  const hit = systemMetaCache.get(id);
+  if (hit) return hit;
+  const { rows } = await db.query<{ systemName: string; regionName: string | null }>(
+    `SELECT s.name AS "systemName", r.name AS "regionName"
+       FROM solar_systems s
+       LEFT JOIN map_regions r ON r.id = s.region_id
+      WHERE s.id = $1`,
+    [id],
+  );
+  const meta = rows[0] ?? { systemName: String(id), regionName: null };
+  systemMetaCache.set(id, meta);
+  return meta;
+}
+
+const shipNameCache = new Map<number, string>();
+export async function resolveShipTypeName(id: number): Promise<string> {
+  if (!id) return '';
+  const hit = shipNameCache.get(id);
+  if (hit !== undefined) return hit;
+  const { rows } = await db.query<{ name: string }>(`SELECT name FROM item_types WHERE id = $1`, [id]);
+  const name = rows[0]?.name ?? '';
+  shipNameCache.set(id, name);
+  return name;
+}
+
+// Single-process consumer of zKillboard's live killmail feed. Filters to
+// high-value kills in systems that are currently on a live map and pushes a
+// `kill.recent` event over the SSE stream so the client can flash the system
+// node. Opt-in (KILL_FEED=1).
+//
+// Transport is zKill's R2Z2 "ephemeral" feed (the replacement for the
+// sunset-2026 RedisQ): fetch a starting sequence, then GET each
+// /ephemeral/{seq}.json in order, incrementing until a 404 (caught up), then
+// sleep >= 6s and resume. Fair-use: one consumer, a reachable User-Agent
+// contact (a blank UA is Cloudflare-blocked), stay under 15 req/s, and honour
+// the mandatory 6s idle wait (violating it earns a 403). See
+// https://github.com/zKillboard/zKillboard/wiki/API-(R2Z2)
 const log = createLogger('killFeed');
 
-// ttw = long-poll wait (seconds): RedisQ holds the request open until a kill
-// arrives or the window elapses, so an idle feed paces itself with no client-side
-// delay and no busy-poll.
-const REDISQ_URL = `https://redisq.zkillboard.com/listen.php?queueID=${encodeURIComponent(config.killFeed.queueId)}&ttw=10`;
-const USER_AGENT = `Eve-Nexum/1.0 (${config.killFeed.contact})`;
-const FETCH_TIMEOUT_MS = 20_000;
+const R2Z2_SEQUENCE_URL = 'https://r2z2.zkillboard.com/ephemeral/sequence.json';
+const r2z2KillUrl = (seq: number) => `https://r2z2.zkillboard.com/ephemeral/${seq}.json`;
+const USER_AGENT = `Eve-Nexum/1.0 (${config.killFeed.contact})`; // non-blank UA required (Cloudflare)
+const FETCH_TIMEOUT_MS = 15_000;
 const MAX_BACKOFF_MS = 30_000;
-const MIN_CYCLE_MS = 2_000;
+const IDLE_SLEEP_MS = 6_000;  // mandatory >=6s wait after a 404 (caught up) — a shorter wait is 403'd
+const REQ_SPACING_MS = 120;   // ~8 req/s while catching up; comfortably under the 15 req/s cap
 const SEEN_CAP = 2000;
 
-// RedisQ payload — untrusted external input. Every field is coerced with Number()
-// at the use site; we forward only numeric ids + value + timestamp to clients,
-// never any attacker/victim name strings.
-interface RedisQResponse {
-  package: {
-    killmail?: {
-      killmail_id?:     number;
-      killmail_time?:   string;
-      solar_system_id?: number;
-      victim?:          { ship_type_id?: number };
-    };
-    zkb?: { totalValue?: number };
-  } | null;
+// R2Z2 ephemeral payload — untrusted external input. Every field is coerced with
+// Number() at the use site. ESI killmails carry only ids (no names); the display
+// names we send to clients are resolved by US from those ids (resolveEntityNames
+// + SDE), so no zKill-supplied string is ever forwarded.
+interface EsiKillmail {
+  killmail_id?:     number;
+  killmail_time?:   string;
+  solar_system_id?: number;
+  victim?:          { ship_type_id?: number; character_id?: number; corporation_id?: number };
+}
+interface EphemeralKill {
+  killmail_id?: number;
+  killmail?:    EsiKillmail;       // the raw ESI killmail (nested)
+  zkb?:         { totalValue?: number };
 }
 
 // Bounded FIFO of recently-seen killmail ids — drops repeats across reconnects
@@ -55,24 +112,28 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-async function pollOnce(): Promise<void> {
-  const res = await fetch(REDISQ_URL, {
+// GET a JSON document. A 404 is a normal signal (no killmail at this sequence
+// yet), returned as status 404 with a null body rather than thrown.
+async function getJson(url: string): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url, {
     headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'error',
   });
-  if (!res.ok) throw new Error(`RedisQ HTTP ${res.status}`);
+  if (res.status === 404) return { status: 404, body: null };
+  if (!res.ok) throw new Error(`R2Z2 HTTP ${res.status}`);
+  return { status: 200, body: await res.json() };
+}
 
-  const body = await res.json() as RedisQResponse;
-  const km = body?.package?.killmail;
-  if (!km) return; // idle window — nothing this cycle
-
-  const killmailId    = Number(km.killmail_id);
+// Process one ephemeral killmail: filter, match to live maps, decorate, publish.
+async function processKill(body: EphemeralKill): Promise<void> {
+  const km = body.killmail ?? {};
+  const killmailId    = Number(body.killmail_id ?? km.killmail_id);
   const solarSystemId = Number(km.solar_system_id);
   if (!Number.isFinite(killmailId) || !Number.isFinite(solarSystemId)) return;
   if (!markSeen(killmailId)) return;
 
-  const totalValue = Number(body!.package!.zkb?.totalValue ?? 0);
+  const totalValue = Number(body.zkb?.totalValue ?? 0);
   if (!(totalValue >= config.killFeed.minValueIsk)) return;
 
   // Only touch the DB when at least one map is actually being watched.
@@ -87,20 +148,65 @@ async function pollOnce(): Promise<void> {
   );
   if (!rows.length) return;
 
-  const shipTypeId = Number(km.victim?.ship_type_id) || 0;
+  // Numeric ids only from the (untrusted) killmail. character_id is absent for
+  // structure/NPC-only losses -> null. `Number(x) || null` maps 0/NaN to null;
+  // a real id is a large positive number so it survives.
+  const shipTypeId          = Number(km.victim?.ship_type_id) || 0;
+  const victimCharacterId   = Number(km.victim?.character_id) || null;
+  const victimCorporationId = Number(km.victim?.corporation_id) || null;
   const parsed = km.killmail_time ? Date.parse(km.killmail_time) : NaN;
   const atMs = Number.isFinite(parsed) ? parsed : Date.now();
 
+  // Resolve who/what/where from the ids on OUR side (ESI cache + SDE) — the
+  // killmail carries no names, so nothing untrusted is echoed to clients.
+  const [meta, shipTypeName, names] = await Promise.all([
+    resolveSystemMeta(solarSystemId),
+    resolveShipTypeName(shipTypeId),
+    resolveEntityNames([victimCharacterId, victimCorporationId]),
+  ]);
+  const killRow: KillRow = {
+    killmailId, atMs, eveSystemId: solarSystemId,
+    systemName: meta.systemName, regionName: meta.regionName,
+    shipTypeId, shipTypeName, totalValue,
+    victimCharacterId,
+    victimName: victimCharacterId ? names.get(victimCharacterId)?.name ?? null : null,
+    victimCorporationId,
+    victimCorpName: victimCorporationId ? names.get(victimCorporationId)?.name ?? null : null,
+  };
+
   for (const { mapId } of rows) {
-    publishToMap(mapId, {
-      type:        'kill.recent',
-      actor:       null,
-      eveSystemId: solarSystemId,
-      killmailId,
-      shipTypeId,
-      totalValue,
-      atMs,
-    });
+    publishToMap(mapId, { type: 'kill.recent', actor: null, ...killRow });
+  }
+
+  // Corp/alliance Discord kill alert for the matched maps (opt-in per org).
+  await dispatchDiscord(rows.map((r) => r.mapId), killRow);
+}
+
+// Send a Discord kill alert to the webhook of each matched corp/alliance map
+// that has one configured and whose per-org min-ISK the kill clears. Dedupes by
+// URL so two maps sharing a webhook get a single message. Best-effort — a webhook
+// lookup failure is logged and swallowed, never breaking the poll loop.
+async function dispatchDiscord(mapIds: string[], kill: KillRow): Promise<void> {
+  if (!mapIds.length) return;
+  try {
+    const { rows } = await db.query<{ killWebhook: string | null; killMinIsk: string }>(
+      `SELECT COALESCE(cds.kill_webhook, ads.kill_webhook)      AS "killWebhook",
+              COALESCE(cds.kill_min_isk, ads.kill_min_isk, 0)   AS "killMinIsk"
+         FROM maps m
+         LEFT JOIN corp_discord_settings     cds ON cds.corp_id     = m.corp_id
+         LEFT JOIN alliance_discord_settings ads ON ads.alliance_id = m.alliance_id
+        WHERE m.id = ANY($1::uuid[])`,
+      [mapIds],
+    );
+    const sent = new Set<string>();
+    for (const r of rows) {
+      if (!r.killWebhook || sent.has(r.killWebhook)) continue;
+      if (kill.totalValue < Number(r.killMinIsk)) continue;
+      sent.add(r.killWebhook);
+      notifyDiscord(r.killWebhook, killEmbed(kill));
+    }
+  } catch (err) {
+    log.warn('kill Discord dispatch failed:', err instanceof Error ? err.message : err);
   }
 }
 
@@ -108,18 +214,30 @@ let running = false;
 
 async function loop(): Promise<void> {
   let backoff = 1_000;
+  let seq: number | null = null;
   while (running) {
-    const started = Date.now();
     try {
-      await pollOnce();
-      backoff = 1_000; // success resets backoff (RedisQ ttw already paces us)
-      // Floor the request rate. RedisQ's ttw=10 normally holds the request ~10s,
-      // but if it ever returns fast (proxy, empty burst) this keeps us from
-      // busy-polling the feed — fair-use insurance, negligible for real kills.
-      const elapsed = Date.now() - started;
-      if (elapsed < MIN_CYCLE_MS) await sleep(MIN_CYCLE_MS - elapsed);
+      // Obtain a starting sequence once (and again after a hard error resets it).
+      if (seq === null) {
+        const { body } = await getJson(R2Z2_SEQUENCE_URL);
+        const n = Number((body as { sequence?: number } | null)?.sequence);
+        if (!Number.isFinite(n)) throw new Error('R2Z2 sequence.json: missing sequence');
+        seq = n;
+      }
+      const { status, body } = await getJson(r2z2KillUrl(seq));
+      if (status === 404) {
+        // Caught up — no killmail at this sequence yet. Honour the mandatory
+        // >=6s wait, then retry the SAME sequence.
+        await sleep(IDLE_SLEEP_MS);
+        backoff = 1_000;
+        continue;
+      }
+      await processKill(body as EphemeralKill);
+      seq += 1;                     // advance past the processed killmail
+      backoff = 1_000;
+      await sleep(REQ_SPACING_MS);  // pace catch-up bursts under the 15 req/s cap
     } catch (err) {
-      log.warn(`RedisQ poll failed (retry in ${Math.round(backoff / 1000)}s):`, err instanceof Error ? err.message : err);
+      log.warn(`R2Z2 poll failed (retry in ${Math.round(backoff / 1000)}s):`, err instanceof Error ? err.message : err);
       await sleep(backoff);
       backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
     }
@@ -135,6 +253,6 @@ export function startKillFeed(): void {
   }
   if (running) return;
   running = true;
-  log.info(`live kill feed enabled (queueId="${config.killFeed.queueId}", min ${config.killFeed.minValueIsk.toLocaleString()} ISK)`);
+  log.info(`live kill feed enabled (R2Z2 ephemeral, min ${config.killFeed.minValueIsk.toLocaleString()} ISK)`);
   void loop();
 }

--- a/server/src/services/mapEvents.ts
+++ b/server/src/services/mapEvents.ts
@@ -33,6 +33,14 @@ export function subscribeMap(mapId: string, res: Response): () => void {
   };
 }
 
+// Map ids that currently have at least one live SSE subscriber. A key exists in
+// `subscribers` only while its Set is non-empty (see the cleanup in the
+// unsubscribe fn above), so the keys ARE the set of actively-viewed maps. Lets
+// background producers (e.g. the kill feed) skip work for maps nobody is watching.
+export function activeMapIds(): string[] {
+  return [...subscribers.keys()];
+}
+
 // Register a transform callback for a map's events. Returns an unsubscribe fn.
 // The callback gets the event object (not an SSE frame), so the caller decides
 // what, if anything, to forward.

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -10,6 +10,7 @@ import type { MapSystem } from '../../types';
 import { CLASS_COLORS, CLASS_LABELS, EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIERS } from '../../data/wormholes';
 import { useMapStore } from '../../store/mapStore';
 import { usePresenceStore } from '../../store/presenceStore';
+import { useSystemKill, RECENT_KILL_MS } from '../../store/killStore';
 import { useAccountLocations } from '../../hooks/useAccountLocations';
 import { useSovData } from '../../hooks/useSovData';
 import { useStandings } from '../../hooks/useStandings';
@@ -45,6 +46,14 @@ import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
 type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean; routeHighlighted?: boolean };
+
+// Compact ISK for the recent-kill tooltip: 1.2B / 340M / 90K.
+function iskCompact(v: number): string {
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
+  if (v >= 1_000_000)     return `${(v / 1_000_000).toFixed(0)}M`;
+  if (v >= 1_000)         return `${(v / 1_000).toFixed(0)}K`;
+  return String(Math.round(v));
+}
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();
@@ -149,6 +158,8 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const allKills        = useCurrentHourKills();
   const myKills         = sys.eveSystemId !== null ? allKills.get(sys.eveSystemId) : undefined;
   const hotKills        = !!myKills && myKills.shipKills + myKills.podKills > 0;
+  // Live "a kill just happened here" flag from the zKill feed (ephemeral, SSE).
+  const recentKill      = useSystemKill(sys.eveSystemId);
 
   // Active heatmap glow for this node — value for the selected metric,
   // normalised against the per-map max (from HeatmapContext). null = no glow
@@ -166,6 +177,9 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
     return { glow: Math.min(1, raw * heatmap.intensity), color: heatColor(raw, heatmap.colorVision !== 'off') };
   }, [heatmap.metric, heatmap.max, heatmap.intensity, heatmap.colorVision, sys.eveSystemId, allKills, fleet, user?.characterId]);
   const now             = useNow30s();
+  // The flag fades once the kill ages past the display window; the 30s ticker
+  // re-evaluates this so it drops on its own without another SSE frame.
+  const killFresh       = !!recentKill && now - recentKill.atMs < RECENT_KILL_MS;
   const [staleHours]    = useStaleThreshold();
   // staleHours === 0 is the "Never fade" sentinel: no system is ever stale.
   const isStale         = staleHours > 0 && !!sys.lastActivityAt &&
@@ -410,6 +424,17 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
       <div className="system-node__meta-row">
         <span className="system-node__class-badge">{CLASS_LABELS[sys.systemClass]}</span>
         <div className="system-node__icons">
+          {killFresh && recentKill && (
+            <span className="system-node__recentkill-icon">
+              <SkullIcon size={14} weight="fill" />
+              <span className="system-node__recentkill-tooltip">
+                {t('mapNode.recentKill', {
+                  value: iskCompact(recentKill.totalValue),
+                  ago: Math.max(0, Math.round((now - recentKill.atMs) / 60_000)),
+                })}
+              </span>
+            </span>
+          )}
           {hotKills && myKills && (
             <span className="system-node__kill-icon">
               <SwordIcon size={14} weight="regular" />

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -11,6 +11,7 @@ import { CLASS_COLORS, CLASS_LABELS, EFFECT_ICONS, EFFECT_LABELS, EFFECT_MODIFIE
 import { useMapStore } from '../../store/mapStore';
 import { usePresenceStore } from '../../store/presenceStore';
 import { useSystemKill, RECENT_KILL_MS } from '../../store/killStore';
+import { iskCompact } from '../../utils/isk';
 import { useAccountLocations } from '../../hooks/useAccountLocations';
 import { useSovData } from '../../hooks/useSovData';
 import { useStandings } from '../../hooks/useStandings';
@@ -46,14 +47,6 @@ import { WHTypeInfo } from '../ui/WHTypeInfo';
 import { truesecColor } from '../../utils/truesec';
 
 type SystemNodeData = MapSystem & { selected: boolean; dimmed?: boolean; routeHighlighted?: boolean };
-
-// Compact ISK for the recent-kill tooltip: 1.2B / 340M / 90K.
-function iskCompact(v: number): string {
-  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
-  if (v >= 1_000_000)     return `${(v / 1_000_000).toFixed(0)}M`;
-  if (v >= 1_000)         return `${(v / 1_000).toFixed(0)}K`;
-  return String(Math.round(v));
-}
 
 export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const { t } = useTranslation();

--- a/web/src/components/ui/AdminPage.tsx
+++ b/web/src/components/ui/AdminPage.tsx
@@ -1723,6 +1723,8 @@ interface DiscordSettings {
   connectionsWebhook: string;
   chainsWebhook:      string;
   exitsMinSecurity:   number;
+  killWebhook:        string;
+  killMinIsk:         number;
   maps:         { id: string; name: string; excluded: boolean }[];
 }
 interface RegionOption { id: number; name: string }
@@ -1761,6 +1763,10 @@ function DiscordTab() {
   const [chainWebhook, setChainWebhook] = useState('');
   // Minimum k-space exit security for the rich exit embed (default 0.45 = HS).
   const [exitMinSec, setExitMinSec]     = useState(0.45);
+  // Kill-alert webhook (empty = off) + its per-org minimum ISK (0 = every kill
+  // the feed surfaces). Requires the server KILL_FEED consumer to be enabled.
+  const [killWebhook, setKillWebhook]   = useState('');
+  const [killMinIsk, setKillMinIsk]     = useState(0);
 
   const load = useCallback(async () => {
     try {
@@ -1777,6 +1783,8 @@ function DiscordTab() {
       setConnWebhook(s.connectionsWebhook ?? '');
       setChainWebhook(s.chainsWebhook ?? '');
       setExitMinSec(s.exitsMinSecurity ?? 0.45);
+      setKillWebhook(s.killWebhook ?? '');
+      setKillMinIsk(s.killMinIsk ?? 0);
       setRegionOpts(r.regions);
       setError(null);
     } catch (e) {
@@ -1795,8 +1803,8 @@ function DiscordTab() {
     try {
       // Send every field the PUT can wipe (it defaults absent flags/lists), so a
       // save never silently resets the chain toggle or another filter dimension.
-      await api('/api/admin/discord', { method: 'PUT', body: JSON.stringify({ allRegions, regions, notifyChains: data.notifyChains, whTypes, whClasses, whSizes, connectionsWebhook: connWebhook.trim(), chainsWebhook: chainWebhook.trim(), exitsMinSecurity: exitMinSec }) });
-      setData((d) => (d ? { ...d, allRegions, regions, whTypes, whClasses, whSizes, connectionsWebhook: connWebhook.trim(), chainsWebhook: chainWebhook.trim(), exitsMinSecurity: exitMinSec } : d));
+      await api('/api/admin/discord', { method: 'PUT', body: JSON.stringify({ allRegions, regions, notifyChains: data.notifyChains, whTypes, whClasses, whSizes, connectionsWebhook: connWebhook.trim(), chainsWebhook: chainWebhook.trim(), exitsMinSecurity: exitMinSec, killWebhook: killWebhook.trim(), killMinIsk }) });
+      setData((d) => (d ? { ...d, allRegions, regions, whTypes, whClasses, whSizes, connectionsWebhook: connWebhook.trim(), chainsWebhook: chainWebhook.trim(), exitsMinSecurity: exitMinSec, killWebhook: killWebhook.trim(), killMinIsk } : d));
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e) {
@@ -1813,7 +1821,7 @@ function DiscordTab() {
     const prev = data.notifyChains;
     setData((d) => (d ? { ...d, notifyChains: next } : d));
     try {
-      await api('/api/admin/discord', { method: 'PUT', body: JSON.stringify({ allRegions: data.allRegions, regions: data.regions, notifyChains: next, whTypes: data.whTypes, whClasses: data.whClasses, whSizes: data.whSizes, connectionsWebhook: data.connectionsWebhook, chainsWebhook: data.chainsWebhook, exitsMinSecurity: data.exitsMinSecurity }) });
+      await api('/api/admin/discord', { method: 'PUT', body: JSON.stringify({ allRegions: data.allRegions, regions: data.regions, notifyChains: next, whTypes: data.whTypes, whClasses: data.whClasses, whSizes: data.whSizes, connectionsWebhook: data.connectionsWebhook, chainsWebhook: data.chainsWebhook, exitsMinSecurity: data.exitsMinSecurity, killWebhook: data.killWebhook, killMinIsk: data.killMinIsk }) });
     } catch (e) {
       setData((d) => (d ? { ...d, notifyChains: prev } : d));
       setError(e instanceof Error ? e.message : t('admin.discord.saveFailed'));
@@ -1861,7 +1869,9 @@ function DiscordTab() {
     || sortJoin(whSizes)   !== sortJoin(data.whSizes)
     || connWebhook.trim()  !== data.connectionsWebhook
     || chainWebhook.trim() !== data.chainsWebhook
-    || exitMinSec          !== data.exitsMinSecurity;
+    || exitMinSec          !== data.exitsMinSecurity
+    || killWebhook.trim()  !== data.killWebhook
+    || killMinIsk          !== data.killMinIsk;
 
   return (
     <>
@@ -1891,6 +1901,26 @@ function DiscordTab() {
           value={chainWebhook}
           spellCheck={false}
           onChange={(e) => setChainWebhook(e.target.value)}
+        />
+        <label className={styles.dcSublabel} htmlFor="kill-webhook">{t('admin.discord.killWebhook')}</label>
+        <input
+          id="kill-webhook"
+          type="url"
+          className={`${styles.dcSearch} ${styles.dcSearchWide}`}
+          placeholder="https://discord.com/api/webhooks/…"
+          value={killWebhook}
+          spellCheck={false}
+          onChange={(e) => setKillWebhook(e.target.value)}
+        />
+        <label className={styles.dcSublabel} htmlFor="kill-min-isk">{t('admin.discord.killMinIsk')}</label>
+        <input
+          id="kill-min-isk"
+          type="number"
+          min={0}
+          step={1000000}
+          className={styles.dcSearch}
+          value={killMinIsk}
+          onChange={(e) => setKillMinIsk(Math.max(0, Math.floor(Number(e.target.value) || 0)))}
         />
       </section>
 

--- a/web/src/components/ui/KillLogPanel.tsx
+++ b/web/src/components/ui/KillLogPanel.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { XIcon, SkullIcon } from '@phosphor-icons/react';
+import { api } from '../../api/client';
+import { useMapStore } from '../../store/mapStore';
+import { useKillStore, useKillLog, type KillRow } from '../../store/killStore';
+import { useNow30s } from '../../hooks/useNow30s';
+import { charPortrait, corpLogo, typeRender } from '../../utils/eveImages';
+import { iskCompact } from '../../utils/isk';
+
+interface Props { onClose: () => void; }
+
+// zKillboard permalink for a killmail.
+const zkbLink = (killmailId: number) => `https://zkillboard.com/kill/${killmailId}/`;
+
+// Compact age token ("3m" / "2h" / "1d"), or null for < 1 minute (rendered as
+// the localised "now"). Kept unit-only so one translatable "{{d}} ago" wrapper
+// works across locales.
+function durToken(atMs: number, now: number): string | null {
+  const s = Math.max(0, Math.floor((now - atMs) / 1000));
+  if (s < 60) return null;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+function KillRowItem({ k, now }: { k: KillRow; now: number }) {
+  const { t } = useTranslation();
+  const portrait = k.victimCharacterId
+    ? charPortrait(k.victimCharacterId, 64)
+    : k.victimCorporationId ? corpLogo(k.victimCorporationId, 64) : null;
+  const d = durToken(k.atMs, now);
+  const ago = d ? t('killLog.ago', { d }) : t('time.now');
+  return (
+    <a
+      className="killlog__row"
+      href={zkbLink(k.killmailId)}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={t('killLog.viewOnZkb')}
+    >
+      <div className="killlog__thumbs">
+        {portrait && <img className="killlog__portrait" src={portrait} alt="" loading="lazy" />}
+        <img className="killlog__ship" src={typeRender(k.shipTypeId, 64)} alt="" loading="lazy" />
+      </div>
+      <div className="killlog__who">
+        <span className="killlog__victim">{k.victimName ?? t('killLog.unknown')}</span>
+        <span className="killlog__corp">{k.victimCorpName ?? ''}</span>
+      </div>
+      <div className="killlog__what">
+        <span className="killlog__ship-name">{k.shipTypeName || t('killLog.unknownShip')}</span>
+        <span className="killlog__value">{iskCompact(k.totalValue)} ISK</span>
+      </div>
+      <div className="killlog__where">
+        <span className="killlog__system">{k.systemName}</span>
+        <span className="killlog__region">{k.regionName ?? ''}</span>
+      </div>
+      <span className="killlog__ago">{ago}</span>
+    </a>
+  );
+}
+
+export function KillLogPanel({ onClose }: Props) {
+  const { t } = useTranslation();
+  const activeMapId = useMapStore((s) => s.activeMapId);
+  const log = useKillLog();
+  const now = useNow30s();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the log from the last-hour backfill on open / map change. All setState
+  // happens in the async callbacks so nothing runs synchronously in the effect.
+  useEffect(() => {
+    if (!activeMapId) return;
+    let cancelled = false;
+    api<KillRow[]>(`/api/maps/${activeMapId}/kills/backfill`)
+      .then((rows) => { if (!cancelled) { useKillStore.getState().seedBackfill(rows); setError(null); } })
+      .catch(() => { if (!cancelled) setError(t('killLog.error')); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [activeMapId, t]);
+
+  const showLoading = loading && !!activeMapId;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal killlog-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal__header">
+          <h2 className="modal__title"><SkullIcon size={18} weight="fill" /> {t('killLog.title')}</h2>
+          <button className="icon-btn" onClick={onClose} aria-label={t('actions.close')}><XIcon size={16} weight="bold" /></button>
+        </div>
+        <div className="modal__body killlog__body">
+          {showLoading && log.length === 0 && <div className="killlog__status">{t('killLog.loading')}</div>}
+          {error && log.length === 0 && <div className="killlog__status killlog__status--error">{error}</div>}
+          {!showLoading && !error && log.length === 0 && <div className="killlog__status">{t('killLog.empty')}</div>}
+          {log.length > 0 && (
+            <div className="killlog__list">
+              {log.map((k) => <KillRowItem key={k.killmailId} k={k} now={now} />)}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -20,6 +20,7 @@ import { LanguageSwitcher } from './LanguageSwitcher';
 import { CharacterSwitcher } from './CharacterSwitcher';
 import { HeatmapMenu } from './HeatmapMenu';
 import { WhTypeChartModal } from './WhTypeChartModal';
+import { KillLogPanel } from './KillLogPanel';
 import { useProximityAlerts } from '../../hooks/useProximityAlerts';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { useUserSetting } from '../../hooks/useUserSetting';
@@ -293,6 +294,7 @@ export function Toolbar() {
   const [showCopy, setShowCopy] = useState(false);
   const [showKeys, setShowKeys] = useState(false);
   const [showWhChart, setShowWhChart] = useState(false);
+  const [showKillLog, setShowKillLog] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const mapSwitcherRef = useRef<HTMLDivElement>(null);
   useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
@@ -540,6 +542,15 @@ export function Toolbar() {
           <GraphIcon size={18} weight="regular" />
         </button>
 
+        <button
+          className="toolbar__toggle toolbar__toggle--icon toolbar__toggle--prominent"
+          onClick={() => setShowKillLog(true)}
+          data-tooltip={t('killLog.tooltip')}
+          aria-label={t('killLog.title')}
+        >
+          <SkullIcon size={18} weight="regular" />
+        </button>
+
         <HeatmapMenu />
 
         <button
@@ -739,6 +750,7 @@ export function Toolbar() {
     {showCopy && <CopyMapModal onClose={() => setShowCopy(false)} />}
     {showKeys && <ApiKeysModal onClose={() => setShowKeys(false)} />}
     {showWhChart && <WhTypeChartModal onClose={() => setShowWhChart(false)} />}
+    {showKillLog && <KillLogPanel onClose={() => setShowKillLog(false)} />}
     {deleteConfirm && (
       <ConfirmModal
         message={t('toolbar.deleteMapConfirm', { name: mapName })}

--- a/web/src/hooks/useMapEventStream.ts
+++ b/web/src/hooks/useMapEventStream.ts
@@ -49,13 +49,21 @@ export function useMapEventStream(): void {
             presence.remove(data.characterId as number);
             return;
           case 'kill.recent':
-            // Ephemeral, non-map state — route to the kill store, not mapStore.
+            // Ephemeral, non-map state — route the whole decorated KillRow to the
+            // kill store (flags the node + feeds the log), not mapStore.
             useKillStore.getState().recordKill({
-              eveSystemId: data.eveSystemId as number,
-              killmailId:  data.killmailId as number,
-              shipTypeId:  data.shipTypeId as number,
-              totalValue:  data.totalValue as number,
-              atMs:        data.atMs as number,
+              killmailId:          data.killmailId as number,
+              atMs:                data.atMs as number,
+              eveSystemId:         data.eveSystemId as number,
+              systemName:          data.systemName as string,
+              regionName:          (data.regionName as string | null) ?? null,
+              shipTypeId:          data.shipTypeId as number,
+              shipTypeName:        data.shipTypeName as string,
+              totalValue:          data.totalValue as number,
+              victimCharacterId:   (data.victimCharacterId as number | null) ?? null,
+              victimName:          (data.victimName as string | null) ?? null,
+              victimCorporationId: (data.victimCorporationId as number | null) ?? null,
+              victimCorpName:      (data.victimCorpName as string | null) ?? null,
             });
             return;
         }

--- a/web/src/hooks/useMapEventStream.ts
+++ b/web/src/hooks/useMapEventStream.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useMapStore, type RemoteEvent } from '../store/mapStore';
 import { usePresenceStore, type PresenceViewer } from '../store/presenceStore';
+import { useKillStore } from '../store/killStore';
 import { apiUrl } from '../api/client';
 import { CLIENT_ID } from '../api/clientId';
 
@@ -17,6 +18,7 @@ export function useMapEventStream(): void {
     if (!activeMapId) return;
     openedOnce.current = false;
     usePresenceStore.getState().reset(); // clear last map's roster; snapshot repopulates
+    useKillStore.getState().reset();     // clear last map's kill flags
 
     const es = new EventSource(apiUrl(`/api/maps/${activeMapId}/events`), { withCredentials: true });
 
@@ -45,6 +47,16 @@ export function useMapEventStream(): void {
             return;
           case 'presence.leave':
             presence.remove(data.characterId as number);
+            return;
+          case 'kill.recent':
+            // Ephemeral, non-map state — route to the kill store, not mapStore.
+            useKillStore.getState().recordKill({
+              eveSystemId: data.eveSystemId as number,
+              killmailId:  data.killmailId as number,
+              shipTypeId:  data.shipTypeId as number,
+              totalValue:  data.totalValue as number,
+              atMs:        data.atMs as number,
+            });
             return;
         }
 

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "Alle Karten benachrichtigen standardmäßig. Hake eine Karte an, um sie von Discord auszuschließen.",
       "noCorpMaps": "Noch keine Corp-Karten.",
       "colMap": "Karte",
-      "colExclude": "Ausschließen"
+      "colExclude": "Ausschließen",
+      "killWebhook": "Kill-Webhook",
+      "killMinIsk": "Mindest-ISK"
     },
     "roles": {
       "button": "Rollen?",
@@ -1782,5 +1784,16 @@
     "typePersonal": "Persönlich",
     "typeCorp": "Corp",
     "typeAlliance": "Allianz"
+  },
+  "killLog": {
+    "title": "Kill-Log",
+    "tooltip": "Aktuelle Kills auf dieser Karte",
+    "empty": "Keine aktuellen Kills",
+    "loading": "Kills werden geladen...",
+    "error": "Kills konnten nicht geladen werden",
+    "viewOnZkb": "Auf zKillboard ansehen",
+    "unknown": "Unbekannt",
+    "unknownShip": "Unbekanntes Schiff",
+    "ago": "vor {{d}}"
   }
 }

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Charakter {{id}}",
     "altLastKnown": "(zuletzt bekannt)",
     "killsTooltip": "{{ships}} Schiff · {{pods}} Pod-Kills diese Stunde",
+    "recentKill": "Kill vor {{ago}} Min. ({{value}} ISK)",
     "a0Sun": "A0-Sonne",
     "shattered": "Zerschmettert",
     "iceBelt": "Eisgürtel-System",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -382,7 +382,9 @@
       "excludedHint": "All maps notify by default. Tick a map to exclude it from Discord.",
       "noCorpMaps": "No corp maps yet.",
       "colMap": "Map",
-      "colExclude": "Exclude"
+      "colExclude": "Exclude",
+      "killWebhook": "Kill webhook",
+      "killMinIsk": "Minimum ISK"
     }
   },
   "proximityOptIn": {
@@ -1782,5 +1784,16 @@
     "unmapped": "Unmapped hole",
     "filled": "{{sig}} now leads to {{system}}",
     "undo": "Undo"
+  },
+  "killLog": {
+    "title": "Kill Log",
+    "tooltip": "Recent kills on this map",
+    "empty": "No recent kills",
+    "loading": "Loading kills...",
+    "error": "Couldn't load kills",
+    "viewOnZkb": "View on zKillboard",
+    "unknown": "Unknown",
+    "unknownShip": "Unknown ship",
+    "ago": "{{d}} ago"
   }
 }

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1732,6 +1732,7 @@
     "characterFallback": "Character {{id}}",
     "altLastKnown": "(last known)",
     "killsTooltip": "{{ships}} ship · {{pods}} pod kills this hour",
+    "recentKill": "Kill {{ago}}m ago ({{value}} ISK)",
     "a0Sun": "A0 sun",
     "shattered": "Shattered",
     "iceBelt": "Ice belt system",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "Todos los mapas notifican por defecto. Marca un mapa para excluirlo de Discord.",
       "noCorpMaps": "Aún no hay mapas de corp.",
       "colMap": "Mapa",
-      "colExclude": "Excluir"
+      "colExclude": "Excluir",
+      "killWebhook": "Webhook de bajas",
+      "killMinIsk": "ISK mínimo"
     },
     "roles": {
       "button": "¿Roles?",
@@ -1782,5 +1784,16 @@
     "typePersonal": "Personal",
     "typeCorp": "Corp",
     "typeAlliance": "Alianza"
+  },
+  "killLog": {
+    "title": "Registro de bajas",
+    "tooltip": "Bajas recientes en este mapa",
+    "empty": "Sin bajas recientes",
+    "loading": "Cargando bajas...",
+    "error": "No se pudieron cargar las bajas",
+    "viewOnZkb": "Ver en zKillboard",
+    "unknown": "Desconocido",
+    "unknownShip": "Nave desconocida",
+    "ago": "hace {{d}}"
   }
 }

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Personaje {{id}}",
     "altLastKnown": "(última conocida)",
     "killsTooltip": "{{ships}} nave · {{pods}} cápsula destruidas esta hora",
+    "recentKill": "Muerte hace {{ago}} min ({{value}} ISK)",
     "a0Sun": "Sol A0",
     "shattered": "Destrozado",
     "iceBelt": "Sistema con cinturón de hielo",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Personnage {{id}}",
     "altLastKnown": "(dernière connue)",
     "killsTooltip": "{{ships}} vaisseau · {{pods}} capsule détruits cette heure",
+    "recentKill": "Kill il y a {{ago}} min ({{value}} ISK)",
     "a0Sun": "Soleil A0",
     "shattered": "Brisé",
     "iceBelt": "Système à ceinture de glace",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "Toutes les cartes notifient par défaut. Cochez une carte pour l'exclure de Discord.",
       "noCorpMaps": "Aucune carte de corp pour l'instant.",
       "colMap": "Carte",
-      "colExclude": "Exclure"
+      "colExclude": "Exclure",
+      "killWebhook": "Webhook des kills",
+      "killMinIsk": "ISK minimum"
     },
     "roles": {
       "button": "Rôles ?",
@@ -1782,5 +1784,16 @@
     "typePersonal": "Personnelle",
     "typeCorp": "Corpo",
     "typeAlliance": "Alliance"
+  },
+  "killLog": {
+    "title": "Journal des kills",
+    "tooltip": "Kills récents sur cette carte",
+    "empty": "Aucun kill récent",
+    "loading": "Chargement des kills...",
+    "error": "Impossible de charger les kills",
+    "viewOnZkb": "Voir sur zKillboard",
+    "unknown": "Inconnu",
+    "unknownShip": "Vaisseau inconnu",
+    "ago": "il y a {{d}}"
   }
 }

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "すべてのマップがデフォルトで通知します。マップにチェックを入れると Discord から除外されます。",
       "noCorpMaps": "まだコーポマップがありません。",
       "colMap": "マップ",
-      "colExclude": "除外"
+      "colExclude": "除外",
+      "killWebhook": "キル Webhook",
+      "killMinIsk": "最低 ISK"
     },
     "roles": {
       "button": "ロールとは？",
@@ -1782,5 +1784,16 @@
     "typePersonal": "個人",
     "typeCorp": "コーポ",
     "typeAlliance": "アライアンス"
+  },
+  "killLog": {
+    "title": "キルログ",
+    "tooltip": "このマップの最近のキル",
+    "empty": "最近のキルはありません",
+    "loading": "キルを読み込み中...",
+    "error": "キルを読み込めませんでした",
+    "viewOnZkb": "zKillboardで見る",
+    "unknown": "不明",
+    "unknownShip": "不明な艦船",
+    "ago": "{{d}}前"
   }
 }

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "キャラクター {{id}}",
     "altLastKnown": "（最後の確認）",
     "killsTooltip": "今時間 {{ships}} 艦船 · {{pods}} ポッドキル",
+    "recentKill": "{{ago}}分前のキル ({{value}} ISK)",
     "a0Sun": "A0 恒星",
     "shattered": "破壊された星系",
     "iceBelt": "アイスベルト星系",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "캐릭터 {{id}}",
     "altLastKnown": "(마지막 확인)",
     "killsTooltip": "이번 시간 {{ships}} 함선 · {{pods}} 캡슐 킬",
+    "recentKill": "{{ago}}분 전 격추 ({{value}} ISK)",
     "a0Sun": "A0 항성",
     "shattered": "파괴된 성계",
     "iceBelt": "얼음 벨트 성계",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "모든 지도가 기본적으로 알림을 보냅니다. 지도를 체크하면 Discord에서 제외됩니다.",
       "noCorpMaps": "아직 군단 지도가 없습니다.",
       "colMap": "지도",
-      "colExclude": "제외"
+      "colExclude": "제외",
+      "killWebhook": "킬 웹훅",
+      "killMinIsk": "최소 ISK"
     },
     "roles": {
       "button": "역할이란?",
@@ -1782,5 +1784,16 @@
     "typePersonal": "개인",
     "typeCorp": "군단",
     "typeAlliance": "연합"
+  },
+  "killLog": {
+    "title": "킬 로그",
+    "tooltip": "이 맵의 최근 킬",
+    "empty": "최근 킬 없음",
+    "loading": "킬 불러오는 중...",
+    "error": "킬을 불러올 수 없습니다",
+    "viewOnZkb": "zKillboard에서 보기",
+    "unknown": "알 수 없음",
+    "unknownShip": "알 수 없는 함선",
+    "ago": "{{d}} 전"
   }
 }

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "Personagem {{id}}",
     "altLastKnown": "(última conhecida)",
     "killsTooltip": "{{ships}} nave · {{pods}} cápsula destruídas esta hora",
+    "recentKill": "Abate há {{ago}} min ({{value}} ISK)",
     "a0Sun": "Sol A0",
     "shattered": "Estilhaçado",
     "iceBelt": "Sistema com cinturão de gelo",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "Todos os mapas notificam por defeito. Marca um mapa para o excluir do Discord.",
       "noCorpMaps": "Ainda não há mapas de corp.",
       "colMap": "Mapa",
-      "colExclude": "Excluir"
+      "colExclude": "Excluir",
+      "killWebhook": "Webhook de abates",
+      "killMinIsk": "ISK mínimo"
     },
     "roles": {
       "button": "Funções?",
@@ -1782,5 +1784,16 @@
     "typePersonal": "Pessoal",
     "typeCorp": "Corp",
     "typeAlliance": "Aliança"
+  },
+  "killLog": {
+    "title": "Registo de abates",
+    "tooltip": "Abates recentes neste mapa",
+    "empty": "Sem abates recentes",
+    "loading": "A carregar abates...",
+    "error": "Não foi possível carregar os abates",
+    "viewOnZkb": "Ver no zKillboard",
+    "unknown": "Desconhecido",
+    "unknownShip": "Nave desconhecida",
+    "ago": "há {{d}}"
   }
 }

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1700,6 +1700,7 @@
     "characterFallback": "Персонаж {{id}}",
     "altLastKnown": "(последнее изв.)",
     "killsTooltip": "{{ships}} кораблей · {{pods}} капсул убито за этот час",
+    "recentKill": "Килл {{ago}} мин назад ({{value}} ISK)",
     "a0Sun": "Звезда A0",
     "shattered": "Разрушенная",
     "iceBelt": "Система с ледяным поясом",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "По умолчанию уведомляют все карты. Отметьте карту, чтобы исключить её из Discord.",
       "noCorpMaps": "Корп-карт пока нет.",
       "colMap": "Карта",
-      "colExclude": "Исключить"
+      "colExclude": "Исключить",
+      "killWebhook": "Вебхук киллов",
+      "killMinIsk": "Минимум ISK"
     },
     "roles": {
       "button": "Роли?",
@@ -1822,5 +1824,16 @@
     "typePersonal": "Личная",
     "typeCorp": "Корп",
     "typeAlliance": "Альянс"
+  },
+  "killLog": {
+    "title": "Журнал киллов",
+    "tooltip": "Недавние киллы на этой карте",
+    "empty": "Нет недавних киллов",
+    "loading": "Загрузка киллов...",
+    "error": "Не удалось загрузить киллы",
+    "viewOnZkb": "Смотреть на zKillboard",
+    "unknown": "Неизвестно",
+    "unknownShip": "Неизвестный корабль",
+    "ago": "{{d}} назад"
   }
 }

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1662,6 +1662,7 @@
     "characterFallback": "角色 {{id}}",
     "altLastKnown": "（最后已知）",
     "killsTooltip": "本小时 {{ships}} 舰船 · {{pods}} 太空舱击杀",
+    "recentKill": "{{ago}} 分钟前击杀 ({{value}} ISK)",
     "a0Sun": "A0 恒星",
     "shattered": "破碎星系",
     "iceBelt": "冰带星系",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -333,7 +333,9 @@
       "excludedHint": "所有地图默认都会通知。勾选某个地图可将其从 Discord 中排除。",
       "noCorpMaps": "暂无军团地图。",
       "colMap": "地图",
-      "colExclude": "排除"
+      "colExclude": "排除",
+      "killWebhook": "击杀 Webhook",
+      "killMinIsk": "最低 ISK"
     },
     "roles": {
       "button": "角色说明？",
@@ -1782,5 +1784,16 @@
     "typePersonal": "个人",
     "typeCorp": "军团",
     "typeAlliance": "联盟"
+  },
+  "killLog": {
+    "title": "击杀记录",
+    "tooltip": "此地图上的最近击杀",
+    "empty": "暂无最近击杀",
+    "loading": "正在加载击杀...",
+    "error": "无法加载击杀",
+    "viewOnZkb": "在 zKillboard 上查看",
+    "unknown": "未知",
+    "unknownShip": "未知舰船",
+    "ago": "{{d}}前"
   }
 }

--- a/web/src/store/killStore.ts
+++ b/web/src/store/killStore.ts
@@ -1,48 +1,87 @@
 import { create } from 'zustand';
 
-// Live "a kill just happened here" flags — ephemeral, fed by the SSE stream
-// (server-side zKillboard consumer). Kept out of mapStore because it isn't map
-// data and is reset on every map switch. Mirrors presenceStore's per-system
-// index so each SystemNode subscribes to just its own system and re-renders only
-// when a kill lands there.
+// Live kill flags + a chronological kill log — ephemeral, fed by the SSE stream
+// (server-side zKillboard consumer) and, on panel open, a REST backfill. Kept
+// out of mapStore because it isn't map data and is reset on every map switch.
+// `bySystem` mirrors presenceStore's per-system index so each SystemNode
+// subscribes to just its own system and re-renders only when a kill lands there.
 
 // How long a kill keeps a system flagged before the badge fades. The client
 // can't read the server's KILL_FEED_RECENT_SECONDS, so this is the display
 // window; nodes also gate on it via the shared 30s ticker.
 export const RECENT_KILL_MS = 15 * 60 * 1000;
 
-export interface KillFlag {
-  killmailId: number;
-  shipTypeId: number;
-  totalValue: number;
-  atMs:       number;
+// Newest-first log cap — plenty for the panel, bounded so a busy feed can't grow
+// the array without limit.
+const LOG_CAP = 200;
+
+// A single decorated kill — the exact shape the server sends on the `kill.recent`
+// SSE event and returns from GET /api/maps/:id/kills/backfill. Every display name
+// is resolved server-side from a numeric id (no zKill string is forwarded).
+export interface KillRow {
+  killmailId:          number;
+  atMs:                number;
+  eveSystemId:         number;
+  systemName:          string;
+  regionName:          string | null;
+  shipTypeId:          number;
+  shipTypeName:        string;
+  totalValue:          number;
+  victimCharacterId:   number | null;
+  victimName:          string | null;
+  victimCorporationId: number | null;
+  victimCorpName:      string | null;
 }
 
 interface KillState {
-  // Latest kill per eveSystemId.
-  bySystem: Map<number, KillFlag>;
-  recordKill: (k: { eveSystemId: number } & KillFlag) => void;
+  // Latest kill per eveSystemId — drives the pulsing node badge.
+  bySystem: Map<number, KillRow>;
+  // Chronological feed (newest first, deduped by killmailId) — drives the panel.
+  log: KillRow[];
+  // A single live kill: flag its system AND prepend to the log.
+  recordKill: (row: KillRow) => void;
+  // Seed the log from the REST backfill without re-pulsing nodes.
+  seedBackfill: (rows: KillRow[]) => void;
   reset: () => void;
+}
+
+function prependDeduped(log: KillRow[], row: KillRow): KillRow[] {
+  if (log.some((k) => k.killmailId === row.killmailId)) return log;
+  return [row, ...log].slice(0, LOG_CAP);
 }
 
 export const useKillStore = create<KillState>((set) => ({
   bySystem: new Map(),
-  recordKill: ({ eveSystemId, ...kill }) => set((s) => {
+  log: [],
+  recordKill: (row) => set((s) => {
     const next = new Map(s.bySystem);
     // Opportunistically drop flags that have already aged out so the map can't
     // grow unbounded on a busy feed.
     const cutoff = Date.now() - RECENT_KILL_MS;
     for (const [sysId, k] of next) if (k.atMs < cutoff) next.delete(sysId);
     // Keep only the most recent kill for a system.
-    const existing = next.get(eveSystemId);
-    if (!existing || kill.atMs >= existing.atMs) next.set(eveSystemId, kill);
-    return { bySystem: next };
+    const existing = next.get(row.eveSystemId);
+    if (!existing || row.atMs >= existing.atMs) next.set(row.eveSystemId, row);
+    return { bySystem: next, log: prependDeduped(s.log, row) };
   }),
-  reset: () => set({ bySystem: new Map() }),
+  seedBackfill: (rows) => set((s) => {
+    // Merge backfilled history into the log (deduped), newest first, capped.
+    // Does NOT touch bySystem — old kills shouldn't re-pulse nodes.
+    const byId = new Map<number, KillRow>();
+    for (const r of [...s.log, ...rows]) byId.set(r.killmailId, r);
+    const log = [...byId.values()].sort((a, b) => b.atMs - a.atMs).slice(0, LOG_CAP);
+    return { log };
+  }),
+  reset: () => set({ bySystem: new Map(), log: [] }),
 }));
 
 // Per-system selector — mirrors the presence-store slice so a node only
 // re-renders when its own system's flag changes.
-export function useSystemKill(eveSystemId: number | null | undefined): KillFlag | undefined {
+export function useSystemKill(eveSystemId: number | null | undefined): KillRow | undefined {
   return useKillStore((s) => (eveSystemId == null ? undefined : s.bySystem.get(eveSystemId)));
+}
+
+// The chronological kill log for the panel.
+export function useKillLog(): KillRow[] {
+  return useKillStore((s) => s.log);
 }

--- a/web/src/store/killStore.ts
+++ b/web/src/store/killStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+
+// Live "a kill just happened here" flags — ephemeral, fed by the SSE stream
+// (server-side zKillboard consumer). Kept out of mapStore because it isn't map
+// data and is reset on every map switch. Mirrors presenceStore's per-system
+// index so each SystemNode subscribes to just its own system and re-renders only
+// when a kill lands there.
+
+// How long a kill keeps a system flagged before the badge fades. The client
+// can't read the server's KILL_FEED_RECENT_SECONDS, so this is the display
+// window; nodes also gate on it via the shared 30s ticker.
+export const RECENT_KILL_MS = 15 * 60 * 1000;
+
+export interface KillFlag {
+  killmailId: number;
+  shipTypeId: number;
+  totalValue: number;
+  atMs:       number;
+}
+
+interface KillState {
+  // Latest kill per eveSystemId.
+  bySystem: Map<number, KillFlag>;
+  recordKill: (k: { eveSystemId: number } & KillFlag) => void;
+  reset: () => void;
+}
+
+export const useKillStore = create<KillState>((set) => ({
+  bySystem: new Map(),
+  recordKill: ({ eveSystemId, ...kill }) => set((s) => {
+    const next = new Map(s.bySystem);
+    // Opportunistically drop flags that have already aged out so the map can't
+    // grow unbounded on a busy feed.
+    const cutoff = Date.now() - RECENT_KILL_MS;
+    for (const [sysId, k] of next) if (k.atMs < cutoff) next.delete(sysId);
+    // Keep only the most recent kill for a system.
+    const existing = next.get(eveSystemId);
+    if (!existing || kill.atMs >= existing.atMs) next.set(eveSystemId, kill);
+    return { bySystem: next };
+  }),
+  reset: () => set({ bySystem: new Map() }),
+}));
+
+// Per-system selector — mirrors the presence-store slice so a node only
+// re-renders when its own system's flag changes.
+export function useSystemKill(eveSystemId: number | null | undefined): KillFlag | undefined {
+  return useKillStore((s) => (eveSystemId == null ? undefined : s.bySystem.get(eveSystemId)));
+}

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -213,3 +213,98 @@
   margin-bottom: 4px;
 }
 
+
+/* ── Kill Log panel ──────────────────────────────────────── */
+.killlog-modal {
+  width: min(680px, 94vw);
+}
+
+.killlog__body {
+  max-height: min(70vh, 640px);
+  overflow-y: auto;
+  padding: 0;
+}
+
+.killlog__status {
+  padding: 24px 16px;
+  text-align: center;
+  font-size: calc(13px * var(--font-scale, 1));
+  color: var(--text-faintest);
+}
+.killlog__status--error { color: var(--danger); }
+
+.killlog__list {
+  display: flex;
+  flex-direction: column;
+}
+
+.killlog__row {
+  display: grid;
+  grid-template-columns: auto 1.4fr 1fr 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  text-decoration: none;
+  color: var(--text-default);
+}
+.killlog__row:hover { background: var(--surface-overlay); }
+
+.killlog__thumbs {
+  position: relative;
+  width: 44px;
+  height: 32px;
+  flex: none;
+}
+.killlog__portrait {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+.killlog__ship {
+  position: absolute;
+  right: 0;
+  bottom: -2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  background: var(--surface-sunken);
+  outline: 1px solid var(--border);
+  object-fit: cover;
+}
+
+.killlog__who,
+.killlog__what,
+.killlog__where {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.killlog__victim,
+.killlog__ship-name,
+.killlog__system {
+  font-size: calc(13px * var(--font-scale, 1));
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.killlog__corp,
+.killlog__region {
+  font-size: calc(11px * var(--font-scale, 1));
+  color: var(--text-faintest);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.killlog__value {
+  font-size: calc(11px * var(--font-scale, 1));
+  color: #ff8080;
+}
+.killlog__ago {
+  font-size: calc(11px * var(--font-scale, 1));
+  color: var(--text-faintest);
+  white-space: nowrap;
+  text-align: right;
+}

--- a/web/src/styles/system-node.css
+++ b/web/src/styles/system-node.css
@@ -963,6 +963,44 @@
   z-index: 9999 !important;
 }
 
+/* Live "a kill just happened here" flag (zKill feed). Distinct from the hourly
+   kill-icon above: a pulsing red skull that draws the eye for ~15 min then the
+   node stops rendering it. */
+@keyframes recentkill-pulse {
+  0%, 100% { opacity: 1;    filter: drop-shadow(0 0 2px #ff3b3b88); }
+  50%      { opacity: 0.45; filter: drop-shadow(0 0 6px #ff3b3bcc); }
+}
+.system-node__recentkill-icon {
+  color: #ff3b3b;
+  font-size: calc(13px * var(--font-scale, 1));
+  cursor: default;
+  position: relative;
+  animation: recentkill-pulse 1.4s ease-in-out infinite;
+}
+.system-node__recentkill-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 4px 10px;
+  white-space: nowrap;
+  font-size: calc(13px * var(--font-scale, 1));
+  color: #ff6060;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 9999;
+}
+.system-node__recentkill-icon:hover .system-node__recentkill-tooltip {
+  display: block;
+}
+.react-flow__node:has(.system-node__recentkill-icon:hover) {
+  z-index: 9999 !important;
+}
+
 .system-node__incursion-badge {
   display: flex;
   align-items: center;

--- a/web/src/utils/eveImages.ts
+++ b/web/src/utils/eveImages.ts
@@ -6,3 +6,4 @@ export const charPortrait = (id: number, size = 64) => `${BASE}/characters/${id}
 export const corpLogo     = (id: number, size = 64) => `${BASE}/corporations/${id}/logo?size=${size}`;
 export const allianceLogo = (id: number, size = 64) => `${BASE}/alliances/${id}/logo?size=${size}`;
 export const typeIcon     = (id: number, size = 64) => `${BASE}/types/${id}/icon?size=${size}`;
+export const typeRender   = (id: number, size = 64) => `${BASE}/types/${id}/render?size=${size}`;

--- a/web/src/utils/isk.ts
+++ b/web/src/utils/isk.ts
@@ -1,0 +1,7 @@
+// Compact ISK for tight UI (node tooltips, kill-log rows): 1.2B / 340M / 90K.
+export function iskCompact(v: number): string {
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
+  if (v >= 1_000_000)     return `${(v / 1_000_000).toFixed(0)}M`;
+  if (v >= 1_000)         return `${(v / 1_000).toFixed(0)}K`;
+  return String(Math.round(v));
+}


### PR DESCRIPTION
Supersedes #560. Because qa does not yet have the Phase 1 branch, this PR contains the **whole** live-kill-feed feature (Phase 1 + Phase 2) on the correct transport, so #560 can be closed rather than merged.

## Important: transport corrected to R2Z2
Phase 1 (#560) was built on zKill **RedisQ, which was sunset 2026-05-31**. This branch reworks the consumer onto zKill's **R2Z2 ephemeral feed** (the documented replacement): fetch a starting sequence from `/ephemeral/sequence.json`, GET `/ephemeral/{seq}.json` in order incrementing until a 404 (caught up), then sleep >=6s and resume. Non-blank User-Agent (Cloudflare-required), paced under the 15 req/s cap. Decoration / map-matching / SSE fan-out are unchanged.

## Feature (off by default -- `KILL_FEED=1`)
- **On-map flag** (Phase 1): high-value kills (>= `KILL_FEED_MIN_ISK`, default 50M) in systems on a live map pulse a red skull on the node for ~15 min.
- **Kill log** (Phase 2): a toolbar-opened panel listing recent kills for the current map's systems -- victim portrait + name/corp, ship render + name, system + region, ISK, live time-ago, each linking to the zKillboard killmail. Seeded by the backfill, then live kills prepend.
- **Backfill**: `GET /api/maps/:mapId/kills/backfill` -- access-checked, rate-limited (esiLimiter), system-capped, and **chunked (5 at a time)** so a big chain can't burst zKill. Reuses a refactored cached `fetchSystemKills`.
- **Discord kill webhook**: `kill_webhook` + per-org `kill_min_isk` on both org settings tables, admin GET/PUT, `killEmbed`, deduped best-effort dispatch to matched corp/alliance maps.

## Security
- Every display name is resolved by **us** from the killmail's numeric IDs (`resolveEntityNames` + SDE); no zKill-supplied string is forwarded (ESI killmails carry only IDs anyway).
- Backfill is access-checked + rate-limited + bounded; Discord dispatch is parameterized, deduped, SSRF-guarded via the existing `isDiscordWebhookUrl` allowlist, and failure-isolated.
- No new inbound surface. One new migration (two nullable columns + a defaulted BIGINT).

## Verification
Built via two forks (server, client) + my review -- I reworked the transport to R2Z2, added the backfill concurrency bound, and re-checked the untrusted-input handling. server + web `tsc` clean; eslint clean (one pre-existing unrelated warning); i18n parity across all 9 locales.

## To try it
Set `KILL_FEED=1` (+ optional `KILL_FEED_MIN_ISK`, `KILL_FEED_CONTACT`) on the server. Defaults off, so safe to merge and enable deliberately.