### PR TITLE
Kill log: vertically centre the title skull icon

### DIFF
--- a/web/src/components/ui/KillLogPanel.tsx
+++ b/web/src/components/ui/KillLogPanel.tsx
@@ -108,7 +108,7 @@ export function KillLogPanel({ onClose }: Props) {
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal killlog-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal__header">
-          <h2 className="modal__title"><SkullIcon size={18} weight="fill" /> {t('killLog.title')}</h2>
+          <h2 className="modal__title killlog__title"><SkullIcon size={18} weight="fill" />{t('killLog.title')}</h2>
           <button className="icon-btn" onClick={onClose} aria-label={t('actions.close')}><XIcon size={16} weight="bold" /></button>
         </div>
         <div className="modal__body killlog__body">

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -222,6 +222,14 @@
   width: min(760px, 94vw);
 }
 
+/* Vertically centre the skull icon with the title text (the base .modal__title
+   is block, so the inline SVG baseline-aligns and rides high). */
+.killlog__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .killlog__body {
   max-height: min(70vh, 640px);
   overflow-y: auto;


### PR DESCRIPTION
Small fix: the skull icon in the "Kill Log" modal title sat above the text because the base `.modal__title` is `display: block`, so the inline SVG baseline-aligned. Added a scoped `.killlog__title` (inline-flex + `align-items: center` + gap) so the icon centres with the text. Scoped to the kill log so other modal titles are untouched.

CSS + one JSX class; web `tsc` clean.