### PR TITLE
killFeed: heartbeat + per-forward diagnostic logs

### DIFF
--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -267,7 +267,10 @@ export function startKillFeed(): void {
   running = true;
   log.info(`live kill feed enabled (R2Z2 ephemeral, min ${config.killFeed.minValueIsk.toLocaleString()} ISK)`);
   const hb = setInterval(() => {
-    log.info(`heartbeat: ${stats.seen} seen, ${stats.overMin} >= min ISK, ${stats.forwarded} forwarded to live maps`);
+    // `watched` = maps with a live SSE client right now. If this is 0, no kill
+    // can ever forward regardless of the feed — the browser's event stream isn't
+    // registering (nothing to match against).
+    log.info(`heartbeat: ${stats.seen} seen, ${stats.overMin} >= min ISK, ${stats.forwarded} forwarded; ${activeMapIds().length} map(s) watched now`);
   }, HEARTBEAT_MS);
   hb.unref?.();
   void loop();

--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -132,9 +132,11 @@ async function processKill(body: EphemeralKill): Promise<void> {
   const solarSystemId = Number(km.solar_system_id);
   if (!Number.isFinite(killmailId) || !Number.isFinite(solarSystemId)) return;
   if (!markSeen(killmailId)) return;
+  stats.seen++;
 
   const totalValue = Number(body.zkb?.totalValue ?? 0);
   if (!(totalValue >= config.killFeed.minValueIsk)) return;
+  stats.overMin++;
 
   // Only touch the DB when at least one map is actually being watched.
   const live = activeMapIds();
@@ -177,6 +179,8 @@ async function processKill(body: EphemeralKill): Promise<void> {
   for (const { mapId } of rows) {
     publishToMap(mapId, { type: 'kill.recent', actor: null, ...killRow });
   }
+  stats.forwarded++;
+  log.info(`forwarded kill in ${meta.systemName} (${Math.round(totalValue / 1e6)}M ISK) -> ${rows.length} map(s)`);
 
   // Corp/alliance Discord kill alert for the matched maps (opt-in per org).
   await dispatchDiscord(rows.map((r) => r.mapId), killRow);
@@ -211,6 +215,14 @@ async function dispatchDiscord(mapIds: string[], kill: KillRow): Promise<void> {
 }
 
 let running = false;
+
+// Rolling counters for the heartbeat log, so "is the feed actually working?" is
+// observable: `seen` = killmails pulled from the firehose, `overMin` = those at
+// or above the ISK floor, `forwarded` = those in a currently-viewed map's
+// systems (the ones that flash a node). seen climbing with forwarded stuck at 0
+// just means no big kill has happened in a mapped system yet — not a fault.
+const stats = { seen: 0, overMin: 0, forwarded: 0 };
+const HEARTBEAT_MS = 120_000;
 
 async function loop(): Promise<void> {
   let backoff = 1_000;
@@ -254,5 +266,9 @@ export function startKillFeed(): void {
   if (running) return;
   running = true;
   log.info(`live kill feed enabled (R2Z2 ephemeral, min ${config.killFeed.minValueIsk.toLocaleString()} ISK)`);
+  const hb = setInterval(() => {
+    log.info(`heartbeat: ${stats.seen} seen, ${stats.overMin} >= min ISK, ${stats.forwarded} forwarded to live maps`);
+  }, HEARTBEAT_MS);
+  hb.unref?.();
   void loop();
 }


### PR DESCRIPTION
Makes the live kill consumer observable so "is it working?" is answerable at a glance.

- **Heartbeat** every 2 min: `[killFeed] heartbeat: N seen, M >= min ISK, K forwarded to live maps`.
  - `seen` = killmails pulled from the R2Z2 firehose (climbing = the loop is alive).
  - `overMin` = those at/above the ISK floor.
  - `forwarded` = those in a system on a currently-viewed map (the ones that flash a node).
- **Per-forward** info log: `forwarded kill in <system> (<n>M ISK) -> <k> map(s)` whenever a kill actually goes out.

`seen` climbing while `forwarded` stays 0 is the expected "no big kill in a mapped system yet" state, not a fault. Server-only, tiny.