### PR TITLE
Kill feed: fix node flashes never firing + show more kills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,5 +123,6 @@ ALLIANCE_MAP_SHARED=false
 # KILL_FEED_MIN_ISK=50000000        # only flag kills at/above this ISK value
 # KILL_FEED_RECENT_SECONDS=900      # how long a flag lingers (client shows ~15m)
 # KILL_FEED_BACKFILL_MAX_SYSTEMS=30 # cap systems queried for the kill-log backfill
+# KILL_FEED_BACKFILL_SECONDS=10800   # kill-log history window (default 3h)
 
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -187,6 +187,9 @@ export const config = {
     // panel-open. Capped so a huge chain can't fan out into a burst of zKill
     // REST calls (fair-use). Extra systems are skipped (logged), not queried.
     backfillMaxSystems: intEnv(process.env.KILL_FEED_BACKFILL_MAX_SYSTEMS, 30),
+    // How far back the kill-log backfill looks (seconds). Longer = more history
+    // in the log, but more per-system kills to hydrate via ESI on panel-open.
+    backfillSeconds: intEnv(process.env.KILL_FEED_BACKFILL_SECONDS, 10_800), // 3h
   },
   // Required in non-dev (guarded above). The dev fallback is randomised per
   // boot rather than a known literal, so a dev instance accidentally exposed

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1974,7 +1974,7 @@ mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
 
   // Per-system fetch is cached + ESI-concurrency-capped inside fetchSystemKills.
   const perSystemFetch = async (sysId: number): Promise<KillRow[]> => {
-    const kills = (await fetchSystemKills(sysId, 3600))
+    const kills = (await fetchSystemKills(sysId, config.killFeed.backfillSeconds))
       .filter((k) => k.zkb.totalValue >= config.killFeed.minValueIsk);
     if (!kills.length) return [];
     const meta = await resolveSystemMeta(sysId);
@@ -2015,7 +2015,7 @@ mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
     }
   }
   merged.sort((a, b) => b.atMs - a.atMs);
-  res.json(merged.slice(0, 50));
+  res.json(merged.slice(0, 200));
 });
 
 // POST /api/maps/:mapId/presence — a viewer reports its current location.

--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -172,7 +172,7 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
   const now             = useNow30s();
   // The flag fades once the kill ages past the display window; the 30s ticker
   // re-evaluates this so it drops on its own without another SSE frame.
-  const killFresh       = !!recentKill && now - recentKill.atMs < RECENT_KILL_MS;
+  const killFresh       = !!recentKill && now - recentKill.flaggedAtMs < RECENT_KILL_MS;
   const [staleHours]    = useStaleThreshold();
   // staleHours === 0 is the "Never fade" sentinel: no system is ever stale.
   const isStale         = staleHours > 0 && !!sys.lastActivityAt &&

--- a/web/src/store/killStore.ts
+++ b/web/src/store/killStore.ts
@@ -13,7 +13,7 @@ export const RECENT_KILL_MS = 15 * 60 * 1000;
 
 // Newest-first log cap — plenty for the panel, bounded so a busy feed can't grow
 // the array without limit.
-const LOG_CAP = 200;
+const LOG_CAP = 300;
 
 // A single decorated kill — the exact shape the server sends on the `kill.recent`
 // SSE event and returns from GET /api/maps/:id/kills/backfill. Every display name
@@ -33,9 +33,16 @@ export interface KillRow {
   victimCorpName:      string | null;
 }
 
