### PR TITLE
Killboard panel: merge live-feed kills (pulsing) + fresher REST cache

### DIFF
--- a/server/src/routes/killboard.ts
+++ b/server/src/routes/killboard.ts
@@ -10,7 +10,7 @@ router.use(optionalAuth);
 const log = createLogger('killboard');
 
 const ZKB_AGENT    = 'Eve-Nexum/1.0 (https://github.com/GQuantrill/eve-nexum; gq@area404.org)';
-const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_TTL_MS = 90 * 1000; // fresher REST half now that the live feed covers the newest kills
 const FETCH_TIMEOUT_MS = 8_000;
 
 interface ZkbEntry {

--- a/server/src/services/killBuffer.ts
+++ b/server/src/services/killBuffer.ts
@@ -4,13 +4,17 @@ import { config } from '../config.js';
 // the kill-log backfill can be served WITHOUT any zKillboard REST calls. Numeric
 // ids only (untrusted-safe); display names are resolved on read via buildKillRow.
 export interface BufferedKill {
-  killmailId:          number;
-  atMs:                number;
-  eveSystemId:         number;
-  shipTypeId:          number;
-  totalValue:          number;
-  victimCharacterId:   number | null;
-  victimCorporationId: number | null;
+  killmailId:            number;
+  atMs:                  number;
+  eveSystemId:           number;
+  shipTypeId:            number;
+  totalValue:            number;
+  victimCharacterId:     number | null;
+  victimCorporationId:   number | null;
+  finalBlowCharacterId:  number | null;
+  finalBlowCorporationId: number | null;
+  finalBlowShipTypeId:   number;
+  npc:                   boolean;
 }
 
 // Rolling in-memory buffer of recent kills, fed by the live consumer. Append

--- a/server/src/services/killFeed.ts
+++ b/server/src/services/killFeed.ts
@@ -23,6 +23,15 @@ export interface KillRow {
   victimName:          string | null;
   victimCorporationId: number | null;
   victimCorpName:      string | null;
+  npc:                 boolean;
+  finalBlow: {
+    characterId:   number | null;
+    name:          string | null;
+    corporationId: number | null;
+    corpName:      string | null;
+    shipTypeId:    number;
+    shipName:      string;
+  } | null;
 }
 
 // Static SDE lookups, cached in-process (system/region and ship-type names never
@@ -59,11 +68,16 @@ export async function resolveShipTypeName(id: number): Promise<string> {
 // zKill-supplied string is ever forwarded. Used by both the live SSE path and
 // the REST backfill (which reads the in-memory buffer).
 export async function buildKillRow(k: BufferedKill): Promise<KillRow> {
-  const [meta, shipTypeName, names] = await Promise.all([
+  const [meta, shipTypeName, fbShipName, names] = await Promise.all([
     resolveSystemMeta(k.eveSystemId),
     resolveShipTypeName(k.shipTypeId),
-    resolveEntityNames([k.victimCharacterId, k.victimCorporationId]),
+    resolveShipTypeName(k.finalBlowShipTypeId),
+    resolveEntityNames([
+      k.victimCharacterId, k.victimCorporationId,
+      k.finalBlowCharacterId, k.finalBlowCorporationId,
+    ]),
   ]);
+  const hasFinalBlow = k.finalBlowCharacterId != null || k.finalBlowCorporationId != null || k.finalBlowShipTypeId > 0;
   return {
     killmailId: k.killmailId, atMs: k.atMs, eveSystemId: k.eveSystemId,
     systemName: meta.systemName, regionName: meta.regionName,
@@ -72,6 +86,15 @@ export async function buildKillRow(k: BufferedKill): Promise<KillRow> {
     victimName: k.victimCharacterId ? names.get(k.victimCharacterId)?.name ?? null : null,
     victimCorporationId: k.victimCorporationId,
     victimCorpName: k.victimCorporationId ? names.get(k.victimCorporationId)?.name ?? null : null,
+    npc: k.npc,
+    finalBlow: hasFinalBlow ? {
+      characterId:   k.finalBlowCharacterId,
+      name:          k.finalBlowCharacterId ? names.get(k.finalBlowCharacterId)?.name ?? null : null,
+      corporationId: k.finalBlowCorporationId,
+      corpName:      k.finalBlowCorporationId ? names.get(k.finalBlowCorporationId)?.name ?? null : null,
+      shipTypeId:    k.finalBlowShipTypeId,
+      shipName:      fbShipName,
+    } : null,
   };
 }
 
@@ -107,11 +130,12 @@ interface EsiKillmail {
   killmail_time?:   string;
   solar_system_id?: number;
   victim?:          { ship_type_id?: number; character_id?: number; corporation_id?: number };
+  attackers?:       Array<{ character_id?: number; corporation_id?: number; ship_type_id?: number; final_blow?: boolean }>;
 }
 interface EphemeralKill {
   killmail_id?: number;
   esi?:         EsiKillmail;       // the raw ESI killmail (R2Z2 nests it under `esi`)
-  zkb?:         { totalValue?: number };
+  zkb?:         { totalValue?: number; npc?: boolean };
 }
 
 // Bounded FIFO of recently-seen killmail ids — drops repeats across reconnects
@@ -170,11 +194,20 @@ async function processKill(body: EphemeralKill): Promise<void> {
   const parsed = km.killmail_time ? Date.parse(km.killmail_time) : NaN;
   const atMs = Number.isFinite(parsed) ? parsed : Date.now();
 
+  // Final-blow attacker (numeric ids only) so the killboard panel can render the
+  // live kill as a full row; and zKill's npc flag so the panel's NPC toggle works.
+  const fb = km.attackers?.find((a) => a?.final_blow);
+  const finalBlowCharacterId   = Number(fb?.character_id) || null;
+  const finalBlowCorporationId = Number(fb?.corporation_id) || null;
+  const finalBlowShipTypeId    = Number(fb?.ship_type_id) || 0;
+  const npc = !!body.zkb?.npc;
+
   // Record into the rolling buffer UNCONDITIONALLY (even with no map open) so the
   // kill-log backfill can be served from memory — no zKillboard REST scraping.
   const buffered: BufferedKill = {
     killmailId, atMs, eveSystemId: solarSystemId,
     shipTypeId, totalValue, victimCharacterId, victimCorporationId,
+    finalBlowCharacterId, finalBlowCorporationId, finalBlowShipTypeId, npc,
   };
   recordKill(buffered);
 

--- a/web/src/components/ui/KillboardPane.module.css
+++ b/web/src/components/ui/KillboardPane.module.css
@@ -84,6 +84,30 @@
   transition: background 0.1s;
 }
 
+/* A kill sourced live from the R2Z2 feed (not yet in / ahead of zKill's REST):
+   a subtle left accent plus a pulsing dot so it's obvious it's real-time. */
+.killLive {
+  position: relative;
+  box-shadow: inset 2px 0 0 #ff3b3b;
+}
+.liveDot {
+  position: absolute;
+  left: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ff3b3b;
+  box-shadow: 0 0 4px #ff3b3b;
+  animation: killboard-live-pulse 1.4s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes killboard-live-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.3; }
+}
+
 .kill:hover { background: rgba(255,255,255,0.03); }
 
 .killPod { background: rgba(100,40,180,0.08); }

--- a/web/src/components/ui/KillboardPane.tsx
+++ b/web/src/components/ui/KillboardPane.tsx
@@ -1,12 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { useKillboard, useLastKill } from '../../hooks/useKillboard';
 import { useStandings } from '../../hooks/useStandings';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useNow30s } from '../../hooks/useNow30s';
+import { useSystemKillLog, RECENT_KILL_MS, type KillRow as FeedKill } from '../../store/killStore';
 import { abbreviateValue, splitHoursMinutes } from '../../i18n/format';
 import type { ZkbKill } from '../../hooks/useKillboard';
 import styles from './KillboardPane.module.css';
+
+// Adapt a live kill-feed row into the zKill shape the panel renders. We only
+// have the final-blow attacker from the feed, so `attackers` holds just that.
+function killRowToZkb(r: FeedKill): ZkbKill {
+  return {
+    killmail_id:   r.killmailId,
+    killmail_time: new Date(r.atMs).toISOString(),
+    victim: {
+      character_id:     r.victimCharacterId ?? undefined,
+      character_name:   r.victimName ?? undefined,
+      corporation_id:   r.victimCorporationId ?? undefined,
+      corporation_name: r.victimCorpName ?? undefined,
+      ship_type_id:     r.shipTypeId,
+    },
+    attackers: r.finalBlow ? [{
+      final_blow:       true,
+      character_id:     r.finalBlow.characterId ?? undefined,
+      character_name:   r.finalBlow.name ?? undefined,
+      corporation_id:   r.finalBlow.corporationId ?? undefined,
+      corporation_name: r.finalBlow.corpName ?? undefined,
+      ship_type_id:     r.finalBlow.shipTypeId || undefined,
+    }] : [],
+    zkb: { hash: '', totalValue: r.totalValue, solo: false, npc: r.npc },
+  };
+}
 
 const NPC_TOGGLE_KEY = 'nexum.killboardIncludeNpc';
 
@@ -130,7 +157,7 @@ function killRowTint(victim: number, killer: number): string {
   return '';
 }
 
-function KillRow({ kill, standings }: { kill: ZkbKill; standings: ReturnType<typeof useStandings> }) {
+function KillRow({ kill, standings, pulse }: { kill: ZkbKill; standings: ReturnType<typeof useStandings>; pulse?: boolean }) {
   const { t } = useTranslation();
   const isPod      = kill.victim.ship_type_id === 670;
   const v          = kill.victim;
@@ -141,7 +168,8 @@ function KillRow({ kill, standings }: { kill: ZkbKill; standings: ReturnType<typ
   const tint           = killRowTint(victimStanding, killerStanding);
 
   return (
-    <div className={[styles.kill, isPod && styles.killPod, tint].filter(Boolean).join(' ')}>
+    <div className={[styles.kill, isPod && styles.killPod, pulse && styles.killLive, tint].filter(Boolean).join(' ')}>
+      {pulse && <span className={styles.liveDot} data-tip={t('killboard.live')} aria-label={t('killboard.live')} />}
       {/* Victim side: victim ship → victim affiliations */}
       <span className={styles.shipWrap}>
         <a
@@ -236,6 +264,21 @@ export function KillboardPane({ eveSystemId }: Props) {
   const standings = useStandings();
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
+  // Merge the live kill feed for this system with the zKill REST list so recent
+  // notable kills show immediately, without waiting on zKill's cached REST API.
+  const liveRows = useSystemKillLog(eveSystemId);
+  const now      = useNow30s();
+  const liveIds  = useMemo(() => new Set(liveRows.map((r) => r.killmailId)), [liveRows]);
+  const mergedKills = useMemo(() => {
+    const byId = new Map<number, ZkbKill>();
+    for (const k of kills) byId.set(k.killmail_id, k); // REST first — fuller attacker list wins on overlap
+    for (const r of liveRows) {
+      if (!includeNpc && r.npc) continue;              // respect the NPC toggle for live rows too
+      if (!byId.has(r.killmailId)) byId.set(r.killmailId, killRowToZkb(r));
+    }
+    return [...byId.values()].sort((a, b) => Date.parse(b.killmail_time) - Date.parse(a.killmail_time));
+  }, [kills, liveRows, includeNpc]);
+
   // Nothing in the last 24h (and not merely NPC-filtered) → look up the last
   // kill of any age so the pane can say "last kill was X ago" instead of a bare
   // "no kills". Gated so active systems never trigger the extra lookup.
@@ -251,8 +294,8 @@ export function KillboardPane({ eveSystemId }: Props) {
     return <p className={styles.state}>{t('panes.noEveSystem')}</p>;
   }
 
-  const visibleKills = kills.slice(0, visibleCount);
-  const hasMore      = visibleCount < kills.length;
+  const visibleKills = mergedKills.slice(0, visibleCount);
+  const hasMore      = visibleCount < mergedKills.length;
 
   // Render the meta row (with the NPC toggle) regardless of whether there
   // are kills to show — otherwise the user has no way to flip the toggle
@@ -261,7 +304,7 @@ export function KillboardPane({ eveSystemId }: Props) {
     <div className={styles.pane}>
       <div className={styles.paneMeta}>
         <span>
-          {t('units.kills', { count: kills.length })}
+          {t('units.kills', { count: mergedKills.length })}
           {!includeNpc && npcCount > 0 && (
             <span className={styles.npcHidden} data-tooltip={t('killboard.npcHiddenTooltip')}>
               {' '}· {t('killboard.npcHidden', { count: npcCount })}
@@ -285,11 +328,11 @@ export function KillboardPane({ eveSystemId }: Props) {
         </label>
       </div>
 
-      {loading && kills.length === 0 ? (
+      {loading && mergedKills.length === 0 ? (
         <p className={styles.state}>{t('killboard.loading')}</p>
-      ) : error ? (
+      ) : error && mergedKills.length === 0 ? (
         <p className={`${styles.state} ${styles.stateError}`}>{error}</p>
-      ) : kills.length === 0 ? (
+      ) : mergedKills.length === 0 ? (
         <p className={styles.state}>
           {!includeNpc && npcCount > 0 ? (
             <>
@@ -306,14 +349,21 @@ export function KillboardPane({ eveSystemId }: Props) {
         </p>
       ) : (
         <div className={styles.list}>
-          {visibleKills.map((k) => <KillRow key={k.killmail_id} kill={k} standings={standings} />)}
+          {visibleKills.map((k) => (
+            <KillRow
+              key={k.killmail_id}
+              kill={k}
+              standings={standings}
+              pulse={liveIds.has(k.killmail_id) && now - Date.parse(k.killmail_time) < RECENT_KILL_MS}
+            />
+          ))}
           {hasMore && (
             <button
               type="button"
               className={styles.loadMore}
               onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
             >
-              {t('killboard.loadMore', { count: kills.length - visibleCount })}
+              {t('killboard.loadMore', { count: mergedKills.length - visibleCount })}
             </button>
           )}
         </div>

--- a/web/src/hooks/useMapEventStream.ts
+++ b/web/src/hooks/useMapEventStream.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useMapStore, type RemoteEvent } from '../store/mapStore';
 import { usePresenceStore, type PresenceViewer } from '../store/presenceStore';
-import { useKillStore } from '../store/killStore';
+import { useKillStore, type KillRow } from '../store/killStore';
 import { apiUrl } from '../api/client';
 import { CLIENT_ID } from '../api/clientId';
 
@@ -64,6 +64,8 @@ export function useMapEventStream(): void {
               victimName:          (data.victimName as string | null) ?? null,
               victimCorporationId: (data.victimCorporationId as number | null) ?? null,
               victimCorpName:      (data.victimCorpName as string | null) ?? null,
+              npc:                 !!data.npc,
+              finalBlow:           (data.finalBlow as KillRow['finalBlow']) ?? null,
             });
             return;
         }

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "vor {{hours}}h {{minutes}}m",
     "viewKillmail": "Killmail auf zKillboard ansehen",
+    "live": "Live",
     "soloKill": "Solo-Kill",
     "gank": "Gank — {{count}} Angreifer",
     "attackers": "{{count}} Angreifer",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1128,6 +1128,7 @@
   "killboard": {
     "hoursMinutesAgo": "{{hours}}h {{minutes}}m ago",
     "viewKillmail": "View killmail on zKillboard",
+    "live": "Live",
     "soloKill": "Solo kill",
     "gank": "Gank — {{count}} attackers",
     "attackers": "{{count}} attackers",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "hace {{hours}}h {{minutes}}m",
     "viewKillmail": "Ver killmail en zKillboard",
+    "live": "En directo",
     "soloKill": "Kill en solitario",
     "gank": "Gank — {{count}} atacantes",
     "attackers": "{{count}} atacantes",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "il y a {{hours}}h {{minutes}}m",
     "viewKillmail": "Voir le killmail sur zKillboard",
+    "live": "En direct",
     "soloKill": "Solo kill",
     "gank": "Gank — {{count}} attaquants",
     "attackers": "{{count}} attaquants",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "{{hours}}時間{{minutes}}分前",
     "viewKillmail": "zKillboard でキルメールを表示",
+    "live": "ライブ",
     "soloKill": "ソロキル",
     "gank": "ガンク — 攻撃者 {{count}} 名",
     "attackers": "攻撃者 {{count}} 名",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "{{hours}}시간 {{minutes}}분 전",
     "viewKillmail": "zKillboard에서 킬메일 보기",
+    "live": "실시간",
     "soloKill": "솔로 킬",
     "gank": "갱크 — 공격자 {{count}}명",
     "attackers": "공격자 {{count}}명",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "há {{hours}}h {{minutes}}m",
     "viewKillmail": "Ver killmail no zKillboard",
+    "live": "Ao vivo",
     "soloKill": "Kill a solo",
     "gank": "Gank — {{count}} atacantes",
     "attackers": "{{count}} atacantes",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1088,6 +1088,7 @@
   "killboard": {
     "hoursMinutesAgo": "{{hours}}ч {{minutes}}м назад",
     "viewKillmail": "Посмотреть киллмейл на zKillboard",
+    "live": "В реальном времени",
     "soloKill": "Соло-килл",
     "gank": "Ганк — {{count}} атакующих",
     "attackers": "{{count}} атакующих",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1058,6 +1058,7 @@
   "killboard": {
     "hoursMinutesAgo": "{{hours}} 小时 {{minutes}} 分钟前",
     "viewKillmail": "在 zKillboard 上查看击杀报告",
+    "live": "实时",
     "soloKill": "单人击杀",
     "gank": "围杀 — {{count}} 名攻击者",
     "attackers": "{{count}} 名攻击者",

--- a/web/src/store/killStore.ts
+++ b/web/src/store/killStore.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { create } from 'zustand';
 
 // Live kill flags + a chronological kill log — ephemeral, fed by the SSE stream
@@ -31,6 +32,15 @@ export interface KillRow {
   victimName:          string | null;
   victimCorporationId: number | null;
   victimCorpName:      string | null;
+  npc:                 boolean;
+  finalBlow: {
+    characterId:   number | null;
+    name:          string | null;
+    corporationId: number | null;
+    corpName:      string | null;
+    shipTypeId:    number;
+    shipName:      string;
+  } | null;
 }
 
 // A per-system flag carries the kill plus when WE received it. The node badge
@@ -105,4 +115,16 @@ export function useSystemKill(eveSystemId: number | null | undefined): KillFlag 
 // The chronological kill log for the panel.
 export function useKillLog(): KillRow[] {
   return useKillStore((s) => s.log);
+}
+
+// Live kills for one system (newest-first) — merged into that system's killboard
+// panel so recent notable kills appear without waiting on zKill's REST. Subscribes
+// to the stable `log` and memoises the filter (a filter inside the selector would
+// return a fresh array every store change and re-render needlessly).
+export function useSystemKillLog(eveSystemId: number | null | undefined): KillRow[] {
+  const log = useKillStore((s) => s.log);
+  return useMemo(
+    () => (eveSystemId == null ? [] : log.filter((k) => k.eveSystemId === eveSystemId)),
+    [log, eveSystemId],
+  );
 }


### PR DESCRIPTION
Makes the per-system ZKILLBOARD panel show recent kills in real time, instead of waiting on zKill's lagging REST API. **Stacked on #572** (base is `killfeed-buffer`, since it extends `KillRow`) -- merge #572 first.

**Problem:** the panel only read zKill's REST API, which trails its website by minutes-to-hours, so a kill the Kill Log already had (that 2-min Perimeter Tornado) was absent from the panel for the same system.

**Fix:** the panel now merges the **live R2Z2 feed's kills for that system** (from the kill store) with the REST list -- deduped by killmail id (REST wins on overlap for the fuller attacker list), NPC toggle honoured, newest-first. Live-sourced **recent** rows get a **pulsing red dot** so it's obvious which came from the real-time feed vs zKill's history.

**To render live kills as full killboard rows:** the feed record (`BufferedKill`) + `KillRow` now carry the **final-blow attacker** (char/corp/ship) and an **`npc`** flag, pulled from the R2Z2 killmail's `attackers[]`/`zkb`. Names are resolved **server-side from numeric IDs** (same invariant -- no zKill strings forwarded).

**Also:** killboard REST cache **5 min -> 90 s** so the history half is fresher too.

Built via fork + my review (final-blow resolution, the REST-wins dedup, pulse gating on live-sourced AND recent). server + web `tsc` clean; eslint clean (1 pre-existing warning); `killboard.live` in all 9 locales. Client killboard pane merge is the only UI change; no schema.

Note the same coverage caveat: only kills >= `KILL_FEED_MIN_ISK` come through live, so the panel gets the *notable* recent kills instantly; cheap/NPC ones still wait for the (now 90s) REST refresh.