### PR TITLE
Fix: heatmap option click closed the menu without selecting

### DIFF
--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -149,6 +149,11 @@ export function Select<V extends string = string>({
           ref={dropdownRef}
           className={styles.dropdown}
           role="listbox"
+          // Portalled to <body>, so it's outside any parent popover's ref. Mark
+          // it so useClickOutside doesn't read a click on an option as "outside"
+          // and close the parent (unmounting this dropdown before the option's
+          // mousedown selects). See useClickOutside.
+          data-select-dropdown=""
           aria-label={ariaLabel}
           style={{ position: 'fixed', left: pos.left, top: pos.top, maxHeight: pos.maxHeight, minWidth: minW }}
         >

--- a/web/src/hooks/useClickOutside.ts
+++ b/web/src/hooks/useClickOutside.ts
@@ -22,7 +22,13 @@ export function useClickOutside<T extends HTMLElement>(
   useEffect(() => {
     if (!enabled) return;
     const onDown = (e: PointerEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) cb.current();
+      if (!ref.current || ref.current.contains(e.target as Node)) return;
+      // A themed <Select>'s dropdown is portalled to <body>, so it's outside
+      // `ref` — but a click on one of its options is NOT an "outside" click for
+      // the popover that hosts the Select. Ignore it, or the host would close
+      // (unmounting the Select) before the option's mousedown applies.
+      if ((e.target as Element | null)?.closest?.('[data-select-dropdown]')) return;
+      cb.current();
     };
     document.addEventListener('pointerdown', onDown, true);
     return () => document.removeEventListener('pointerdown', onDown, true);


### PR DESCRIPTION
Bug: in the toolbar heatmap dropdown, clicking an option (Pod kills, NPC kills, …) closed the menu **without applying** it — you were stuck on the current metric.

**Cause:** the heatmap popover closes via `useClickOutside` (a `pointerdown` capture listener). It hosts the themed `<Select>`, whose option list is **portalled to `<body>`** — so a click on an option lands *outside* the popover's `ref`. `useClickOutside` fired on `pointerdown` (before the option's `onMouseDown`), closed the popover, and unmounted the `<Select>` before the selection could register.

**Fix:** the `<Select>` dropdown now carries `data-select-dropdown`, and `useClickOutside` ignores pointerdowns that land inside such an element. General -- any `useClickOutside` popover containing a `Select` benefits (not just the heatmap). Two-line change; `tsc` + eslint clean.

For your batch on release.