### PR TITLE
Track k-space: keep k-space to k-space jumps made via a wormhole

### DIFF
--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -6,6 +6,7 @@ import { useAuth } from '../context/AuthContext';
 import { readUserSetting } from './useUserSetting';
 import { pickHandles } from '../components/map/edgeUtils';
 import { maybeConfirmWhJump } from './whJumpConfirm';
+import { prefetchStargateNeighbors, isDefiniteWormholeHop } from '../utils/stargateAdjacency';
 import type { SystemClass, WormholeEffect } from '../types';
 
 interface Box { position: { x: number; y: number } }
@@ -235,11 +236,18 @@ export function applyTrackedJump(
   const systems = () => useMapStore.getState().map.systems;
 
   if (skip && isKspaceSkip(curr.systemClass)) {
-    // Arriving in K-space: keep it only when jumping in FROM J-space (the first
-    // K-space of this excursion). Intermediate K-space, or a login already
-    // parked in K-space, is skipped.
+    // Warm this system's stargate neighbours so the NEXT hop out of it can be
+    // classified (gate vs wormhole) synchronously.
+    prefetchStargateNeighbors(curr.eveSystemId);
+    // Arriving in K-space: keep it when jumping in FROM J-space (the first
+    // K-space of this excursion), OR when the hop from a previous K-space system
+    // was NOT via a stargate — non-adjacent K-space systems mean a wormhole /
+    // Ansiblex was used, and that connection is exactly what the map is for.
+    // Only a plain gate hop through intermediate K-space is dropped.
     const fromJspace = prev !== null && !isKspaceSkip(prev.systemClass);
-    if (fromJspace) {
+    const viaWormhole = prev !== null && isKspaceSkip(prev.systemClass)
+      && isDefiniteWormholeHop(prev.eveSystemId, curr.eveSystemId);
+    if (fromJspace || viaWormhole) {
       const mapSystemId = applyJump(curr, prevMapSystemId, true);
       return { mapSystemId, anchor: mapSystemId };
     }

--- a/web/src/utils/stargateAdjacency.ts
+++ b/web/src/utils/stargateAdjacency.ts
@@ -1,0 +1,31 @@
+import { api } from '../api/client';
+
+// Client cache of a system's stargate neighbours (eve system ids), backed by the
+// same GET /api/systems/:id/adjacent (map_stargates) the "Add adjacent" menu and
+// the connection gate-classifier use. Used by K-space tracking to tell a plain
+// stargate hop (adjacent systems) from a wormhole / Ansiblex jump (non-adjacent),
+// so the "don't track K-space" policy keeps genuine K-space-to-K-space wormhole
+// connections instead of dropping them as intermediate gate hops.
+
+const cache = new Map<number, Set<number>>();
+const inflight = new Set<number>();
+
+// Warm the cache for a system (fire-and-forget). Called on each K-space arrival
+// so the NEXT hop can be classified synchronously without waiting on the network.
+export function prefetchStargateNeighbors(eveSystemId: number): void {
+  if (!eveSystemId || cache.has(eveSystemId) || inflight.has(eveSystemId)) return;
+  inflight.add(eveSystemId);
+  api<Array<{ eveSystemId: number }>>(`/api/systems/${eveSystemId}/adjacent`)
+    .then((rows) => cache.set(eveSystemId, new Set(rows.map((r) => r.eveSystemId))))
+    .catch(() => { /* leave uncached — callers then assume a gate (see below) */ })
+    .finally(() => inflight.delete(eveSystemId));
+}
+
+// True ONLY when we know `from`'s neighbours and `to` is not among them — i.e. a
+// definite non-stargate (wormhole / Ansiblex) hop. Unknown (not yet cached, or a
+// failed fetch) returns false, so the caller safely assumes a gate and preserves
+// the prior "drop intermediate K-space" behaviour rather than over-recording.
+export function isDefiniteWormholeHop(from: number, to: number): boolean {
+  const neighbors = cache.get(from);
+  return neighbors !== undefined && !neighbors.has(to);
+}


### PR DESCRIPTION
Bug: with "don't track K-space" on, a k-space->k-space jump made through a **wormhole / Ansiblex** was dropped as "intermediate K-space" -- losing the connection the map is for. Only a plain **stargate** hop (between adjacent systems) should be dropped.

**Fix:** classify the hop by **stargate adjacency**. New `utils/stargateAdjacency.ts` caches a system's stargate neighbours via the existing `GET /api/systems/:id/adjacent` (the same `map_stargates` the connection gate-classifier uses). `applyTrackedJump` prefetches neighbours on each k-space arrival, then **keeps** a k-space->k-space hop when the two systems are **not** stargate-adjacent (`isDefiniteWormholeHop`) -- a wormhole was used. A plain gate hop through intermediate k-space is still dropped. Unknown/uncached falls back to the old skip (no regression).

Kept the tracking effect **synchronous** (prefetch-on-arrival + sync cache check) rather than an async refactor of that sensitive path. Works for live tracking **and** `nexumDebug.simulateJumps`.

Verifies your case: `nexumDebug.simulateJumps(['J212025','Hasmijaala','Enderailen'], 2000)` -- Hasmijaala->Enderailen (non-adjacent) is now recorded with a WH connection. `tsc` + eslint clean. For the release batch.
