### PR TITLE
Kill flash: stop the hover tooltip blinking with the skull

### DIFF
--- a/web/src/styles/system-node.css
+++ b/web/src/styles/system-node.css
@@ -975,6 +975,10 @@
   font-size: calc(13px * var(--font-scale, 1));
   cursor: default;
   position: relative;
+}
+/* Pulse the skull glyph only — putting the opacity animation on the wrapper
+   would cascade to its subtree and blink the hover tooltip too. */
+.system-node__recentkill-icon svg {
   animation: recentkill-pulse 1.4s ease-in-out infinite;
 }
 .system-node__recentkill-tooltip {


### PR DESCRIPTION
The recent-kill pulse animation was on the icon wrapper span, so its opacity cascaded to the whole subtree -- including the hover tooltip, which blinked along with the skull. Moved the animation onto the skull `svg` only; the wrapper and its tooltip stay steady while the glyph still pulses. CSS-only.