### PR TITLE
Release batch: bookmark-format modal + heatmap select fix + k-space WH tracking

### DIFF
--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -149,6 +149,11 @@ export function Select<V extends string = string>({
           ref={dropdownRef}
           className={styles.dropdown}
           role="listbox"
+          // Portalled to <body>, so it's outside any parent popover's ref. Mark
+          // it so useClickOutside doesn't read a click on an option as "outside"
+          // and close the parent (unmounting this dropdown before the option's
+          // mousedown selects). See useClickOutside.
+          data-select-dropdown=""
           aria-label={ariaLabel}
           style={{ position: 'fixed', left: pos.left, top: pos.top, maxHeight: pos.maxHeight, minWidth: minW }}
         >

--- a/web/src/hooks/useClickOutside.ts
+++ b/web/src/hooks/useClickOutside.ts
@@ -22,7 +22,13 @@ export function useClickOutside<T extends HTMLElement>(
   useEffect(() => {
     if (!enabled) return;
     const onDown = (e: PointerEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) cb.current();
+      if (!ref.current || ref.current.contains(e.target as Node)) return;
+      // A themed <Select>'s dropdown is portalled to <body>, so it's outside
+      // `ref` — but a click on one of its options is NOT an "outside" click for
+      // the popover that hosts the Select. Ignore it, or the host would close
+      // (unmounting the Select) before the option's mousedown applies.
+      if ((e.target as Element | null)?.closest?.('[data-select-dropdown]')) return;
+      cb.current();
     };
     document.addEventListener('pointerdown', onDown, true);
     return () => document.removeEventListener('pointerdown', onDown, true);

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -6,6 +6,7 @@ import { useAuth } from '../context/AuthContext';
 import { readUserSetting } from './useUserSetting';
 import { pickHandles } from '../components/map/edgeUtils';
 import { maybeConfirmWhJump } from './whJumpConfirm';
+import { prefetchStargateNeighbors, isDefiniteWormholeHop } from '../utils/stargateAdjacency';
 import type { SystemClass, WormholeEffect } from '../types';
 
 interface Box { position: { x: number; y: number } }
@@ -235,11 +236,18 @@ export function applyTrackedJump(
   const systems = () => useMapStore.getState().map.systems;
 
   if (skip && isKspaceSkip(curr.systemClass)) {
-    // Arriving in K-space: keep it only when jumping in FROM J-space (the first
-    // K-space of this excursion). Intermediate K-space, or a login already
-    // parked in K-space, is skipped.
+    // Warm this system's stargate neighbours so the NEXT hop out of it can be
+    // classified (gate vs wormhole) synchronously.
+    prefetchStargateNeighbors(curr.eveSystemId);
+    // Arriving in K-space: keep it when jumping in FROM J-space (the first
+    // K-space of this excursion), OR when the hop from a previous K-space system
+    // was NOT via a stargate — non-adjacent K-space systems mean a wormhole /
+    // Ansiblex was used, and that connection is exactly what the map is for.
+    // Only a plain gate hop through intermediate K-space is dropped.
     const fromJspace = prev !== null && !isKspaceSkip(prev.systemClass);
-    if (fromJspace) {
+    const viaWormhole = prev !== null && isKspaceSkip(prev.systemClass)
+      && isDefiniteWormholeHop(prev.eveSystemId, curr.eveSystemId);
+    if (fromJspace || viaWormhole) {
       const mapSystemId = applyJump(curr, prevMapSystemId, true);
       return { mapSystemId, anchor: mapSystemId };
     }

--- a/web/src/utils/stargateAdjacency.ts
+++ b/web/src/utils/stargateAdjacency.ts
@@ -1,0 +1,31 @@
+import { api } from '../api/client';
+
+// Client cache of a system's stargate neighbours (eve system ids), backed by the
+// same GET /api/systems/:id/adjacent (map_stargates) the "Add adjacent" menu and
+// the connection gate-classifier use. Used by K-space tracking to tell a plain
+// stargate hop (adjacent systems) from a wormhole / Ansiblex jump (non-adjacent),
+// so the "don't track K-space" policy keeps genuine K-space-to-K-space wormhole
+// connections instead of dropping them as intermediate gate hops.
+
+const cache = new Map<number, Set<number>>();
+const inflight = new Set<number>();
+
+// Warm the cache for a system (fire-and-forget). Called on each K-space arrival
+// so the NEXT hop can be classified synchronously without waiting on the network.
+export function prefetchStargateNeighbors(eveSystemId: number): void {
+  if (!eveSystemId || cache.has(eveSystemId) || inflight.has(eveSystemId)) return;
+  inflight.add(eveSystemId);
+  api<Array<{ eveSystemId: number }>>(`/api/systems/${eveSystemId}/adjacent`)
+    .then((rows) => cache.set(eveSystemId, new Set(rows.map((r) => r.eveSystemId))))
+    .catch(() => { /* leave uncached — callers then assume a gate (see below) */ })
+    .finally(() => inflight.delete(eveSystemId));
+}
+
+// True ONLY when we know `from`'s neighbours and `to` is not among them — i.e. a
+// definite non-stargate (wormhole / Ansiblex) hop. Unknown (not yet cached, or a
+// failed fetch) returns false, so the caller safely assumes a gate and preserves
+// the prior "drop intermediate K-space" behaviour rather than over-recording.
+export function isDefiniteWormholeHop(from: number, to: number): boolean {
+  const neighbors = cache.get(from);
+  return neighbors !== undefined && !neighbors.has(to);
+}


### PR DESCRIPTION
Promotes to release for a 3.17.2 patch:
- Map bookmark format editor: lock to owner/admins, moved into map settings, opens in its own modal (already on release).
- Heatmap: clicking an option no longer closes the menu without selecting (#581).
- Track k-space: keep a k-space->k-space jump made via a wormhole/Ansiblex instead of dropping it as an intermediate gate hop (#582).