### PR TITLE
Fix: corrupt systemClass black-screens the whole map (MiniMap nodeColor)

### DIFF
--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -1475,7 +1475,10 @@ export function MapCanvas() {
             position={minimapPosition}
             nodeColor={(n) => {
               const sys = systems.find((s) => s.id === n.id);
-              return sys ? cssVarToHex(CLASS_COLORS[sys.systemClass]) : '#333';
+              // CLASS_COLORS can miss (corrupt/unknown systemClass) → undefined;
+              // fall back rather than feed undefined into the colour resolver.
+              const color = sys ? CLASS_COLORS[sys.systemClass] : undefined;
+              return color ? cssVarToHex(color) : '#333';
             }}
             maskColor="rgba(13,17,23,0.85)"
             onClick={(_e, position) => {

--- a/web/src/utils/cssVar.ts
+++ b/web/src/utils/cssVar.ts
@@ -2,7 +2,12 @@
 // is consumed somewhere CSS custom properties don't apply — notably the
 // react-flow MiniMap, which paints to a <canvas> and so can't read `var()`.
 // Plain colour strings (hex/rgb) pass straight through.
-export function cssVarToHex(value: string): string {
+export function cssVarToHex(value: string | null | undefined): string {
+  // A missing/corrupt colour must never throw — the MiniMap's nodeColor paints
+  // during React render, so one bad value (e.g. a system with an unknown
+  // systemClass, so CLASS_COLORS[...] is undefined) would crash the whole map to
+  // a black screen. Fall back to a neutral grey instead.
+  if (typeof value !== 'string' || value === '') return '#666';
   const m = /^var\((--[\w-]+)\)$/.exec(value.trim());
   if (!m) return value;
   const resolved = getComputedStyle(document.documentElement).getPropertyValue(m[1]).trim();


### PR DESCRIPTION
## Root cause
A system on the map has a `systemClass` that isn't one of the 13 known classes (C1-C6, C13, HS/LS/NS, Thera, Pochven, Drifter) — most likely `null`/empty. So `CLASS_COLORS[systemClass]` is `undefined`, and the MiniMap's `nodeColor` fed that straight into `cssVarToHex`, which called `value.trim()` on `undefined` and **threw during React render** — which unmounts the whole tree to a **black screen**.

Matches the reported stack: `nodeColor` → `ef` (`.trim()`) → `Cannot read properties of undefined (reading 'trim')`.

## Fix
- `cssVarToHex` now returns a neutral grey for non-string/empty input instead of throwing (defends every caller, kills this whole class of crash).
- `nodeColor` falls back to the default node colour when the class lookup misses, instead of passing `undefined`.

The offending node now renders with a default colour; the map loads normally.

## Note
This stops the crash, but the underlying data is still off — one system has a bad/missing `systemClass`. Once deployed, that system will show with no class colour/badge so it's easy to spot and re-set. Worth checking how it got there (custom system? import?).