### PR TITLE
killFeed: diagnostic for why kill Discord alerts don't fire

### DIFF
--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -209,6 +209,11 @@ async function dispatchDiscord(mapIds: string[], kill: KillRow): Promise<void> {
       sent.add(r.killWebhook);
       notifyDiscord(r.killWebhook, killEmbed(kill));
     }
+    // Diagnostic: explains why a forwarded kill did/didn't post to Discord.
+    // 0 matched-with-webhook => the map is personal, or the URL isn't in that
+    // org's *Kill* field. webhooks but 0 dispatched => below the org kill_min_isk.
+    const withHook = rows.filter((r) => r.killWebhook).length;
+    log.info(`kill Discord: ${rows.length} matched map(s), ${withHook} with a kill webhook, dispatched to ${sent.size}`);
   } catch (err) {
     log.warn('kill Discord dispatch failed:', err instanceof Error ? err.message : err);
   }


### PR DESCRIPTION
The kill-webhook dispatch was silent, so "Discord never fires" was un-diagnosable. Adds one info line per **forwarded** kill:

`[killFeed] kill Discord: N matched map(s), K with a kill webhook, dispatched to D`

Reading it:
- **`0 with a kill webhook`** -> the matched map is **personal** (no org), or the URL wasn't saved in that org's **Kill** field. This is the most common cause -- Discord alerts, like all Discord notifications, only fire for corp/alliance maps.
- **`K with a webhook, dispatched to 0`** -> the kill was below that org's `kill_min_isk`.
- **`dispatched to D>0`** but no Discord message -> delivery problem; look for the `[discord] queued …` line and any drain error.

No behaviour change; server-only log.