### PR TITLE
Import a Wanderer map export (Import/Export section)

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1508,6 +1508,158 @@ mapsRouter.post('/import', async (req, res) => {
   }
 });
 
+// ── Wanderer import ─────────────────────────────────────────────────────────
+// Import a map exported from Wanderer (the other EVE wormhole mapper). Its export
+// gives only EVE system ids + a coarse layout + numeric mass/time/size codes. We
+// enrich each system's name/class/effect/statics/region from our SDE, classify
+// each connection as gate vs wormhole from map_stargates (Wanderer doesn't export
+// that), de-overlap the layout for our larger nodes, and create a personal map.
+// Not recoverable from the export: wormhole types (N062/K162) and signatures.
+const W_MASS: Record<number, string> = { 0: 'stable', 1: 'destabilized', 2: 'critical' };
+const W_TIME: Record<number, string> = { 0: 'fresh', 1: 'eol' };
+const W_SIZE: Record<number, string> = { 0: 'small', 1: 'medium', 2: 'large', 3: 'xl' };
+
+interface WSystem { id?: unknown; position?: { x?: unknown; y?: unknown }; locked?: unknown; tag?: unknown; description?: unknown }
+interface WConn   { source?: unknown; target?: unknown; mass_status?: unknown; time_status?: unknown; ship_size_type?: unknown }
+
+// Push overlapping node boxes apart (our nodes are far bigger than Wanderer's),
+// preserving relative layout. Same idea as the region seeder.
+function deOverlapCoords(coords: Array<{ x: number; y: number }>): void {
+  const MIN_X = 240, MIN_Y = 160;
+  for (let pass = 0; pass < 20; pass++) {
+    let moved = false;
+    for (let i = 0; i < coords.length; i++) for (let j = i + 1; j < coords.length; j++) {
+      const dx = coords[j].x - coords[i].x, dy = coords[j].y - coords[i].y;
+      const ox = MIN_X - Math.abs(dx), oy = MIN_Y - Math.abs(dy);
+      if (ox <= 0 || oy <= 0) continue;
+      if (ox <= oy) { const s = (dx < 0 ? -1 : 1) * (ox / 2); coords[i].x -= s; coords[j].x += s; }
+      else          { const s = (dy < 0 ? -1 : 1) * (oy / 2); coords[i].y -= s; coords[j].y += s; }
+      moved = true;
+    }
+    if (!moved) break;
+  }
+}
+
+mapsRouter.post('/import/wanderer', async (req, res) => {
+  const body = req.body as { name?: unknown; systems?: unknown; connections?: unknown };
+  const systems     = Array.isArray(body.systems) ? (body.systems as WSystem[]) : null;
+  const connections = Array.isArray(body.connections) ? (body.connections as WConn[]) : [];
+  if (!systems)                                   { res.status(400).json({ error: 'systems must be an array' }); return; }
+  if (systems.length > MAX_IMPORT_SYSTEMS)        { res.status(413).json({ error: `Too many systems (max ${MAX_IMPORT_SYSTEMS})` }); return; }
+  if (connections.length > MAX_IMPORT_CONNECTIONS) { res.status(413).json({ error: `Too many connections (max ${MAX_IMPORT_CONNECTIONS})` }); return; }
+
+  // v1 imports to a PERSONAL map — enforce that scope's quota.
+  const oid = await resolveOwnerId(req);
+  const quota = await db.query(`SELECT 1 FROM maps WHERE owner_id = $1 AND corp_id IS NULL AND alliance_id IS NULL`, [oid]);
+  if ((quota.rowCount ?? 0) >= config.maxUserMaps) { res.status(403).json({ error: 'Maximum maps reached' }); return; }
+
+  const eveIds = [...new Set(systems.map((s) => Number(s.id)).filter((n) => Number.isInteger(n) && n > 0))];
+  if (eveIds.length === 0) { res.status(400).json({ error: 'No valid EVE system ids in the file' }); return; }
+
+  // Enrich from the SDE; unknown ids (Abyssal, bad data) are skipped.
+  const { rows: sde } = await db.query<{ id: number; name: string; systemClass: string | null; effect: string | null; statics: string[]; regionName: string | null }>(
+    `SELECT s.id, s.name, s.class AS "systemClass", s.effect, s.statics, r.name AS "regionName"
+       FROM solar_systems s LEFT JOIN map_regions r ON r.id = s.region_id
+      WHERE s.id = ANY($1::int[])`,
+    [eveIds],
+  );
+  const sdeById = new Map(sde.map((r) => [r.id, r]));
+
+  // In-game stargate pairs among the imported systems → 'gate'; the rest 'standard'.
+  const { rows: gates } = await db.query<{ a: number; b: number }>(
+    `SELECT system_id AS a, destination_system_id AS b FROM map_stargates
+      WHERE system_id = ANY($1::int[]) AND destination_system_id = ANY($1::int[])`,
+    [eveIds],
+  );
+  const pairKey = (a: number, b: number) => (a < b ? `${a}|${b}` : `${b}|${a}`);
+  const gatePairs = new Set(gates.map((g) => pairKey(g.a, g.b)));
+
+  // Keep only systems we could enrich; carry their Wanderer layout + fields.
+  const kept = systems
+    .map((s) => ({ s, eve: Number(s.id) }))
+    .filter(({ eve }) => Number.isInteger(eve) && sdeById.has(eve));
+  if (kept.length === 0) { res.status(400).json({ error: 'None of the systems were recognised (not in the EVE SDE)' }); return; }
+  const coords = kept.map(({ s }) => ({ x: Number(s.position?.x) || 0, y: Number(s.position?.y) || 0 }));
+  deOverlapCoords(coords);
+
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const name = String(typeof body.name === 'string' && body.name.trim() ? body.name : 'Imported from Wanderer').slice(0, MAX_MAP_NAME_LEN);
+    const mapRes = await client.query<{ id: string }>(
+      `INSERT INTO maps (user_id, owner_id, name) VALUES ($1, $2, $3) RETURNING id`,
+      [req.session.userId, oid, name],
+    );
+    const mapId = mapRes.rows[0].id;
+
+    // Systems.
+    const idByEve = new Map<number, string>();
+    const SYSCOLS = 16;
+    const sysPh: string[] = []; const sysVals: unknown[] = [];
+    kept.forEach(({ s, eve }, i) => {
+      const info = sdeById.get(eve)!;
+      const newId = crypto.randomUUID();
+      idByEve.set(eve, newId);
+      const base = sysVals.length;
+      sysPh.push(`(${Array.from({ length: SYSCOLS }, (_, k) => `$${base + k + 1}`).join(',')})`);
+      sysVals.push(
+        newId, mapId, eve, info.name, info.systemClass ?? 'unknown',
+        info.effect ?? 'none', info.statics ?? [], info.regionName ?? null, null,
+        coords[i].x, coords[i].y, 'unknown', false, s.locked === true,
+        typeof s.description === 'string' ? s.description.slice(0, 2000) : '',
+        typeof s.tag === 'string' ? s.tag.slice(0, 50) : null,
+      );
+    });
+    if (sysPh.length > 0) {
+      await client.query(
+        `INSERT INTO map_systems
+           (id, map_id, eve_system_id, name, system_class, effect, statics, region_name, npc_type,
+            position_x, position_y, status, is_home, locked, notes, tag)
+         VALUES ${sysPh.join(',')}`,
+        sysVals,
+      );
+    }
+
+    // Connections — only where both endpoints survived; dedup undirected pair.
+    const seen = new Set<string>();
+    const CONNCOLS = 8;
+    const connPh: string[] = []; const connVals: unknown[] = [];
+    for (const c of connections) {
+      const a = Number(c.source), b = Number(c.target);
+      const src = idByEve.get(a), tgt = idByEve.get(b);
+      if (!src || !tgt || src === tgt) continue;
+      const key = src < tgt ? `${src}|${tgt}` : `${tgt}|${src}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const type = gatePairs.has(pairKey(a, b)) ? 'gate' : 'standard';
+      const base = connVals.length;
+      connPh.push(`(${Array.from({ length: CONNCOLS }, (_, k) => `$${base + k + 1}`).join(',')})`);
+      connVals.push(
+        crypto.randomUUID(), mapId, src, tgt, type,
+        W_MASS[Number(c.mass_status)] ?? 'stable',
+        W_TIME[Number(c.time_status)] ?? 'fresh',
+        W_SIZE[Number(c.ship_size_type)] ?? 'large',
+      );
+    }
+    if (connPh.length > 0) {
+      await client.query(
+        `INSERT INTO map_connections
+           (id, map_id, source_id, target_id, connection_type, mass_status, time_status, size)
+         VALUES ${connPh.join(',')}`,
+        connVals,
+      );
+    }
+
+    await client.query('COMMIT');
+    res.status(201).json({ id: mapId, imported: { systems: sysPh.length, connections: connPh.length, skipped: systems.length - kept.length } });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+});
+
 // Merge a source system note into a destination note. Destination is truth:
 // fill it if empty, otherwise append the source note under a divider so
 // nothing is lost. Returns the new note string, or null when no change is

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -929,6 +929,12 @@ export function MapSidebar() {
       });
       await useMapStore.getState().loadMaps();
       await useMapStore.getState().switchMap(id);
+      // Tidy connection handles to the imported layout + fit it in view, deferred
+      // so the canvas has mounted the new nodes first (matches the region seed).
+      setTimeout(() => {
+        useMapStore.getState().optimizeConnections();
+        useMapStore.getState().requestFitView();
+      }, 500);
     } catch (err) {
       toast.error(
         t("mapSidebar.importFailed", { error: err instanceof Error ? err.message : String(err) }),
@@ -963,6 +969,14 @@ export function MapSidebar() {
       );
       await useMapStore.getState().loadMaps();
       await useMapStore.getState().switchMap(id);
+      // Re-route connection handles to the imported layout + fit it in view,
+      // deferred so the canvas has mounted the new nodes first (matches the
+      // region seed). Wanderer connections arrive without handles, so this
+      // tidies every edge onto the nearest sides.
+      setTimeout(() => {
+        useMapStore.getState().optimizeConnections();
+        useMapStore.getState().requestFitView();
+      }, 500);
       toast.success(
         t("mapSidebar.wandererImported", {
           systems: imported.systems, connections: imported.connections, skipped: imported.skipped,

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -887,7 +887,11 @@ export function MapSidebar() {
   const connectionCount = useMapStore((s) => s.map.connections.length);
   const systemCount = useMapStore((s) => s.map.systems.length);
 
-  const atMapLimit = maps.length >= maxMaps;
+  // Import creates a PERSONAL map, so the cap is the personal-map limit — count
+  // only maps the user owns (not corp/alliance maps or ones merely shared with
+  // them). Matches the server's quota (owner_id, corp/alliance NULL). Counting
+  // every visible map wrongly disabled Import for corp/alliance members/admins.
+  const atMapLimit = maps.filter((m) => !m.isCorpMap && !m.isAllianceMap && !m.sharedWithMe).length >= maxMaps;
 
 
   function handleExport() {

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -776,6 +776,7 @@ function MergeSection() {
 export function MapSidebar() {
   const { t } = useTranslation();
   const importInputRef = useRef<HTMLInputElement>(null);
+  const wandererInputRef = useRef<HTMLInputElement>(null);
   const [threshold, setThreshold] = useProximityThreshold();
   const [staleHours, setStaleHours] = useStaleThreshold();
   // Single source of truth for which section is expanded. Defaults to
@@ -924,6 +925,45 @@ export function MapSidebar() {
       });
       await useMapStore.getState().loadMaps();
       await useMapStore.getState().switchMap(id);
+    } catch (err) {
+      toast.error(
+        t("mapSidebar.importFailed", { error: err instanceof Error ? err.message : String(err) }),
+      );
+    }
+  }
+
+  // Import a map exported from Wanderer. Its shape differs from a Nexum export
+  // (systems carry only an EVE id + layout; connections use source/target + numeric
+  // codes), so it goes to a dedicated endpoint that enriches from the SDE and
+  // classifies gate vs wormhole. Creates a new personal map.
+  async function handleImportWanderer(file: File) {
+    let parsed: { systems?: unknown; connections?: unknown };
+    try {
+      parsed = JSON.parse(await file.text()) as { systems?: unknown; connections?: unknown };
+    } catch {
+      toast.error(t("mapSidebar.invalidJson"));
+      return;
+    }
+    if (!Array.isArray(parsed.systems)) {
+      toast.error(t("mapSidebar.notWandererMap"));
+      return;
+    }
+    const name = file.name.replace(/\.json$/i, "") || "Imported from Wanderer";
+    try {
+      const { id, imported } = await api<{ id: string; imported: { systems: number; connections: number; skipped: number } }>(
+        "/api/maps/import/wanderer",
+        {
+          method: "POST",
+          body: JSON.stringify({ name, systems: parsed.systems, connections: parsed.connections ?? [] }),
+        },
+      );
+      await useMapStore.getState().loadMaps();
+      await useMapStore.getState().switchMap(id);
+      toast.success(
+        t("mapSidebar.wandererImported", {
+          systems: imported.systems, connections: imported.connections, skipped: imported.skipped,
+        }),
+      );
     } catch (err) {
       toast.error(
         t("mapSidebar.importFailed", { error: err instanceof Error ? err.message : String(err) }),
@@ -1390,6 +1430,18 @@ export function MapSidebar() {
                   {t("mapSidebar.importJson")}
                 </button>
               </div>
+              <div
+                className={`map-sidebar__import-wrap${atMapLimit ? " map-sidebar__import-wrap--disabled" : ""}`}
+              >
+                <button
+                  className="map-sidebar__action"
+                  onClick={() => wandererInputRef.current?.click()}
+                  disabled={atMapLimit}
+                  title={t("mapSidebar.importWandererTitle")}
+                >
+                  {t("mapSidebar.importWanderer")}
+                </button>
+              </div>
               <button
                 type="button"
                 className="map-sidebar__action"
@@ -1434,6 +1486,18 @@ export function MapSidebar() {
         onChange={(e) => {
           const file = e.target.files?.[0];
           if (file) handleImport(file);
+          e.target.value = "";
+        }}
+      />
+
+      <input
+        ref={wandererInputRef}
+        type="file"
+        accept=".json,application/json"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleImportWanderer(file);
           e.target.value = "";
         }}
       />

--- a/web/src/components/ui/MapSidebar.tsx
+++ b/web/src/components/ui/MapSidebar.tsx
@@ -1415,10 +1415,6 @@ export function MapSidebar() {
         {!hideTopologyTools && (
           <CollapsibleSection title={t("mapSidebar.sections.importExport")} {...sectionProps("export")}>
             <div className="map-sidebar__section">
-              <button className="map-sidebar__action" onClick={handleExport}>
-                {t("mapSidebar.exportJson")}
-              </button>
-
               <div
                 className={`map-sidebar__import-wrap${atMapLimit ? " map-sidebar__import-wrap--disabled" : ""}`}
               >
@@ -1442,6 +1438,10 @@ export function MapSidebar() {
                   {t("mapSidebar.importWanderer")}
                 </button>
               </div>
+
+              <button className="map-sidebar__action" onClick={handleExport}>
+                {t("mapSidebar.exportJson")}
+              </button>
               <button
                 type="button"
                 className="map-sidebar__action"

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "Ungültige JSON-Datei.",
     "notNexumMap": "Die Datei sieht nicht wie ein Eve-Nexum-Kartenexport aus.",
     "importFailed": "Import fehlgeschlagen: {{error}}",
+    "importWanderer": "↑ Aus Wanderer importieren",
+    "importWandererTitle": "Eine aus dem Wanderer-Mapper exportierte Karte importieren (erstellt eine neue persönliche Karte)",
+    "notWandererMap": "Die Datei sieht nicht wie ein Wanderer-Export aus.",
+    "wandererImported": "Aus Wanderer importiert: {{systems}} Systeme, {{connections}} Verbindungen ({{skipped}} übersprungen).",
     "colorVision": "Farbsehen",
     "colorVisionOptions": {
       "off": "Standardfarben",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -687,7 +687,11 @@
     "exportFailed": "Export failed: {{error}}",
     "invalidJson": "Invalid JSON file.",
     "notNexumMap": "File does not look like a Eve-Nexum map export.",
-    "importFailed": "Import failed: {{error}}"
+    "importFailed": "Import failed: {{error}}",
+    "importWanderer": "↑ Import from Wanderer",
+    "importWandererTitle": "Import a map exported from the Wanderer mapper (creates a new personal map)",
+    "notWandererMap": "File does not look like a Wanderer export.",
+    "wandererImported": "Imported from Wanderer: {{systems}} systems, {{connections}} connections ({{skipped}} skipped)."
   },
   "customIntel": {
     "title": "Custom Intel",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "Archivo JSON no válido.",
     "notNexumMap": "El archivo no parece una exportación de mapa de Eve-Nexum.",
     "importFailed": "Error al importar: {{error}}",
+    "importWanderer": "↑ Importar desde Wanderer",
+    "importWandererTitle": "Importar un mapa exportado del mapeador Wanderer (crea un nuevo mapa personal)",
+    "notWandererMap": "El archivo no parece una exportación de Wanderer.",
+    "wandererImported": "Importado desde Wanderer: {{systems}} sistemas, {{connections}} conexiones ({{skipped}} omitidos).",
     "colorVision": "Visión del color",
     "colorVisionOptions": {
       "off": "Colores predeterminados",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "Fichier JSON invalide.",
     "notNexumMap": "Le fichier ne ressemble pas à un export de carte Eve-Nexum.",
     "importFailed": "Échec de l'import : {{error}}",
+    "importWanderer": "↑ Importer depuis Wanderer",
+    "importWandererTitle": "Importer une carte exportée depuis le mappeur Wanderer (crée une nouvelle carte personnelle)",
+    "notWandererMap": "Le fichier ne ressemble pas à un export Wanderer.",
+    "wandererImported": "Importé depuis Wanderer : {{systems}} systèmes, {{connections}} connexions ({{skipped}} ignorés).",
     "colorVision": "Vision des couleurs",
     "colorVisionOptions": {
       "off": "Couleurs par défaut",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "無効な JSON ファイルです。",
     "notNexumMap": "このファイルは Eve-Nexum のマップエクスポートではないようです。",
     "importFailed": "インポートに失敗しました: {{error}}",
+    "importWanderer": "↑ Wanderer からインポート",
+    "importWandererTitle": "Wanderer マッパーからエクスポートしたマップをインポート（新しい個人マップを作成）",
+    "notWandererMap": "ファイルが Wanderer のエクスポートではないようです。",
+    "wandererImported": "Wanderer からインポート：{{systems}} システム、{{connections}} 接続（{{skipped}} 件スキップ）。",
     "colorVision": "色覚",
     "colorVisionOptions": {
       "off": "デフォルトの色",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "잘못된 JSON 파일입니다.",
     "notNexumMap": "이 파일은 Eve-Nexum 지도 내보내기 파일이 아닌 것 같습니다.",
     "importFailed": "가져오기 실패: {{error}}",
+    "importWanderer": "↑ Wanderer에서 가져오기",
+    "importWandererTitle": "Wanderer 매퍼에서 내보낸 지도 가져오기 (새 개인 지도 생성)",
+    "notWandererMap": "파일이 Wanderer 내보내기 형식이 아닌 것 같습니다.",
+    "wandererImported": "Wanderer에서 가져옴: 성계 {{systems}}개, 연결 {{connections}}개 ({{skipped}}개 건너뜀).",
     "colorVision": "색각",
     "colorVisionOptions": {
       "off": "기본 색상",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "Ficheiro JSON inválido.",
     "notNexumMap": "O ficheiro não parece uma exportação de mapa do Eve-Nexum.",
     "importFailed": "Falha na importação: {{error}}",
+    "importWanderer": "↑ Importar do Wanderer",
+    "importWandererTitle": "Importar um mapa exportado do mapeador Wanderer (cria um novo mapa pessoal)",
+    "notWandererMap": "O ficheiro não parece uma exportação do Wanderer.",
+    "wandererImported": "Importado do Wanderer: {{systems}} sistemas, {{connections}} ligações ({{skipped}} ignorados).",
     "colorVision": "Visão de cores",
     "colorVisionOptions": {
       "off": "Cores padrão",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -620,6 +620,10 @@
     "invalidJson": "Некорректный файл JSON.",
     "notNexumMap": "Файл не похож на экспорт карты Eve-Nexum.",
     "importFailed": "Не удалось импортировать: {{error}}",
+    "importWanderer": "↑ Импорт из Wanderer",
+    "importWandererTitle": "Импортировать карту, экспортированную из маппера Wanderer (создаёт новую личную карту)",
+    "notWandererMap": "Файл не похож на экспорт из Wanderer.",
+    "wandererImported": "Импортировано из Wanderer: {{systems}} систем, {{connections}} соединений ({{skipped}} пропущено).",
     "colorVision": "Цветовое зрение",
     "colorVisionOptions": {
       "off": "Цвета по умолчанию",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -602,6 +602,10 @@
     "invalidJson": "无效的 JSON 文件。",
     "notNexumMap": "该文件看起来不像 Eve-Nexum 地图导出文件。",
     "importFailed": "导入失败：{{error}}",
+    "importWanderer": "↑ 从 Wanderer 导入",
+    "importWandererTitle": "导入从 Wanderer 地图工具导出的地图（创建新的个人地图）",
+    "notWandererMap": "该文件看起来不是 Wanderer 的导出文件。",
+    "wandererImported": "已从 Wanderer 导入：{{systems}} 个星系，{{connections}} 条连接（跳过 {{skipped}} 个）。",
     "colorVision": "色觉",
     "colorVisionOptions": {
       "off": "默认颜色",


### PR DESCRIPTION
Adds an **Import from Wanderer** button to the sidebar's Import/Export section — absorbs a Wanderer (the other EVE wormhole mapper) JSON export into a new personal Nexum map. Part of pulling users over from Wanderer.

### Server — `POST /api/maps/import/wanderer`
Wanderer's export gives only EVE system ids + a coarse layout + numeric mass/time/size codes, so the endpoint fills the rest from what nexum already knows:
- **SDE enrichment** — each system's name / class / effect / statics / region resolved from `solar_systems` by EVE id (systems not in the SDE are skipped).
- **Gate vs wormhole** — Wanderer doesn't export connection type, and its k-space maps are mostly gates, so each connection is classified `gate` vs `standard` from `map_stargates`.
- **Code maps** — mass `0/1/2` -> stable/destabilized/critical, time `0/1` -> fresh/eol, size `0-3` -> small..xl.
- **Layout** — de-overlaps Wanderer's tight coordinates (our nodes are far larger) with the region-seeder's algorithm; dedupes undirected pairs and drops self-loops.

Security: auth + personal-map quota; sizes capped by the existing `MAX_IMPORT` limits; ids validated as SDE-known integers; strings length-capped; parameterized SQL; single transaction.

### Client
`handleImportWanderer` in `MapSidebar` posts the file's systems/connections, switches to the new map, and toasts imported/skipped counts. New i18n in all 9 locales. Import/Export section reordered so **imports are on top, exports below**.

### Known limits (v1)
- **Not in Wanderer's export, so not imported:** wormhole types (N062/K162) and signatures — the user re-scans.
- Wanderer's per-system occupancy status is intel-ish and doesn't map cleanly onto nexum's scan-status, so systems come in as `unknown` (notes/tag preserved).
- Imports to a **personal** map (use the existing map-copy to move it to corp/alliance).

Verified against a real 134-system / 109-connection export (109 -> 107 after dedup; all codes map to valid enums). server + web `tsc`, eslint, build clean; full i18n parity.
