### PR TITLE
Map node: enlarge the un-dived wormhole pull pill

### DIFF
--- a/web/src/styles/system-node.css
+++ b/web/src/styles/system-node.css
@@ -559,9 +559,9 @@
 }
 
 .system-node__hole {
-  width: calc(14px * var(--font-scale, 1));
-  height: calc(6px * var(--font-scale, 1));
-  border-radius: 3px;
+  width: calc(18px * var(--font-scale, 1));
+  height: calc(8px * var(--font-scale, 1));
+  border-radius: 4px;
   background: var(--text-faint); /* neutral: unknown destination */
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
   cursor: pointer;


### PR DESCRIPTION
Small visual tweak requested: make the un-dived wormhole pull handle (the little pill at the bottom-left of a system node) slightly larger. Bumped 14x6 -> 18x8px, border-radius 3 -> 4, keeping the `--font-scale` multiplier. CSS only.