### PR TITLE
Kill flash: pulse still-recent kills from the backfill on open

### DIFF
--- a/web/src/store/killStore.ts
+++ b/web/src/store/killStore.ts
@@ -76,11 +76,22 @@ export const useKillStore = create<KillState>((set) => ({
   }),
   seedBackfill: (rows) => set((s) => {
     // Merge backfilled history into the log (deduped), newest first, capped.
-    // Does NOT touch bySystem — old kills shouldn't re-pulse nodes.
     const byId = new Map<number, KillRow>();
     for (const r of [...s.log, ...rows]) byId.set(r.killmailId, r);
     const log = [...byId.values()].sort((a, b) => b.atMs - a.atMs).slice(0, LOG_CAP);
-    return { log };
+    // Flag any backfilled kill that's STILL within the recency window so its
+    // node pulses the moment the map loads (a kill 6 min ago should already be
+    // flashing). Anchor to the kill's own time (atMs) — not "now" — so it flashes
+    // only for the remainder and expires correctly, and never override a fresher
+    // existing (e.g. live) flag.
+    const cutoff = Date.now() - RECENT_KILL_MS;
+    const bySystem = new Map(s.bySystem);
+    for (const r of rows) {
+      if (r.atMs < cutoff) continue;
+      const existing = bySystem.get(r.eveSystemId);
+      if (!existing || r.atMs > existing.flaggedAtMs) bySystem.set(r.eveSystemId, { ...r, flaggedAtMs: r.atMs });
+    }
+    return { log, bySystem };
   }),
   reset: () => set({ bySystem: new Map(), log: [] }),
 }));


### PR DESCRIPTION
Bug: when you open a map, a node whose only recent kill came from the **on-open backfill** never flashed -- e.g. SV5-8N had a kill 6 min ago (well inside the 15-min window) but the skull wasn't pulsing. `seedBackfill` deliberately skipped `bySystem` to avoid re-pulsing *old* kills, but that also suppressed still-recent ones.

**Fix:** `seedBackfill` now flags any backfilled kill still inside the recency window, **anchored to the kill's own time (`atMs`)** -- not "now" -- so:
- a kill 6 min ago pulses for the remaining ~9 min and then expires correctly;
- a kill 40 min ago stays silent (already past the window);
- a fresher existing flag (e.g. a live kill just received) is never overridden.

Contrast with live kills, which anchor to *receipt* time (they arrive with a stale killmail timestamp due to feed delay). Client-only; `tsc` + eslint clean.