### PR TITLE
Kill backfill: filter by ISK + cap per system before ESI hydration

### DIFF
--- a/server/src/routes/killboard.ts
+++ b/server/src/routes/killboard.ts
@@ -131,10 +131,18 @@ async function fetchEsi(killmailId: number, hash: string): Promise<EsiKillmail |
 // killboard route (24h) and the kill-log backfill (1h). SSRF-safe: the URL is
 // built from the bounded NUMBER, never raw text. Cache is keyed by
 // system:pastSeconds so the two windows don't clobber each other.
-export async function fetchSystemKills(systemId: number, pastSeconds: number): Promise<KillEntry[]> {
+export async function fetchSystemKills(
+  systemId: number,
+  pastSeconds: number,
+  opts: { minValueIsk?: number; maxKills?: number } = {},
+): Promise<KillEntry[]> {
   if (!Number.isInteger(systemId) || systemId <= 0 || systemId > 100_000_000) return [];
   const secs = Number.isInteger(pastSeconds) && pastSeconds > 0 && pastSeconds <= 604_800 ? pastSeconds : 86_400;
-  const key = `${systemId}:${secs}`;
+  const minValueIsk = Math.max(0, opts.minValueIsk ?? 0);
+  const maxKills = opts.maxKills && opts.maxKills > 0 ? opts.maxKills : 0; // 0 = no cap
+  // Cache per (system, window, value-floor, cap) — the filtered result differs,
+  // so the killboard pane (no floor/cap) and the kill-log backfill don't collide.
+  const key = `${systemId}:${secs}:${minValueIsk}:${maxKills}`;
 
   const fresh = cache.get(key);
   if (fresh) return fresh.value;
@@ -168,11 +176,24 @@ export async function fetchSystemKills(systemId: number, pastSeconds: number): P
 
     const etag = zkbRes.headers.get('etag') ?? undefined;
 
+    // Filter by value and cap to the newest N BEFORE hydrating. The zKill list
+    // already carries zkb.totalValue, and killmail_id is monotonic with time, so
+    // we only pay an ESI call for kills we actually keep. Without this a busy
+    // region (e.g. The Forge) hydrates thousands of cheap kills per open, trips
+    // ESI/zKill rate limits, and falls back to stale data — dropping the newest
+    // kills, differently each run. Defaults (floor 0, no cap) = pane unchanged.
+    let wanted = minValueIsk > 0
+      ? zkbBody.filter((k) => (k.zkb?.totalValue ?? 0) >= minValueIsk)
+      : zkbBody;
+    if (maxKills > 0 && wanted.length > maxKills) {
+      wanted = [...wanted].sort((a, b) => b.killmail_id - a.killmail_id).slice(0, maxKills);
+    }
+
     // Hydrate full killmails from ESI in parallel (capped at ESI_MAX_CONCURRENT
     // so a busy system queues rather than thundering CCP).
-    const esiResults = await Promise.all(zkbBody.map((k) => fetchEsi(k.killmail_id, k.zkb.hash)));
+    const esiResults = await Promise.all(wanted.map((k) => fetchEsi(k.killmail_id, k.zkb.hash)));
 
-    const kills = zkbBody
+    const kills = wanted
       .map((zkb, i) => {
         const esi = esiResults[i];
         if (!esi) return null;

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1973,9 +1973,15 @@ mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
   if (!systemIds.length) { res.json([]); return; }
 
   // Per-system fetch is cached + ESI-concurrency-capped inside fetchSystemKills.
+  // Pass the ISK floor + a per-system cap so it filters BEFORE ESI hydration —
+  // essential in busy regions (The Forge) where hydrating every kill would trip
+  // rate limits and return stale/incomplete data. 40 newest kept per system; the
+  // merged result is sliced to 200 below anyway.
   const perSystemFetch = async (sysId: number): Promise<KillRow[]> => {
-    const kills = (await fetchSystemKills(sysId, config.killFeed.backfillSeconds))
-      .filter((k) => k.zkb.totalValue >= config.killFeed.minValueIsk);
+    const kills = await fetchSystemKills(sysId, config.killFeed.backfillSeconds, {
+      minValueIsk: config.killFeed.minValueIsk,
+      maxKills: 40,
+    });
     if (!kills.length) return [];
     const meta = await resolveSystemMeta(sysId);
     return Promise.all(kills.map(async (k): Promise<KillRow> => ({

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1975,12 +1975,12 @@ mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
   // Per-system fetch is cached + ESI-concurrency-capped inside fetchSystemKills.
   // Pass the ISK floor + a per-system cap so it filters BEFORE ESI hydration —
   // essential in busy regions (The Forge) where hydrating every kill would trip
-  // rate limits and return stale/incomplete data. 40 newest kept per system; the
-  // merged result is sliced to 200 below anyway.
+  // rate limits and return stale/incomplete data. 20 newest kept per system to
+  // keep ESI calls low; the merged result is sliced to 200 below anyway.
   const perSystemFetch = async (sysId: number): Promise<KillRow[]> => {
     const kills = await fetchSystemKills(sysId, config.killFeed.backfillSeconds, {
       minValueIsk: config.killFeed.minValueIsk,
-      maxKills: 40,
+      maxKills: 20,
     });
     if (!kills.length) return [];
     const meta = await resolveSystemMeta(sysId);


### PR DESCRIPTION
Fixes the reported "two servers show different kills, one older, and neither matches zKill" on a busy region.

**Root cause:** on The Forge with `MAX_SYSTEMS=88`, the backfill hydrated **every** killmail via ESI *before* applying the ISK floor -- thousands of ESI calls per open. That trips ESI/zKill rate limits, so systems fall back to **stale cache** and the newest kills go missing, varying per run and per server.

**Fix:** `fetchSystemKills` now takes optional `{ minValueIsk, maxKills }`. The zKill list already carries `zkb.totalValue` and `killmail_id` (monotonic with time), so it drops sub-floor kills and keeps only the **newest N per system before hydrating**. The kill-log backfill passes the configured floor + **40/system**; the killboard pane keeps its old unfiltered/uncapped behaviour via the defaults. Cache key includes floor+cap so the two paths don't collide.

Result: far fewer ESI calls -> no rate-limit stalls -> the newest notable kills are captured, consistently and across servers. Server-only; `tsc` clean.

Note: it still won't *exactly* mirror zkillboard.com -- it's scoped to the map's systems, floored by `KILL_FEED_MIN_ISK`, and zKill's REST feed lags its website by a few minutes (the live R2Z2 feed covers truly-recent kills).