### PR TITLE
Announcer: warm-up + multi-threaded TTS (COOP/COEP) — speeds up generation

### DIFF
--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -53,6 +53,19 @@ server {
     # proxy, the header is a no-op.
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
+    # Cross-origin isolation — enables SharedArrayBuffer so the voice announcer's
+    # WASM inference can run MULTI-THREADED (single-threaded generation took ~13s
+    # per phrase). COEP is 'credentialless' (NOT require-corp) specifically so
+    # cross-origin no-cors resources — EVE character/corp portraits from
+    # images.evetech.net, which send no CORP header — still load, just without
+    # credentials (they're public). Login is a full-page redirect, so COOP
+    # same-origin doesn't affect SSO. WATCH ON QA before promoting: portraits,
+    # GTM/GA (cross-origin scripts + the noscript iframe), and the SSO round-trip.
+    # If any break and can't be resolved, drop these two headers — the worker
+    # falls back to single-threaded automatically (checks crossOriginIsolated).
+    add_header Cross-Origin-Opener-Policy   "same-origin"    always;
+    add_header Cross-Origin-Embedder-Policy "credentialless" always;
+
     # Live map-edit SSE stream. Must disable proxy buffering or nginx holds the
     # event frames until the response ends (which never happens on a long-lived
     # stream). Matched before the generic /api block below.

--- a/web/src/audio/ttsWorker.ts
+++ b/web/src/audio/ttsWorker.ts
@@ -33,6 +33,7 @@ async function primeVoice(id: string): Promise<void> {
 
 let tts: KokoroTTS | null = null;
 let loadPromise: Promise<void> | null = null;
+let threads = 1;   // WASM inference threads actually used (diagnostic)
 
 type VoiceId = NonNullable<Parameters<KokoroTTS['generate']>[1]>['voice'];
 type DtypeOpt = NonNullable<Parameters<typeof KokoroTTS.from_pretrained>[1]>['dtype'];
@@ -44,7 +45,13 @@ function load(): Promise<void> {
   if (loadPromise) return loadPromise;
   loadPromise = (async () => {
     const wasm = env.backends.onnx.wasm as { numThreads?: number; wasmPaths?: string };
-    wasm.numThreads = 1;
+    // Multi-thread the WASM backend when the page is cross-origin isolated (COOP +
+    // COEP set by nginx) so SharedArrayBuffer is available — threads cut generation
+    // time roughly with core count. Falls back to a single thread otherwise, so the
+    // code is correct whether or not the isolation headers are deployed.
+    const coi = (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated === true;
+    threads = coi ? Math.min(navigator.hardwareConcurrency || 4, 8) : 1;
+    wasm.numThreads = threads;
     if (SELF_HOSTED) {
       wasm.wasmPaths = LOCAL_WASM_PATH;
       env.allowLocalModels = true;
@@ -75,7 +82,7 @@ function load(): Promise<void> {
 self.onmessage = async (e: MessageEvent) => {
   const msg = e.data as { type: string; id?: number; text?: string; voice?: string };
   if (msg.type === 'load') {
-    try { await load(); post({ type: 'ready', backend: `wasm/${DTYPE}${SELF_HOSTED ? '/self-hosted' : ''}` }); }
+    try { await load(); post({ type: 'ready', backend: `wasm/${DTYPE}${SELF_HOSTED ? '/self-hosted' : ''}/${threads}t` }); }
     catch (err) { post({ type: 'loadError', error: err instanceof Error ? err.message : String(err) }); }
     return;
   }

--- a/web/src/audio/ttsWorker.ts
+++ b/web/src/audio/ttsWorker.ts
@@ -60,6 +60,14 @@ function load(): Promise<void> {
         if (typeof pr === 'number') post({ type: 'progress', progress: Math.round(pr) });
       },
     });
+    // Warm up: ONNX Runtime's FIRST inference compiles/optimises kernels and is
+    // much slower than steady state. Run one throwaway generation now — behind the
+    // loading UI — so the user's first real announcement pays only steady-state
+    // cost, not the cold-start penalty. Non-fatal if it fails.
+    try {
+      await primeVoice('af_nicole');
+      await tts.generate('warming up', { voice: 'af_nicole' as VoiceId });
+    } catch { /* warm-up is best-effort */ }
   })().catch((e: unknown) => { loadPromise = null; throw e; });
   return loadPromise;
 }


### PR DESCRIPTION
Makes the voice announcer fast. Follows the Web Worker fix (already in qa), which
removed the UI freeze but left generation at ~13s/phrase (single-threaded CPU).

### Two changes
1. **Warm-up** — run one throwaway generation at the end of `load()`, behind the
   loading UI, so the first real announcement doesn't eat ONNX's cold-start (kernel
   compilation) penalty.
2. **Multi-threading** — enable `SharedArrayBuffer` via cross-origin isolation so
   ORT runs multi-threaded:
   - nginx: `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: credentialless`.
   - worker: `numThreads = min(cores, 8)` when `crossOriginIsolated`, else `1`
     (graceful fallback — drop the headers and it reverts to single-thread, no code change).

`credentialless` (not `require-corp`) is deliberate: cross-origin no-cors resources
like EVE portraits (images.evetech.net, no CORP header) still load. Login is a
full-page redirect, so COOP doesn't affect SSO.

### Verified in-browser (real COOP/COEP headers)
`crossOriginIsolated=true` → loaded with **8 threads** → generation **~4.6s vs ~13s**
(~2.8x) → audio plays, no crash.

### ⚠️ QA soak checklist — COOP/COEP is site-wide, watch before promoting
- [ ] **EVE portraits** (character/corp/alliance images) still load
- [ ] **GTM / GA analytics** still fire (cross-origin scripts + the noscript iframe are the main risk)
- [ ] **EVE SSO login + add-character** round-trip works
- [ ] Announcer Preview is noticeably faster; backend string shows `/Nt`

If anything in the first three breaks and can't be resolved, **drop the two
headers** — the announcer falls back to single-threaded automatically.

### Deploy
Rebuild the web image (nginx template baked at build). Both compose files.