### PR TITLE
Let a share recipient leave a shared map (without deleting it)

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -3237,6 +3237,38 @@ mapsRouter.post('/:mapId/shares', async (req, res) => {
   }
 });
 
+// DELETE /api/maps/:mapId/shares/mine — a share RECIPIENT drops the map from
+// their OWN list (leave the share) without deleting it for anyone else. This is
+// the recipient counterpart to the owner-only revoke below: it deletes ONLY a
+// map_shares row whose target_character_id is the caller's own EVE character, so
+// it can never touch another character's grant or a corp/alliance-scoped grant
+// (which belongs to the whole org — only an admin can revoke those via :shareId).
+// The self-scoped WHERE makes this safe without a broader access check: with no
+// matching personal grant it simply deletes nothing and 404s. Must be registered
+// BEFORE the ':shareId' route so 'mine' isn't captured as a share UUID.
+mapsRouter.delete('/:mapId/shares/mine', async (req, res) => {
+  const { mapId } = req.params;
+  if (!UUID_RE.test(mapId)) { res.status(404).json({ error: 'Map not found' }); return; }
+
+  // Session-authed only — this is a personal-list action; external API keys
+  // don't have a "my list" to leave. authUser resolves the session user id.
+  const userId = req.session.userId;
+  if (!userId) { res.status(401).json({ error: 'Not authenticated' }); return; }
+  const { rows } = await db.query<{ callerChar: number | null }>(
+    `SELECT character_id AS "callerChar" FROM users WHERE id = $1`,
+    [userId],
+  );
+  const callerChar = rows[0]?.callerChar ?? null;
+  if (callerChar === null) { res.status(400).json({ error: 'No character on account' }); return; }
+
+  const { rowCount } = await db.query(
+    `DELETE FROM map_shares WHERE map_id = $1 AND target_character_id = $2`,
+    [mapId, callerChar],
+  );
+  if (!rowCount) { res.status(404).json({ error: 'No personal share to leave' }); return; }
+  res.json({ ok: true });
+});
+
 // DELETE /api/maps/:mapId/shares/:shareId — revoke. Personal maps: owner only;
 // corp/alliance maps: an admin / alliance-admin of the owning org.
 mapsRouter.delete('/:mapId/shares/:shareId', async (req, res) => {

--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -64,6 +64,13 @@ export async function listVisibleMaps(p: VisibleMapsParams) {
               AND (m.corp_id IS NULL OR NOT m.corp_id = ANY($2::int[]))
               AND (m.alliance_id IS NULL OR NOT m.alliance_id = ANY($6::int[]))
             ) AS "sharedWithMe",
+            -- True iff the caller has an explicit CHARACTER-scoped grant (not a
+            -- corp/alliance one, which belongs to the whole org). Only these can
+            -- be self-removed via DELETE /:mapId/shares/mine.
+            EXISTS (
+              SELECT 1 FROM map_shares ms
+               WHERE ms.map_id = m.id AND ms.target_character_id = $3
+            ) AS "canLeaveShare",
             m.locked,
             ou.character_name             AS "ownerName",
             m.allow_as_merge_source       AS "allowAsMergeSource",

--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -226,12 +226,17 @@ export function Toolbar() {
   const switchMap       = useMapStore((s) => s.switchMap);
   const requestFitView  = useMapStore((s) => s.requestFitView);
   const deleteMap       = useMapStore((s) => s.deleteMap);
+  const leaveShare      = useMapStore((s) => s.leaveShare);
   const mapOptionsOpen  = useMapStore((s) => s.mapOptionsOpen);
   const setMapOptionsOpen = useMapStore((s) => s.setMapOptionsOpen);
   const trackJumps      = useMapStore((s) => s.trackJumps);
   const setTrackJumps   = useMapStore((s) => s.setTrackJumps);
 
-  const atMapLimit      = maps.filter((m) => !m.isCorpMap && !m.isAllianceMap).length >= maxMaps;
+  // Personal-map cap counts only maps the caller OWNS. A map merely shared with
+  // them (sharedWithMe) has a different owner and doesn't count server-side, so
+  // exclude it here too — otherwise received shares wrongly eat into the cap and
+  // disable "+ New Map" / "Copy".
+  const atMapLimit      = maps.filter((m) => !m.isCorpMap && !m.isAllianceMap && !m.sharedWithMe).length >= maxMaps;
   const atCorpMapLimit  = corpMapCount >= maxCorpMaps;
   const { user, logout } = useAuth();
   const canEdit       = useCanEdit();
@@ -249,6 +254,9 @@ export function Toolbar() {
   // A map merely shared with you (map_shares grant, not your own / your org's) can't
   // be copied — only its owner may fork it. Hide the Copy action for those.
   const activeIsShared = !!maps.find((m) => m.id === activeMapId)?.sharedWithMe;
+  // A map shared with this character specifically (not via corp/alliance) can be
+  // dropped from their own list — gates the "Leave shared map" action below.
+  const activeCanLeave = !!maps.find((m) => m.id === activeMapId)?.canLeaveShare;
   const canManageMaps = useCanCreateMaps();
   const canManageAllianceMaps = useCanManageAllianceMaps();
   // Corp maps exist under corp OR alliance mode (a corp inside the alliance).
@@ -296,6 +304,7 @@ export function Toolbar() {
   const [showWhChart, setShowWhChart] = useState(false);
   const [showKillLog, setShowKillLog] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [leaveConfirm, setLeaveConfirm] = useState(false);
   const mapSwitcherRef = useRef<HTMLDivElement>(null);
   useClickOutside(showMaps, mapSwitcherRef, () => setShowMaps(false));
 
@@ -326,6 +335,11 @@ export function Toolbar() {
   async function handleDeleteMap() {
     if (!activeMapId) return;
     await deleteMap(activeMapId);
+  }
+
+  async function handleLeaveShare() {
+    if (!activeMapId) return;
+    await leaveShare(activeMapId);
   }
 
   // Nearest-threat chip: null unless an in-zone threat exists (the user's
@@ -450,6 +464,11 @@ export function Toolbar() {
               {canManageMaps && maps.length > 1 && !maps.find((m) => m.id === activeMapId)?.sharedWithMe && (
                 <button className="map-dropdown__item map-dropdown__item--danger" onClick={() => { setShowMaps(false); setDeleteConfirm(true); }}>
                   {t('toolbar.deleteThisMap')}
+                </button>
+              )}
+              {activeCanLeave && (
+                <button className="map-dropdown__item map-dropdown__item--danger" onClick={() => { setShowMaps(false); setLeaveConfirm(true); }}>
+                  {t('toolbar.leaveThisMap')}
                 </button>
               )}
             </div>
@@ -758,6 +777,16 @@ export function Toolbar() {
         onConfirm={async () => {
           setDeleteConfirm(false);
           await handleDeleteMap();
+        }}
+      />
+    )}
+    {leaveConfirm && (
+      <ConfirmModal
+        message={t('toolbar.leaveMapConfirm', { name: mapName })}
+        onCancel={() => setLeaveConfirm(false)}
+        onConfirm={async () => {
+          setLeaveConfirm(false);
+          await handleLeaveShare();
         }}
       />
     )}

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "Kartenlimit erreicht",
     "newMap": "+ Neue Karte",
     "deleteThisMap": "Diese Karte löschen",
+    "leaveThisMap": "Geteilte Karte verlassen",
     "name": "Kartenname",
     "totalSystems": "Systeme gesamt",
     "totalConnections": "Verbindungen gesamt",
@@ -1249,6 +1250,7 @@
     "currentSystem": "Aktuelles System",
     "centerOnSystem": "Karte auf {{system}} zentrieren",
     "deleteMapConfirm": "\"{{name}}\" löschen? Dies kann nicht rückgängig gemacht werden.",
+    "leaveMapConfirm": "\"{{name}}\" aus deiner Liste entfernen? Der Eigentümer kann sie später erneut teilen.",
     "online": {
       "offline": "Offline",
       "statusUnknown": "Status unbekannt",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1297,6 +1297,7 @@
     "newMap": "+ New Map",
     "copyThisMap": "Copy this map",
     "deleteThisMap": "Delete this map",
+    "leaveThisMap": "Leave shared map",
     "name": "Name",
     "totalSystems": "Total Systems",
     "totalConnections": "Total Connections",
@@ -1323,6 +1324,7 @@
     "currentSystem": "Current system",
     "centerOnSystem": "Centre the map on {{system}}",
     "deleteMapConfirm": "Delete \"{{name}}\"? This cannot be undone.",
+    "leaveMapConfirm": "Remove \"{{name}}\" from your list? The owner can share it again later.",
     "online": {
       "offline": "Offline",
       "statusUnknown": "Status unknown",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "Límite de mapas alcanzado",
     "newMap": "+ Nuevo mapa",
     "deleteThisMap": "Eliminar este mapa",
+    "leaveThisMap": "Salir del mapa compartido",
     "name": "Nombre del mapa",
     "totalSystems": "Sistemas totales",
     "totalConnections": "Conexiones totales",
@@ -1249,6 +1250,7 @@
     "currentSystem": "Sistema actual",
     "centerOnSystem": "Centrar el mapa en {{system}}",
     "deleteMapConfirm": "¿Eliminar «{{name}}»? Esta acción no se puede deshacer.",
+    "leaveMapConfirm": "¿Quitar «{{name}}» de tu lista? El propietario puede volver a compartirlo más tarde.",
     "online": {
       "offline": "Desconectado",
       "statusUnknown": "Estado desconocido",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "Limite de cartes atteinte",
     "newMap": "+ Nouvelle carte",
     "deleteThisMap": "Supprimer cette carte",
+    "leaveThisMap": "Quitter la carte partagée",
     "name": "Nom de la carte",
     "totalSystems": "Total systèmes",
     "totalConnections": "Total connexions",
@@ -1249,6 +1250,7 @@
     "currentSystem": "Système actuel",
     "centerOnSystem": "Centrer la carte sur {{system}}",
     "deleteMapConfirm": "Supprimer « {{name}} » ? Cette action est irréversible.",
+    "leaveMapConfirm": "Retirer « {{name}} » de votre liste ? Le propriétaire pourra la repartager plus tard.",
     "online": {
       "offline": "Hors ligne",
       "statusUnknown": "Statut inconnu",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "マップ上限に到達",
     "newMap": "+ 新規マップ",
     "deleteThisMap": "このマップを削除",
+    "leaveThisMap": "共有マップから退出",
     "name": "マップ名",
     "totalSystems": "総星系数",
     "totalConnections": "総接続数",
@@ -1249,6 +1250,7 @@
     "currentSystem": "現在のシステム",
     "centerOnSystem": "マップを {{system}} に移動",
     "deleteMapConfirm": "「{{name}}」を削除しますか？この操作は取り消せません。",
+    "leaveMapConfirm": "「{{name}}」をリストから削除しますか？オーナーは後で再共有できます。",
     "online": {
       "offline": "オフライン",
       "statusUnknown": "ステータス不明",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "지도 한도 도달",
     "newMap": "+ 새 지도",
     "deleteThisMap": "이 지도 삭제",
+    "leaveThisMap": "공유된 지도 나가기",
     "name": "지도 이름",
     "totalSystems": "전체 성계",
     "totalConnections": "전체 연결",
@@ -1249,6 +1250,7 @@
     "currentSystem": "현재 성계",
     "centerOnSystem": "지도를 {{system}}(으)로 이동",
     "deleteMapConfirm": "“{{name}}”을(를) 삭제할까요? 이 작업은 취소할 수 없습니다.",
+    "leaveMapConfirm": "목록에서 “{{name}}”을(를) 제거할까요? 소유자가 나중에 다시 공유할 수 있습니다.",
     "online": {
       "offline": "오프라인",
       "statusUnknown": "상태 알 수 없음",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "Limite de mapas atingido",
     "newMap": "+ Novo mapa",
     "deleteThisMap": "Eliminar este mapa",
+    "leaveThisMap": "Sair do mapa partilhado",
     "name": "Nome do mapa",
     "totalSystems": "Total de sistemas",
     "totalConnections": "Total de conexões",
@@ -1249,6 +1250,7 @@
     "currentSystem": "Sistema atual",
     "centerOnSystem": "Centrar o mapa em {{system}}",
     "deleteMapConfirm": "Eliminar «{{name}}»? Esta ação não pode ser desfeita.",
+    "leaveMapConfirm": "Remover «{{name}}» da tua lista? O proprietário pode partilhá-lo novamente mais tarde.",
     "online": {
       "offline": "Offline",
       "statusUnknown": "Estado desconhecido",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1264,6 +1264,7 @@
     "mapLimitReached": "Достигнут лимит карт",
     "newMap": "+ Новая карта",
     "deleteThisMap": "Удалить эту карту",
+    "leaveThisMap": "Покинуть общую карту",
     "name": "Название",
     "totalSystems": "Всего систем",
     "totalConnections": "Всего соединений",
@@ -1287,6 +1288,7 @@
     "currentSystem": "Текущая система",
     "centerOnSystem": "Центрировать карту на {{system}}",
     "deleteMapConfirm": "Удалить «{{name}}»? Это нельзя отменить.",
+    "leaveMapConfirm": "Убрать «{{name}}» из вашего списка? Владелец сможет поделиться ею снова позже.",
     "online": {
       "offline": "Офлайн",
       "statusUnknown": "Статус неизвестен",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1226,6 +1226,7 @@
     "mapLimitReached": "已达到地图上限",
     "newMap": "+ 新建地图",
     "deleteThisMap": "删除此地图",
+    "leaveThisMap": "退出共享地图",
     "name": "地图名称",
     "totalSystems": "星系总数",
     "totalConnections": "连接总数",
@@ -1249,6 +1250,7 @@
     "currentSystem": "当前星系",
     "centerOnSystem": "将地图居中到 {{system}}",
     "deleteMapConfirm": "删除「{{name}}」？此操作无法撤销。",
+    "leaveMapConfirm": "从你的列表中移除「{{name}}」？所有者之后可以再次共享。",
     "online": {
       "offline": "离线",
       "statusUnknown": "状态未知",

--- a/web/src/store/mapStore.ts
+++ b/web/src/store/mapStore.ts
@@ -155,6 +155,9 @@ export interface MapListItem {
   /** True when this map isn't owned by the caller and isn't a corp/alliance map
    *  they belong to — i.e. it reached their list via an explicit map_shares grant. */
   sharedWithMe?: boolean;
+  /** True when the caller has a CHARACTER-scoped share grant they can self-remove
+   *  ("leave the share"). False for corp/alliance grants (org-owned — admin only). */
+  canLeaveShare?: boolean;
   locked: boolean;
   /** Owning character's name — shown in the merge picker to disambiguate maps. */
   ownerName?: string | null;
@@ -290,6 +293,7 @@ interface MapStore {
   createMap: (name?: string, isCorpMap?: boolean, isAllianceMap?: boolean, skipKspace?: boolean) => Promise<void>;
   createFromRegion: (regionId: number, name: string, isCorpMap: boolean, isAllianceMap?: boolean, skipKspace?: boolean) => Promise<void>;
   deleteMap: (id: string) => Promise<void>;
+  leaveShare: (id: string) => Promise<void>;
 
   // Map metadata
   setMapName: (name: string) => void;
@@ -732,6 +736,23 @@ export const useMapStore = create<MapStore>()((set, get) => {
 
     deleteMap: async (id) => {
       await api(`/api/maps/${id}`, { method: 'DELETE' });
+      const remaining = get().maps.filter((m) => m.id !== id);
+      set({ maps: remaining });
+      if (get().activeMapId === id) {
+        if (remaining.length > 0) {
+          await get().switchMap(remaining[0].id);
+        } else {
+          set({ map: emptyMap(), activeMapId: null });
+        }
+      }
+    },
+
+    // Recipient-side "leave shared map": drops the map from the caller's own list
+    // by deleting their personal share grant. The map itself is untouched for its
+    // owner and everyone else. Local cleanup mirrors deleteMap (remove from the
+    // list, switch away if it was active).
+    leaveShare: async (id) => {
+      await api(`/api/maps/${id}/shares/mine`, { method: 'DELETE' });
       const remaining = get().maps.filter((m) => m.id !== id);
       set({ maps: remaining });
       if (get().activeMapId === id) {


### PR DESCRIPTION
## Problem
When Character A shares Map 1 with Character B, B sees the map (badged "Shared") but has **no way to remove it** - only A can revoke the share. It also wrongly counted against B's personal map cap on the client.

## Fix

**Server** - new recipient-side endpoint `DELETE /api/maps/:mapId/shares/mine`:
- Deletes **only** the `map_shares` row whose `target_character_id` is the caller's **own** EVE character. It can never touch another character's grant, and never a corp/alliance-scoped grant (those belong to the whole org - still admin-only via the existing `:shareId` revoke route).
- Self-scoped `WHERE` makes it safe with no broader access check; if there's no personal grant it deletes nothing and 404s.
- Registered **before** the `:shareId` route so `mine` isn't parsed as a share UUID.
- `listVisibleMaps` now returns `canLeaveShare` (EXISTS a character-scoped grant to the caller), so the UI only offers "leave" for a personal share - not corp/alliance shares an individual can't remove.

**Client**:
- New "**Leave shared map**" action in the map dropdown (gated on `canLeaveShare`) with a confirm modal mirroring delete; `mapStore.leaveShare` calls the endpoint then removes the map locally / switches away.
- Fixed the personal-cap count to **exclude `sharedWithMe` maps** - matches the server (which only counts owned maps), so a received share no longer disables "+ New Map" / "Copy". (This is the "counts as one of their total maps" part of the report.)

**i18n**: `toolbar.leaveThisMap` + `toolbar.leaveMapConfirm` in all 9 locales.

## Safety
The endpoint is self-scoped to the caller's own character grant - no IDOR, no way to remove others or org grants. `tsc` (web + server) + eslint clean; full en-vs-locale key parity verified.

Branched off `qa` (now synced to 3.17.2).
