### PR TITLE
Clarify kill-count badge tooltip (ESI count vs zKillboard)

### DIFF
--- a/web/src/components/map/SystemNode.tsx
+++ b/web/src/components/map/SystemNode.tsx
@@ -432,7 +432,12 @@ export const SystemNode = memo(({ data, selected }: NodeProps) => {
             <span className="system-node__kill-icon">
               <SwordIcon size={14} weight="regular" />
               <span className="system-node__kill-tooltip">
-                {t('mapNode.killsTooltip', { ships: myKills.shipKills, pods: myKills.podKills })}
+                <span className="system-node__kill-tooltip-main">
+                  {t('mapNode.killsTooltip', { ships: myKills.shipKills, pods: myKills.podKills })}
+                </span>
+                <span className="system-node__kill-tooltip-hint">
+                  {t('mapNode.killsTooltipHint')}
+                </span>
               </span>
             </span>
           )}

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "Charakter {{id}}",
     "altLastKnown": "(zuletzt bekannt)",
     "killsTooltip": "{{ships}} Schiff · {{pods}} Pod-Kills diese Stunde",
+    "killsTooltipHint": "CCP-Stundenzählung · Killmail evtl. noch nicht auf zKillboard",
     "recentKill": "Kill vor {{ago}} Min. ({{value}} ISK)",
     "a0Sun": "A0-Sonne",
     "shattered": "Zerschmettert",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1735,6 +1735,7 @@
     "characterFallback": "Character {{id}}",
     "altLastKnown": "(last known)",
     "killsTooltip": "{{ships}} ship · {{pods}} pod kills this hour",
+    "killsTooltipHint": "CCP hourly count · killmail may not be on zKillboard yet",
     "recentKill": "Kill {{ago}}m ago ({{value}} ISK)",
     "a0Sun": "A0 sun",
     "shattered": "Shattered",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "Personaje {{id}}",
     "altLastKnown": "(última conocida)",
     "killsTooltip": "{{ships}} nave · {{pods}} cápsula destruidas esta hora",
+    "killsTooltipHint": "Recuento horario de CCP · puede que aún no esté en zKillboard",
     "recentKill": "Muerte hace {{ago}} min ({{value}} ISK)",
     "a0Sun": "Sol A0",
     "shattered": "Destrozado",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "Personnage {{id}}",
     "altLastKnown": "(dernière connue)",
     "killsTooltip": "{{ships}} vaisseau · {{pods}} capsule détruits cette heure",
+    "killsTooltipHint": "Décompte horaire CCP · le killmail peut ne pas encore être sur zKillboard",
     "recentKill": "Kill il y a {{ago}} min ({{value}} ISK)",
     "a0Sun": "Soleil A0",
     "shattered": "Brisé",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "キャラクター {{id}}",
     "altLastKnown": "（最後の確認）",
     "killsTooltip": "今時間 {{ships}} 艦船 · {{pods}} ポッドキル",
+    "killsTooltipHint": "CCP の時間別集計 · killmail はまだ zKillboard にない場合があります",
     "recentKill": "{{ago}}分前のキル ({{value}} ISK)",
     "a0Sun": "A0 恒星",
     "shattered": "破壊された星系",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "캐릭터 {{id}}",
     "altLastKnown": "(마지막 확인)",
     "killsTooltip": "이번 시간 {{ships}} 함선 · {{pods}} 캡슐 킬",
+    "killsTooltipHint": "CCP 시간별 집계 · 킬메일이 아직 zKillboard에 없을 수 있음",
     "recentKill": "{{ago}}분 전 격추 ({{value}} ISK)",
     "a0Sun": "A0 항성",
     "shattered": "파괴된 성계",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "Personagem {{id}}",
     "altLastKnown": "(última conhecida)",
     "killsTooltip": "{{ships}} nave · {{pods}} cápsula destruídas esta hora",
+    "killsTooltipHint": "Contagem horária da CCP · pode ainda não estar no zKillboard",
     "recentKill": "Abate há {{ago}} min ({{value}} ISK)",
     "a0Sun": "Sol A0",
     "shattered": "Estilhaçado",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1703,6 +1703,7 @@
     "characterFallback": "Персонаж {{id}}",
     "altLastKnown": "(последнее изв.)",
     "killsTooltip": "{{ships}} кораблей · {{pods}} капсул убито за этот час",
+    "killsTooltipHint": "Почасовой подсчёт CCP · killmail может ещё не быть на zKillboard",
     "recentKill": "Килл {{ago}} мин назад ({{value}} ISK)",
     "a0Sun": "Звезда A0",
     "shattered": "Разрушенная",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1665,6 +1665,7 @@
     "characterFallback": "角色 {{id}}",
     "altLastKnown": "（最后已知）",
     "killsTooltip": "本小时 {{ships}} 舰船 · {{pods}} 太空舱击杀",
+    "killsTooltipHint": "CCP 每小时统计 · 击杀报告可能尚未出现在 zKillboard",
     "recentKill": "{{ago}} 分钟前击杀 ({{value}} ISK)",
     "a0Sun": "A0 恒星",
     "shattered": "破碎星系",

--- a/web/src/styles/system-node.css
+++ b/web/src/styles/system-node.css
@@ -947,12 +947,29 @@
   border: 1px solid var(--border-strong);
   border-radius: 6px;
   padding: 4px 10px;
-  white-space: nowrap;
   font-size: calc(13px * var(--font-scale, 1));
   color: #ff6060;
   font-weight: 600;
   pointer-events: none;
   z-index: 9999;
+  text-align: center;
+}
+
+.system-node__kill-tooltip-main {
+  white-space: nowrap;
+}
+
+/* Muted second line clarifying the count is CCP's ESI hourly aggregate, which
+   can differ from the zKillboard panel (a killmail zKill hasn't ingested yet,
+   or never will). Allowed to wrap so the longer translations stay readable. */
+.system-node__kill-tooltip-hint {
+  display: block;
+  margin-top: 2px;
+  max-width: 210px;
+  white-space: normal;
+  font-size: calc(11px * var(--font-scale, 1));
+  font-weight: 500;
+  color: var(--text-subtle);
 }
 
 .system-node__kill-icon:hover .system-node__kill-tooltip {


### PR DESCRIPTION
The map node badge **"N ship / N pod kills this hour"** is sourced from ESI `/universe/system_kills` (CCP's authoritative hourly tally) - a **different provider** from the ZKILLBOARD panel and the live Kill Log (both zKillboard-derived). CCP can count a kill this hour that zKillboard has no killmail for (not ingested yet, or never posted), so the badge and the zKill surfaces legitimately disagree - which reads as a data bug.

**Fix (UX only, no data/logic change):** add a muted second line to the badge tooltip:

> N ship / N pod kills this hour
> _CCP hourly count - killmail may not be on zKillboard yet_

New i18n key `mapNode.killsTooltipHint` in all 9 locales; tooltip restructured into a nowrap main line + a wrapping hint line. `tsc` + eslint clean, full en-vs-locale key parity verified.

Branched off `qa` after resyncing qa up to `release`/`main` (3.17.2) - qa had drifted 34 commits behind and lacked the kill-feed code this touches.