### PR TITLE
Announcer: fix QA load (nginx .mjs MIME) + run TTS in a Web Worker

### DIFF
--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -105,6 +105,17 @@ server {
     # tied to the bundled transformers.js version, so cache it only modestly to
     # bound staleness if a deploy bumps that dependency.
     location ^~ /ort/ {
+        # nginx's default mime.types has NO .mjs mapping, so the ORT loader module
+        # (ort-wasm-*.jsep.mjs) is served as application/octet-stream and the
+        # browser refuses to run it as an ES module ("Failed to fetch dynamically
+        # imported module"). Declare the JS + wasm types here. NOTE: a types block
+        # replaces the inherited map for this location — fine, /ort only holds
+        # these two file types.
+        types {
+            text/javascript  mjs;
+            application/wasm wasm;
+        }
+        default_type application/octet-stream;
         expires 7d;
         access_log off;
     }


### PR DESCRIPTION
Two announcer fixes for the QA soak.

### 1. Serve `/ort/*.mjs` as JavaScript (nginx MIME) — fixes the load failure
QA showed **"Voice model failed to load … Failed to fetch dynamically imported
module: /ort/ort-wasm-simd-threaded.jsep.mjs"**. The ORT loader is a dynamically
`import()`-ed ES module, but nginx's default `mime.types` has no `.mjs` entry, so
it was served as `application/octet-stream` and browsers refuse to execute it.
Fixed with a per-location `types` block on `/ort/` (`text/javascript` for `.mjs`).
Confirmed against QA via `curl -I`. Slipped through because Vite names its own
chunks `.js` and `vite preview` knows `.mjs`.

### 2. Run Kokoro in a Web Worker — fixes the 5–10s Preview freeze
Generation is multi-second WASM/CPU work; on the main thread it froze the tab per
phrase. Moved model init + generation into `ttsWorker.ts`; the main thread keeps
only the store, messaging, and audio playback. Heavy deps now land in the worker
chunk, not the main bundle.

### Verified in-browser (production CSP, self-hosted q8)
- `.mjs` now serves as `text/javascript`; model + voices load same-origin.
- A 100 ms main-thread tick counter kept advancing **continuously** through
  generation + playback (52 → 279) instead of freezing; audio still plays.
- `connect-src 'self'` holds — zero third-party requests.

### Deploy
Rebuild the web image (nginx template is baked at build; worker ships in the
bundle). `fetch-model` re-pulls ~93 MB during build. Bring up with both compose files.