+// A per-system flag carries the kill plus when WE received it. The node badge
+// freshness is gated on `flaggedAtMs` (receipt), NOT the killmail's `atMs`:
+// zKill/ESI often deliver a killmail 15+ min after the kill, so gating on the
+// kill time would leave a live kill already "stale" on arrival and it would
+// never flash. Receipt time makes every live kill flash for the full window.
+export type KillFlag = KillRow & { flaggedAtMs: number };
+
 interface KillState {
   // Latest kill per eveSystemId — drives the pulsing node badge.
-  bySystem: Map<number, KillRow>;
+  bySystem: Map<number, KillFlag>;
   // Chronological feed (newest first, deduped by killmailId) — drives the panel.
   log: KillRow[];
   // A single live kill: flag its system AND prepend to the log.
@@ -54,14 +61,17 @@ export const useKillStore = create<KillState>((set) => ({
   bySystem: new Map(),
   log: [],
   recordKill: (row) => set((s) => {
+    const now = Date.now();
     const next = new Map(s.bySystem);
-    // Opportunistically drop flags that have already aged out so the map can't
-    // grow unbounded on a busy feed.
-    const cutoff = Date.now() - RECENT_KILL_MS;
-    for (const [sysId, k] of next) if (k.atMs < cutoff) next.delete(sysId);
-    // Keep only the most recent kill for a system.
+    // Opportunistically drop flags that have aged out (by receipt time) so the
+    // map can't grow unbounded on a busy feed.
+    const cutoff = now - RECENT_KILL_MS;
+    for (const [sysId, k] of next) if (k.flaggedAtMs < cutoff) next.delete(sysId);
+    // Keep the most recent kill for a system; stamp receipt time so the badge
+    // flashes for the full window regardless of the killmail's (possibly stale)
+    // timestamp.
     const existing = next.get(row.eveSystemId);
-    if (!existing || row.atMs >= existing.atMs) next.set(row.eveSystemId, row);
+    if (!existing || row.atMs >= existing.atMs) next.set(row.eveSystemId, { ...row, flaggedAtMs: now });
     return { bySystem: next, log: prependDeduped(s.log, row) };
   }),
   seedBackfill: (rows) => set((s) => {
@@ -77,7 +87,7 @@ export const useKillStore = create<KillState>((set) => ({
 
 // Per-system selector — mirrors the presence-store slice so a node only
 // re-renders when its own system's flag changes.
-export function useSystemKill(eveSystemId: number | null | undefined): KillRow | undefined {
+export function useSystemKill(eveSystemId: number | null | undefined): KillFlag | undefined {
   return useKillStore((s) => (eveSystemId == null ? undefined : s.bySystem.get(eveSystemId)));
 }
 

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -223,7 +223,7 @@
 }
 
 .killlog__body {
-  max-height: min(70vh, 640px);
+  max-height: min(80vh, 900px);
   overflow-y: auto;
   padding: 0;
 }


### PR DESCRIPTION
Two things from your feedback.

## Live flashes never fired -- root cause
The node badge gated freshness on the **killmail time** (`atMs`). zKill/ESI commonly deliver a killmail **15+ minutes after** the kill actually happened, so by the time a live `kill.recent` arrived, `now - atMs` was already past the 15-min window -> `killFresh` was false -> **no flash** (even though the kill still landed in the log). That matches exactly what you saw: log populates, nothing flashes.

**Fix:** gate on **receipt time**, not kill time. `bySystem` entries now carry `flaggedAtMs` (stamped when we record the kill); `SystemNode` and the pruning use it. Any live kill now pulses its node for the full window regardless of how stale the killmail timestamp is.

## Show more kills
- **Backfill window 1h -> 3h** (configurable via `KILL_FEED_BACKFILL_SECONDS`). This is why the log looked sparse and why that ~1h-old Jita kill wasn't in it.
- Backfill response cap **50 -> 200**; client log cap **200 -> 300**.
- Kill-log modal taller (`max-height: min(80vh, 900px)`) -- it already scrolls, now shows more before it needs to.

server + web `tsc` + eslint clean.

## Heads-up on testing the flash
This makes flashes fire *when live kills arrive*. If after deploying you still see nothing pulse on a **busy** map, that points upstream to the live consumer rather than the badge -- worth a glance at the server logs for the `killFeed` line (it logs "live kill feed enabled" on boot) to confirm `KILL_FEED=1` is set on the running instance and it's processing. The log filling with *fresh* (0-15 min) entries is the quickest confirmation the live path works; right now your newest was ~46 min (backfill only).