### PR TITLE
Kill backfill from an in-memory buffer (no per-system zKill scraping)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,7 +122,6 @@ ALLIANCE_MAP_SHARED=false
 # KILL_FEED_CONTACT=you@example.com
 # KILL_FEED_MIN_ISK=50000000        # only flag kills at/above this ISK value
 # KILL_FEED_RECENT_SECONDS=900      # how long a flag lingers (client shows ~15m)
-# KILL_FEED_BACKFILL_MAX_SYSTEMS=30 # cap systems queried for the kill-log backfill
 # KILL_FEED_BACKFILL_SECONDS=10800   # kill-log history window (default 3h)
 
 

--- a/README.md
+++ b/README.md
@@ -487,20 +487,19 @@ See [Static data files](#static-data-files) for what `extract-wormholes` does an
 
 #### Live kill feed (opt-in)
 
-Flags recent high-value kills on your mapped systems and feeds a **Kill Log** panel (top-bar skull icon). A single server-side consumer reads zKillboard's live **R2Z2 ephemeral** feed; for a kill at or above a value threshold in a system on a *currently-viewed* map, it pulses that system's node and prepends a row to the log. Opening the log also backfills recent history for that map's systems. Corp/alliance maps can additionally push kills to a Discord webhook (**Admin → Discord**).
+Flags recent high-value kills on your mapped systems and feeds a **Kill Log** panel (top-bar skull icon). A single server-side consumer reads zKillboard's live **R2Z2 ephemeral** feed; for a kill at or above a value threshold in a system on a *currently-viewed* map, it pulses that system's node and prepends a row to the log. It also keeps a rolling in-memory buffer of recent high-value kills, and opening the log **backfills from that buffer** (filtered to the map's systems) — no extra zKillboard requests, so it scales to any map size. Corp/alliance maps can additionally push kills to a Discord webhook (**Admin → Discord**).
 
 **Off by default.** Enable and tune via `.env`:
 
 | Variable | Default | Effect |
 |---|---|---|
-| `KILL_FEED` | `0` (off) | Set to `1` to run the live consumer. While off, the feature is inert (the Kill Log's on-open backfill still works, but nothing flashes live). |
+| `KILL_FEED` | `0` (off) | Set to `1` to run the consumer. While off the whole feature is inert — nothing flashes and the Kill Log stays empty (the buffer is only filled by the running consumer). |
 | `KILL_FEED_CONTACT` | — | A reachable contact (email or URL) — it builds the zKillboard `User-Agent`. Required by zKill fair-use; a blank UA is Cloudflare-blocked. |
-| `KILL_FEED_MIN_ISK` | `50000000` | Only kills at or above this ISK value are flagged and logged. |
+| `KILL_FEED_MIN_ISK` | `50000000` | Only kills at or above this ISK value are flagged, logged, and buffered. |
 | `KILL_FEED_RECENT_SECONDS` | `900` (15 min) | How long a node stays flagged after a kill lands there. |
-| `KILL_FEED_BACKFILL_SECONDS` | `10800` (3 h) | How far back the Kill Log's on-open backfill looks. |
-| `KILL_FEED_BACKFILL_MAX_SYSTEMS` | `30` | **Soft cap** on how many of a map's systems the backfill queries when you open the log. **There is no hard maximum** — raise it for larger chains; a map with more systems than the cap simply has the extras skipped (logged). It exists only as a zKillboard fair-use bound: each system is one zKill REST call, so a huge chain would fan out a lot of requests. Even above the cap, requests go out **at most 5 at a time** and per-system results are **cached (5 min)**, so a higher value just means a slower *first* open and more total zKill load — never a burst. |
+| `KILL_FEED_BACKFILL_SECONDS` | `10800` (3 h) | How long the in-memory buffer retains kills — i.e. how far back the Kill Log shows on open. |
 
-Fair-use: the consumer is a single long-poller that stays under zKill's 15 req/s limit and honours the mandatory 6 s idle wait, and it only does work for maps that have a live viewer (a kill flashes only while someone is watching that map). On boot it logs `[killFeed] live kill feed enabled …` (or `disabled …`), plus a periodic heartbeat and a line per forwarded kill — handy for confirming it's running (`… | grep killFeed`).
+Fair-use: the consumer is a single poller that stays under zKill's 15 req/s limit and waits ~10 s between checks when the feed is caught up. The Kill Log **backfill is served entirely from the in-memory buffer** — no per-system zKillboard requests — but it therefore only contains kills seen **since the server started**, filling in over the first few hours of uptime. On boot the consumer logs `[killFeed] live kill feed enabled …` (or `disabled …`), plus a periodic heartbeat and a line per forwarded kill (`… | grep killFeed`).
 
 #### Upgrading an existing deployment
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -122,7 +122,6 @@ ALLIANCE_MAP_SHARED=false
 # KILL_FEED_CONTACT=you@example.com
 # KILL_FEED_MIN_ISK=50000000        # only flag kills at/above this ISK value
 # KILL_FEED_RECENT_SECONDS=900      # how long a flag lingers (client shows ~15m)
-# KILL_FEED_BACKFILL_MAX_SYSTEMS=30 # cap systems queried for the kill-log backfill
 # KILL_FEED_BACKFILL_SECONDS=10800   # kill-log history window (default 3h)
 
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -183,12 +183,8 @@ export const config = {
     contact:       process.env.KILL_FEED_CONTACT?.trim() || 'gq@area404.org',
     minValueIsk:   intEnv(process.env.KILL_FEED_MIN_ISK, 50_000_000),
     recentSeconds: intEnv(process.env.KILL_FEED_RECENT_SECONDS, 900),
-    // Kill-log backfill: how many of a map's systems to query zKill for on
-    // panel-open. Capped so a huge chain can't fan out into a burst of zKill
-    // REST calls (fair-use). Extra systems are skipped (logged), not queried.
-    backfillMaxSystems: intEnv(process.env.KILL_FEED_BACKFILL_MAX_SYSTEMS, 30),
-    // How far back the kill-log backfill looks (seconds). Longer = more history
-    // in the log, but more per-system kills to hydrate via ESI on panel-open.
+    // How far back the kill-log backfill looks (seconds) — i.e. how long the
+    // in-memory kill buffer retains kills. Longer = more history in the log.
     backfillSeconds: intEnv(process.env.KILL_FEED_BACKFILL_SECONDS, 10_800), // 3h
   },
   // Required in non-dev (guarded above). The dev fallback is randomised per

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -25,9 +25,8 @@ import { notifyDiscord, k162Embed, connectionEmbed, chainEmbed, kspaceExitEmbed 
 import { shortestRoutes } from '../services/routeGraph.js';
 import { whSizeForCode } from './wormholes.js';
 import { effectiveExpiryMs, lifeBucket } from '../data/whLifetimes.js';
-import { esiLimiter } from '../middleware/rateLimits.js';
-import { fetchSystemKills } from './killboard.js';
-import { resolveSystemMeta, resolveShipTypeName, type KillRow } from '../services/killFeed.js';
+import { buildKillRow } from '../services/killFeed.js';
+import { recentKillsForSystems } from '../services/killBuffer.js';
 
 const log = createLogger('maps');
 const discordLog = createLogger('discord');
@@ -1950,11 +1949,13 @@ mapsRouter.get('/:mapId/events', async (req, res) => {
   streamMapEvents(req, res, mapId);
 });
 
-// GET /api/maps/:mapId/kills/backfill — recent (last hour) high-value kills in
-// the map's systems, to seed the kill-log panel on open. Access-checked and
-// rate-limited (esiLimiter) since it fans out to zKill; the system count is
-// capped so a huge chain can't burst the feed. Returns KillRow[] newest-first.
-mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
+// GET /api/maps/:mapId/kills/backfill — recent high-value kills in the map's
+// systems, to seed the kill-log panel on open. Served from the in-memory buffer
+// the live feed fills (services/killBuffer) — no zKillboard REST calls, so it's
+// instant and scales to any map size. Access-checked. Returns KillRow[]
+// newest-first. (The buffer only holds kills since the server booted, so right
+// after a restart the log fills in as the feed runs.)
+mapsRouter.get('/:mapId/kills/backfill', async (req, res) => {
   const { mapId } = req.params;
   const access = await getMapAccess(mapId, req);
   if (!access) { res.status(404).json({ error: 'Map not found' }); return; }
@@ -1964,64 +1965,12 @@ mapsRouter.get('/:mapId/kills/backfill', esiLimiter, async (req, res) => {
        FROM map_systems WHERE map_id = $1 AND eve_system_id IS NOT NULL`,
     [mapId],
   );
-  let systemIds = rows.map((r) => r.eveSystemId);
-  const cap = config.killFeed.backfillMaxSystems;
-  if (systemIds.length > cap) {
-    log.warn(`kill backfill: map ${mapId} has ${systemIds.length} systems, capping to ${cap}`);
-    systemIds = systemIds.slice(0, cap);
-  }
-  if (!systemIds.length) { res.json([]); return; }
+  const systemIds = new Set(rows.map((r) => r.eveSystemId));
+  if (!systemIds.size) { res.json([]); return; }
 
-  // Per-system fetch is cached + ESI-concurrency-capped inside fetchSystemKills.
-  // Pass the ISK floor + a per-system cap so it filters BEFORE ESI hydration —
-  // essential in busy regions (The Forge) where hydrating every kill would trip
-  // rate limits and return stale/incomplete data. 20 newest kept per system to
-  // keep ESI calls low; the merged result is sliced to 200 below anyway.
-  const perSystemFetch = async (sysId: number): Promise<KillRow[]> => {
-    const kills = await fetchSystemKills(sysId, config.killFeed.backfillSeconds, {
-      minValueIsk: config.killFeed.minValueIsk,
-      maxKills: 20,
-    });
-    if (!kills.length) return [];
-    const meta = await resolveSystemMeta(sysId);
-    return Promise.all(kills.map(async (k): Promise<KillRow> => ({
-      killmailId:  k.killmail_id,
-      atMs:        Date.parse(k.killmail_time) || Date.now(),
-      eveSystemId: sysId,
-      systemName:  meta.systemName,
-      regionName:  meta.regionName,
-      shipTypeId:  k.victim.ship_type_id,
-      shipTypeName: await resolveShipTypeName(k.victim.ship_type_id),
-      totalValue:  k.zkb.totalValue,
-      victimCharacterId:   k.victim.character_id ?? null,
-      victimName:          k.victim.character_name ?? null,
-      victimCorporationId: k.victim.corporation_id ?? null,
-      victimCorpName:      k.victim.corporation_name ?? null,
-    })));
-  };
-  // Bound the per-system zKill REST fan-out: fetchSystemKills caps the ESI
-  // hydration internally, but the outer list calls would otherwise all fire at
-  // once (up to backfillMaxSystems), bursting zKill on a cold cache. Process in
-  // small chunks so at most BACKFILL_CONCURRENCY systems hit zKill together.
-  const BACKFILL_CONCURRENCY = 5;
-  const perSystem: KillRow[][] = [];
-  for (let i = 0; i < systemIds.length; i += BACKFILL_CONCURRENCY) {
-    const chunk = systemIds.slice(i, i + BACKFILL_CONCURRENCY);
-    perSystem.push(...await Promise.all(chunk.map(perSystemFetch)));
-  }
-
-  // Merge, dedupe by killmail id, newest first, cap the response.
-  const seen = new Set<number>();
-  const merged: KillRow[] = [];
-  for (const list of perSystem) {
-    for (const row of list) {
-      if (seen.has(row.killmailId)) continue;
-      seen.add(row.killmailId);
-      merged.push(row);
-    }
-  }
-  merged.sort((a, b) => b.atMs - a.atMs);
-  res.json(merged.slice(0, 200));
+  const buffered = recentKillsForSystems(systemIds, 200);
+  const kills = await Promise.all(buffered.map(buildKillRow));
+  res.json(kills);
 });
 
 // POST /api/maps/:mapId/presence — a viewer reports its current location.

--- a/server/src/services/killBuffer.ts
+++ b/server/src/services/killBuffer.ts
@@ -1,0 +1,47 @@
+import { config } from '../config.js';
+
+// A single high-value kill recorded from the live R2Z2 feed, held in memory so
+// the kill-log backfill can be served WITHOUT any zKillboard REST calls. Numeric
+// ids only (untrusted-safe); display names are resolved on read via buildKillRow.
+export interface BufferedKill {
+  killmailId:          number;
+  atMs:                number;
+  eveSystemId:         number;
+  shipTypeId:          number;
+  totalValue:          number;
+  victimCharacterId:   number | null;
+  victimCorporationId: number | null;
+}
+
+// Rolling in-memory buffer of recent kills, fed by the live consumer. Append
+// order ~= time order (the feed is chronological). Bounded by BOTH age and a
+// hard MAX_ENTRIES so it can't grow without limit on a busy feed.
+const MAX_ENTRIES = 20_000;
+const retentionMs = Math.max(60_000, config.killFeed.backfillSeconds * 1_000);
+
+const buffer: BufferedKill[] = [];
+const seen = new Set<number>();
+
+// Record a kill (deduped by killmailId), then prune the front: entries older
+// than the retention window, plus any overflow past MAX_ENTRIES. Front-pruning
+// is valid because the feed delivers in ~time order; recentKillsForSystems also
+// age-filters, so an out-of-order straggler is excluded from results regardless.
+export function recordKill(k: BufferedKill): void {
+  if (seen.has(k.killmailId)) return;
+  seen.add(k.killmailId);
+  buffer.push(k);
+  const cutoff = Date.now() - retentionMs;
+  while (buffer.length && (buffer[0].atMs < cutoff || buffer.length > MAX_ENTRIES)) {
+    const dropped = buffer.shift()!;
+    seen.delete(dropped.killmailId);
+  }
+}
+
+// Recent kills in the given systems, newest-first, capped to `limit`.
+export function recentKillsForSystems(systemIds: Set<number>, limit: number): BufferedKill[] {
+  const cutoff = Date.now() - retentionMs;
+  return buffer
+    .filter((k) => k.atMs >= cutoff && systemIds.has(k.eveSystemId))
+    .sort((a, b) => b.atMs - a.atMs)
+    .slice(0, limit);
+}

--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -4,6 +4,7 @@ import { createLogger } from '../utils/logger.js';
 import { activeMapIds, publishToMap } from './mapEvents.js';
 import { resolveEntityNames } from './entityNames.js';
 import { notifyDiscord, killEmbed } from './discord.js';
+import { recordKill, type BufferedKill } from './killBuffer.js';
 
 // A single decorated kill, shared by the live SSE `kill.recent` event and the
 // REST backfill (routes/maps.ts). Every display name is resolved by US from a
@@ -53,6 +54,27 @@ export async function resolveShipTypeName(id: number): Promise<string> {
   return name;
 }
 
+// Decorate a buffered kill into the full KillRow the client renders: who/what/
+// where resolved by US from the numeric ids (resolveEntityNames + SDE) — no
+// zKill-supplied string is ever forwarded. Used by both the live SSE path and
+// the REST backfill (which reads the in-memory buffer).
+export async function buildKillRow(k: BufferedKill): Promise<KillRow> {
+  const [meta, shipTypeName, names] = await Promise.all([
+    resolveSystemMeta(k.eveSystemId),
+    resolveShipTypeName(k.shipTypeId),
+    resolveEntityNames([k.victimCharacterId, k.victimCorporationId]),
+  ]);
+  return {
+    killmailId: k.killmailId, atMs: k.atMs, eveSystemId: k.eveSystemId,
+    systemName: meta.systemName, regionName: meta.regionName,
+    shipTypeId: k.shipTypeId, shipTypeName, totalValue: k.totalValue,
+    victimCharacterId: k.victimCharacterId,
+    victimName: k.victimCharacterId ? names.get(k.victimCharacterId)?.name ?? null : null,
+    victimCorporationId: k.victimCorporationId,
+    victimCorpName: k.victimCorporationId ? names.get(k.victimCorporationId)?.name ?? null : null,
+  };
+}
+
 // Single-process consumer of zKillboard's live killmail feed. Filters to
 // high-value kills in systems that are currently on a live map and pushes a
 // `kill.recent` event over the SSE stream so the client can flash the system
@@ -72,7 +94,7 @@ const r2z2KillUrl = (seq: number) => `https://r2z2.zkillboard.com/ephemeral/${se
 const USER_AGENT = `Eve-Nexum/1.0 (${config.killFeed.contact})`; // non-blank UA required (Cloudflare)
 const FETCH_TIMEOUT_MS = 15_000;
 const MAX_BACKOFF_MS = 30_000;
-const IDLE_SLEEP_MS = 6_000;  // mandatory >=6s wait after a 404 (caught up) — a shorter wait is 403'd
+const IDLE_SLEEP_MS = 10_000; // wait after a 404 (caught up). R2Z2 mandates >=6s (shorter is 403'd); 10s is comfortably safe and kills already lag by minutes.
 const REQ_SPACING_MS = 120;   // ~8 req/s while catching up; comfortably under the 15 req/s cap
 const SEEN_CAP = 2000;
 
@@ -125,7 +147,8 @@ async function getJson(url: string): Promise<{ status: number; body: unknown }> 
   return { status: 200, body: await res.json() };
 }
 
-// Process one ephemeral killmail: filter, match to live maps, decorate, publish.
+// Process one ephemeral killmail: buffer it, then (if a map is watching its
+// system) decorate + publish + Discord.
 async function processKill(body: EphemeralKill): Promise<void> {
   const km = body.esi ?? {};
   const killmailId    = Number(body.killmail_id ?? km.killmail_id);
@@ -138,7 +161,25 @@ async function processKill(body: EphemeralKill): Promise<void> {
   if (!(totalValue >= config.killFeed.minValueIsk)) return;
   stats.overMin++;
 
-  // Only touch the DB when at least one map is actually being watched.
+  // Numeric ids only from the (untrusted) killmail. character_id is absent for
+  // structure/NPC-only losses -> null. `Number(x) || null` maps 0/NaN to null;
+  // a real id is a large positive number so it survives.
+  const shipTypeId          = Number(km.victim?.ship_type_id) || 0;
+  const victimCharacterId   = Number(km.victim?.character_id) || null;
+  const victimCorporationId = Number(km.victim?.corporation_id) || null;
+  const parsed = km.killmail_time ? Date.parse(km.killmail_time) : NaN;
+  const atMs = Number.isFinite(parsed) ? parsed : Date.now();
+
+  // Record into the rolling buffer UNCONDITIONALLY (even with no map open) so the
+  // kill-log backfill can be served from memory — no zKillboard REST scraping.
+  const buffered: BufferedKill = {
+    killmailId, atMs, eveSystemId: solarSystemId,
+    shipTypeId, totalValue, victimCharacterId, victimCorporationId,
+  };
+  recordKill(buffered);
+
+  // Live path: only decorate + forward when a map is actually being watched AND
+  // the kill is in one of its systems.
   const live = activeMapIds();
   if (!live.length) return;
 
@@ -150,37 +191,13 @@ async function processKill(body: EphemeralKill): Promise<void> {
   );
   if (!rows.length) return;
 
-  // Numeric ids only from the (untrusted) killmail. character_id is absent for
-  // structure/NPC-only losses -> null. `Number(x) || null` maps 0/NaN to null;
-  // a real id is a large positive number so it survives.
-  const shipTypeId          = Number(km.victim?.ship_type_id) || 0;
-  const victimCharacterId   = Number(km.victim?.character_id) || null;
-  const victimCorporationId = Number(km.victim?.corporation_id) || null;
-  const parsed = km.killmail_time ? Date.parse(km.killmail_time) : NaN;
-  const atMs = Number.isFinite(parsed) ? parsed : Date.now();
-
-  // Resolve who/what/where from the ids on OUR side (ESI cache + SDE) — the
-  // killmail carries no names, so nothing untrusted is echoed to clients.
-  const [meta, shipTypeName, names] = await Promise.all([
-    resolveSystemMeta(solarSystemId),
-    resolveShipTypeName(shipTypeId),
-    resolveEntityNames([victimCharacterId, victimCorporationId]),
-  ]);
-  const killRow: KillRow = {
-    killmailId, atMs, eveSystemId: solarSystemId,
-    systemName: meta.systemName, regionName: meta.regionName,
-    shipTypeId, shipTypeName, totalValue,
-    victimCharacterId,
-    victimName: victimCharacterId ? names.get(victimCharacterId)?.name ?? null : null,
-    victimCorporationId,
-    victimCorpName: victimCorporationId ? names.get(victimCorporationId)?.name ?? null : null,
-  };
+  const killRow = await buildKillRow(buffered);
 
   for (const { mapId } of rows) {
     publishToMap(mapId, { type: 'kill.recent', actor: null, ...killRow });
   }
   stats.forwarded++;
-  log.info(`forwarded kill in ${meta.systemName} (${Math.round(totalValue / 1e6)}M ISK) -> ${rows.length} map(s)`);
+  log.info(`forwarded kill in ${killRow.systemName} (${Math.round(totalValue / 1e6)}M ISK) -> ${rows.length} map(s)`);
 
   // Corp/alliance Discord kill alert for the matched maps (opt-in per org).
   await dispatchDiscord(rows.map((r) => r.mapId), killRow);
@@ -243,8 +260,8 @@ async function loop(): Promise<void> {
       }
       const { status, body } = await getJson(r2z2KillUrl(seq));
       if (status === 404) {
-        // Caught up — no killmail at this sequence yet. Honour the mandatory
-        // >=6s wait, then retry the SAME sequence.
+        // Caught up — no killmail at this sequence yet. Wait (>= the 6s R2Z2
+        // minimum), then retry the SAME sequence.
         await sleep(IDLE_SLEEP_MS);
         backoff = 1_000;
         continue;


### PR DESCRIPTION
The proper fix for the kill log not matching zKill / differing between servers on a big busy map.

**Problem:** the backfill scraped zKillboard's REST API **once per mapped system** on open. With `MAX_SYSTEMS=88` on The Forge, that burst tripped zKill's rate limits, so systems fell back to **stale cache** -- recent kills missing, inconsistent per run and per server, never matching zKill. (#571 cut the ESI hydration but not those 88 list calls.)

**Fix:** the live R2Z2 consumer already sees every kill, so:
- New `services/killBuffer.ts` -- a bounded in-memory ring of recent high-value kills: age-pruned to `KILL_FEED_BACKFILL_SECONDS`, hard-capped at 20k, deduped by killmail id. Numeric-only records (untrusted-safe).
- The consumer `recordKill`s **before** the "is a map open?" guard, so the buffer fills continuously; decoration is shared via `buildKillRow`.
- `GET /:mapId/kills/backfill` now serves from the buffer filtered to the map's systems -> **zero zKillboard REST calls**, instant, scales to any map size. Access-checked; no `fetch`/ESI hydration in the route.

**Also:**
- R2Z2 caught-up poll wait **6s -> 10s** (per your call).
- Dropped `KILL_FEED_BACKFILL_MAX_SYSTEMS` from config, both `.env.example`s, and the README (now irrelevant). README kill-feed section rewritten to describe the buffer.

**Trade-off (documented):** the buffer only holds kills since the server booted, so right after a restart the log fills in over the first few hours -- the live feed still flags everything in real time immediately.

Client + killboard pane unchanged (`fetchSystemKills` stays for the pane). Built via fork + my review (buffer bounds, record-before-guard ordering, no external calls in the route). Server `tsc` clean.

Supersedes the REST-scraping approach in the now-merged #571.