### PR TITLE
Fix: scout pane sort did nothing (routes went through the hub being sorted)

### DIFF
--- a/web/src/components/ui/ScoutConnectionsPane.tsx
+++ b/web/src/components/ui/ScoutConnectionsPane.tsx
@@ -92,13 +92,21 @@ export function ScoutConnectionsPane({ scoutSystem }: Props) {
   const canRoute = origin.systemId !== null;
 
   const targetIds = useMemo(() => filtered.map(c => c.inSystemId), [filtered]);
-  const routes = useRoute(origin.systemId, targetIds);
+  // Route to each exit WITHOUT this pane's own scout hub spliced in: a route to
+  // a Turnur exit that travels through Turnur is circular — it's the hole you'd
+  // be taking, so every exit scores (jumps to Turnur + 1) and the whole list
+  // ties. What's wanted here is how far each exit sits from you by ordinary
+  // travel. The other hub and mapped chains stay in — those are real shortcuts.
+  const routes = useRoute(origin.systemId, targetIds, 'active', {
+    excludeScout: scoutSystem === 'Thera' ? 'thera' : 'turnur',
+  });
 
   // Two sort modes:
   //  - 'age'     : remaining time descending — freshest holes at the top, the
   //                soon-to-collapse ones drop to the bottom.
   //  - 'closest' : fewest jumps via the active route preference (shortest /
-  //                secure) ascending. Connections without a usable route (no
+  //                secure) ascending, excluding this pane's own hub (see the
+  //                useRoute call above). Connections without a usable route (no
   //                k-space location, or wormhole-class target) fall to the
   //                bottom. Age then name break ties in both modes.
   const sorted = useMemo(() => {

--- a/web/src/hooks/useRoute.ts
+++ b/web/src/hooks/useRoute.ts
@@ -43,11 +43,19 @@ export interface RouteEntry {
  *   - 'all': every map the user can see, unioned server-side — for the Closest
  *     Systems pane, a per-user tool where the chain you're actually in should
  *     route regardless of which tab is active.
+ *
+ * `excludeScout` drops one scout hub's shortcut edges even when the user has
+ * that toggle on. The Thera / Turnur panes rank their own exits by distance, so
+ * routing *through* the hub they belong to is circular: every exit comes out at
+ * (jumps to the hub + 1), identical for the whole list, which flattens the
+ * "closest" sort into a no-op. Excluding just that hub keeps the other one (and
+ * mapped chains) available as genuine shortcuts.
  */
 export function useRoute(
   from: number | null,
   targets: number[],
   whScope: 'active' | 'all' = 'active',
+  opts: { excludeScout?: 'thera' | 'turnur' } = {},
 ): Record<string, RouteEntry> {
   const [data, setData] = useState<Record<string, RouteEntry>>({});
   const routeMode   = useMapStore((s) => s.routeMode);
@@ -59,6 +67,8 @@ export function useRoute(
 
   const allScope = whScope === 'all';
   const targetsKey = [...targets].sort((a, b) => a - b).join(',');
+  const wantThera  = inclThera  && opts.excludeScout !== 'thera';
+  const wantTurnur = inclTurnur && opts.excludeScout !== 'turnur';
   // In 'all' scope the server resolves the map set itself, so no active map is
   // required — the chains still apply when routing from another region's tab.
   const wantWh   = inclWormholes && (allScope || !!activeMapId);
@@ -71,8 +81,8 @@ export function useRoute(
     }
     let cancelled = false;
     let url = `/api/route?from=${from}&to=${targetsKey}&mode=${routeMode}`;
-    if (inclThera)  url += '&includeThera=true';
-    if (inclTurnur) url += '&includeTurnur=true';
+    if (wantThera)  url += '&includeThera=true';
+    if (wantTurnur) url += '&includeTurnur=true';
     if (wantWh)     url += '&includeWormholes=true';
     if (wantAnsi)   url += '&includeAnsiblex=true';
     if (wantWh || wantAnsi) url += allScope ? '&whScope=all' : `&mapId=${activeMapId}`;
@@ -80,7 +90,7 @@ export function useRoute(
       .then(r => { if (!cancelled) setData(r); })
       .catch(() => { if (!cancelled) setData({}); });
     return () => { cancelled = true; };
-  }, [from, targetsKey, routeMode, inclThera, inclTurnur, wantWh, wantAnsi, allScope, activeMapId]);
+  }, [from, targetsKey, routeMode, wantThera, wantTurnur, wantWh, wantAnsi, allScope, activeMapId]);
 
   return data;
 }


### PR DESCRIPTION
## Problem

On the Turnur (and Thera) Connections panes, the **Sort** dropdown did nothing — "Wormhole Lifetime" and "Shortest route" produced the same list.

With the Thera/Turnur routing toggles on, the pane routed to each exit **with those shortcut edges spliced in**, so the route to a Turnur exit travelled through Turnur — the very hole you'd be taking. Every exit scored `jumps to the hub + 1`, i.e. a flat tie, and the closest sort fell back to its age tiebreak.

Measured live from `30001200` against the current Turnur exits:

```
with Thera+Turnur : 30 30 30 30 30 30 30 30 30 30 30   <- flat, sort is a no-op
Turnur excluded   : 28 30 30 34 37 37 (+ J-space unroutable)
```

## Fix

- `useRoute` gains `opts.excludeScout: 'thera' | 'turnur'`, dropping that hub's shortcut edges from the request even when the user's toggle is on.
- Each scout pane passes its own hub, so the Turnur pane never routes via Turnur and the Thera pane never via Thera.
- The *other* hub, mapped wormhole chains and Ansiblex stay in — genuine, non-circular shortcuts (JA-G0T: 28 via Thera vs 42 by gates).

## Side effect (intended)

The per-row "N jumps" and the expanded route squares now show real travel distance to the exit instead of the circular via-the-hole number.

## Testing

- `tsc -b` and eslint clean (one pre-existing `set-state-in-effect` warning in `useRoute`).
- Verified at the API level against production data (numbers above); no local stack was available for a click-through.