### PR TITLE
Fix: the "checked X ago" clock reported the online poll, not the location poll

### DIFF
--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -5,7 +5,7 @@ import { timeAgo, jumps } from '../../i18n/format';
 import { useMapStore } from '../../store/mapStore';
 import { useAuth, formatRole, isAdminRole } from '../../context/AuthContext';
 import { useOnlineStatus } from '../../hooks/useOnlineStatus';
-import { useCharacterLocation } from '../../hooks/useCharacterLocation';
+import { useCharacterLocation, useCharacterLocationCheckedAt } from '../../hooks/useCharacterLocation';
 import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { useCanEdit } from '../../hooks/useCanEdit';
 import { useCanEditContent } from '../../hooks/useCanEditContent';
@@ -152,6 +152,11 @@ function onlineTooltip(t: TFunction, online: boolean | null, lastLoginIso: strin
 // Compact "last checked" indicator: a clock icon whose tooltip carries the
 // "checked Xs ago" text. Owns its own 5 s tick so the rest of the Toolbar
 // doesn't re-render every five seconds along with it.
+//
+// It sits next to the system name, so it reports the LOCATION poll (10 s). It
+// used to read the online-status poll's timestamp instead — a separate 30 s
+// check — so a location refreshed seconds ago routinely read "checked 25s ago"
+// and looked stale when it wasn't.
 function CheckedAtIcon({ checkedAt }: { checkedAt: Date }) {
   const { t } = useTranslation();
   const [, setTick] = useState(0);
@@ -270,7 +275,8 @@ export function Toolbar() {
   const noCreateOption = atMapLimit
     && (!canCorpCreate || atCorpMapLimit)
     && (!canAllianceCreate || atAllianceMapLimit);
-  const { online, checkedAt, lastLogin } = useOnlineStatus(!!user);
+  const { online, lastLogin } = useOnlineStatus(!!user);
+  const locCheckedAt = useCharacterLocationCheckedAt();
   // The character THIS TAB acts as: the per-tab pinned character (a routeOrigin
   // override) when set, else the session-active character. The avatar, name and
   // you-are-here follow it; the role badge stays on the session identity below.
@@ -704,7 +710,7 @@ export function Toolbar() {
                 {shownSystemDisplay}
               </span>
             ))}
-            {checkedAt && <CheckedAtIcon checkedAt={checkedAt} />}
+            {locCheckedAt != null && <CheckedAtIcon checkedAt={new Date(locCheckedAt)} />}
           </div>
         </div>
         <CharacterSwitcher />

--- a/web/src/hooks/createPolledStore.ts
+++ b/web/src/hooks/createPolledStore.ts
@@ -43,8 +43,10 @@ export function createPolledStore<T>(opts: {
   const subscribers = new Set<() => void>();
 
   // Adopt a value (freshly fetched, or received from another tab) as current.
-  function apply(next: T): void {
-    fetchedAt = Date.now();
+  // `at` is when the value was actually FETCHED — for a peer's value that's the
+  // peer's fetch time, not now, so the staleness check below stays honest.
+  function apply(next: T, at: number = Date.now()): void {
+    fetchedAt = at;
     loaded = true;
     if (equals && equals(cache, next)) return;   // equivalent — keep ref, no re-render
     cache = next;
@@ -56,7 +58,7 @@ export function createPolledStore<T>(opts: {
     // If another tab already fetched within this interval, reuse it — no network.
     if (crossTab) {
       const shared = readXTab(crossTab.key, pollMs);
-      if (shared !== undefined) { apply(crossTab.deserialize(shared)); return Promise.resolve(); }
+      if (shared !== undefined) { apply(crossTab.deserialize(shared.v), shared.at); return Promise.resolve(); }
     }
     inflight = doFetch()
       .then((next) => {
@@ -76,7 +78,7 @@ export function createPolledStore<T>(opts: {
     if (!timer) timer = setInterval(load, pollMs);
     // Live-adopt values another tab fetches, so a tab that skipped the network
     // still updates the instant a peer publishes.
-    if (crossTab && !unsubX) unsubX = subscribeXTab(crossTab.key, (v) => apply(crossTab.deserialize(v)));
+    if (crossTab && !unsubX) unsubX = subscribeXTab(crossTab.key, (v, at) => apply(crossTab.deserialize(v), at));
     return () => {
       subscribers.delete(cb);
       if (subscribers.size === 0 && timer) {

--- a/web/src/hooks/crossTabPoll.ts
+++ b/web/src/hooks/crossTabPoll.ts
@@ -10,16 +10,21 @@ const PREFIX = 'nexum.xpoll.';
 /** The localStorage key a given poll key is stored under (for raw listeners). */
 export const xTabStorageKey = (key: string): string => PREFIX + key;
 
-interface Entry { v: unknown; at: number }
+export interface Entry { v: unknown; at: number }
 
-/** A fresh cross-tab value for `key` (younger than maxAgeMs), or undefined. */
-export function readXTab(key: string, maxAgeMs: number): unknown | undefined {
+/**
+ * A fresh cross-tab value for `key` (published less than maxAgeMs ago), or
+ * undefined. The publish time comes back with it: an adopting tab must age the
+ * value from when the PEER fetched it, not from when it read it, or a value
+ * that's nearly a full interval old is recorded — and displayed — as brand new.
+ */
+export function readXTab(key: string, maxAgeMs: number): Entry | undefined {
   try {
     const raw = localStorage.getItem(PREFIX + key);
     if (!raw) return undefined;
     const e = JSON.parse(raw) as Entry;
     if (typeof e.at !== 'number' || Date.now() - e.at >= maxAgeMs) return undefined;
-    return e.v;
+    return e;
   } catch { return undefined; }
 }
 
@@ -30,11 +35,11 @@ export function writeXTab(key: string, v: unknown): void {
 }
 
 /** Notify when another tab publishes a new value for `key`. Returns a cleanup. */
-export function subscribeXTab(key: string, cb: (v: unknown) => void): () => void {
+export function subscribeXTab(key: string, cb: (v: unknown, at: number) => void): () => void {
   const full = PREFIX + key;
   const handler = (e: StorageEvent): void => {
     if (e.key !== full || !e.newValue) return;
-    try { cb((JSON.parse(e.newValue) as Entry).v); } catch { /* ignore malformed */ }
+    try { const p = JSON.parse(e.newValue) as Entry; cb(p.v, p.at); } catch { /* ignore malformed */ }
   };
   window.addEventListener('storage', handler);
   return () => window.removeEventListener('storage', handler);

--- a/web/src/hooks/useCharacterLocation.ts
+++ b/web/src/hooks/useCharacterLocation.ts
@@ -75,7 +75,10 @@ function catchUp(): void { if (document.visibilityState === 'visible') load(); }
 function onLocStorage(e: StorageEvent): void {
   const cid = currentActingId;
   if (cid == null || !e.newValue || e.key !== xTabStorageKey(xTabKey(cid))) return;
-  try { adopt(cid, (JSON.parse(e.newValue) as { v: CharacterLocation }).v); } catch { /* ignore malformed */ }
+  try {
+    const p = JSON.parse(e.newValue) as { v: CharacterLocation; at: number };
+    adopt(cid, p.v, p.at);
+  } catch { /* ignore malformed */ }
 }
 
 function subscribe(cb: () => void): () => void {
@@ -100,13 +103,19 @@ function subscribe(cb: () => void): () => void {
 const noopSubscribe = (): (() => void) => () => {};
 const getSnapshot = () => moduleCache?.data ?? EMPTY;
 const getEmpty = () => EMPTY;
+const getFetchedAt = () => moduleCache?.fetchedAt ?? null;
+const getNoFetchedAt = () => null;
 
 const xTabKey = (charId: number): string => `location:${charId}`;
 
 // Adopt a location as current for `charId` (from our own fetch or another tab).
-function adopt(charId: number, data: CharacterLocation): void {
+// `at` is when the location was actually READ — a peer's publish time when we
+// adopt its value, not now. Stamping Date.now() there would report a value that
+// is nearly a full interval old as brand new, both to the freshness indicator
+// and to the mount-time staleness check.
+function adopt(charId: number, data: CharacterLocation, at: number = Date.now()): void {
   if (currentActingId !== charId) return; // acting char changed meanwhile — ignore
-  moduleCache = { charId, data, fetchedAt: Date.now() };
+  moduleCache = { charId, data, fetchedAt: at };
   notify();
 }
 
@@ -118,7 +127,11 @@ function load(): Promise<CharacterLocation> {
   // reuse it — no network call. Keyed by charId so a tab pinned to a different
   // pilot still fetches its own.
   const shared = readXTab(xTabKey(charId), POLL_MS);
-  if (shared !== undefined) { const data = shared as CharacterLocation; adopt(charId, data); return Promise.resolve(data); }
+  if (shared !== undefined) {
+    const data = shared.v as CharacterLocation;
+    adopt(charId, data, shared.at);
+    return Promise.resolve(data);
+  }
   inflightCharId = charId;
   inflight = api<RawLocationResponse>(`/api/character/${charId}/location`)
     .then(r => {
@@ -172,5 +185,22 @@ export function useCharacterLocation(): CharacterLocation {
     enabled ? subscribe : noopSubscribe,
     enabled ? getSnapshot : getEmpty,
     getEmpty,
+  );
+}
+
+/**
+ * When the location shown by {@link useCharacterLocation} was last read from
+ * ESI, as an epoch ms timestamp (null before the first read). Drives the
+ * toolbar's "checked X ago" indicator, which sits next to the system name and
+ * must therefore age THIS poll — not the separate 30 s online-status check it
+ * used to read, which made a location refreshed seconds ago look 20-30 s stale.
+ */
+export function useCharacterLocationCheckedAt(): number | null {
+  const { isShareMode } = useShareMode();
+  const enabled = !isShareMode;
+  return useSyncExternalStore(
+    enabled ? subscribe : noopSubscribe,
+    enabled ? getFetchedAt : getNoFetchedAt,
+    getNoFetchedAt,
   );
 }

--- a/web/src/hooks/useOnlineStatus.ts
+++ b/web/src/hooks/useOnlineStatus.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api/client';
 
+// 30 s — this only drives the online/offline dot and its tooltip. It deliberately
+// does NOT feed the toolbar's "checked X ago" indicator: that sits beside the
+// system name and must age the 10 s location poll (see useCharacterLocation).
 const POLL_MS = 30_000;
 
 interface OnlineStatus {
   online:    boolean | null;
-  checkedAt: Date | null;
   /** TQ session start as reported by ESI. Set when online === true; the
    *  toolbar surfaces it in the tooltip so orphan sessions (still "online"
    *  hours after the user crashed out) are visible at a glance. */
@@ -14,7 +16,6 @@ interface OnlineStatus {
 
 export function useOnlineStatus(enabled: boolean): OnlineStatus {
   const [online, setOnline]         = useState<boolean | null>(null);
-  const [checkedAt, setCheckedAt]   = useState<Date | null>(null);
   const [lastLogin, setLastLogin]   = useState<string | null>(null);
 
   const check = useCallback(async () => {
@@ -23,7 +24,6 @@ export function useOnlineStatus(enabled: boolean): OnlineStatus {
       const data = await api<{ online: boolean | null; scopeMissing?: boolean; lastLogin?: string | null }>('/api/character/online');
       setOnline(data.scopeMissing ? null : data.online);
       setLastLogin(data.lastLogin ?? null);
-      setCheckedAt(new Date());
     } catch {
       setOnline(null);
       setLastLogin(null);
@@ -37,5 +37,5 @@ export function useOnlineStatus(enabled: boolean): OnlineStatus {
     return () => clearInterval(id);
   }, [enabled, check]);
 
-  return { online, checkedAt, lastLogin };
+  return { online, lastLogin };
 }


### PR DESCRIPTION
## Problem

The clock next to the character's system name in the toolbar reads as "this location was last checked X ago". It was wired to `useOnlineStatus`'s timestamp — a **separate 30s online/offline check** — not to the 10s location poll whose result it sits beside.

So a location refreshed 3 seconds ago routinely displayed `checked 25s ago`, which reads as the location poll having stalled.

`timeAgo` prints exact seconds, so the 20s seen in the wild is out of range for a 10s poll and completely ordinary for a 30s one. Sampled on production: location requests every ~10s (all `304 Not Modified` — the character wasn't moving), online-status requests 31.0s apart, tooltip showing 19-20s.

## Fix

- `useCharacterLocation` exposes `useCharacterLocationCheckedAt()` — when the displayed location was actually read — and the toolbar uses that.
- `adopt()` / `createPolledStore`'s `apply()` now take the real read time instead of stamping `Date.now()`. A value adopted from a peer tab was recorded as brand new when it could be nearly a full interval old — that would have made the new indicator lie the same way, and it also suppressed a warranted mount-time refetch.
- `useOnlineStatus` drops its now-unused `checkedAt`, so there's only one "last checked" timestamp to wire up.

**No poll cadence changed.**

## Not included

The underlying data still has a real floor of roughly 15-20s worst case: ESI's own ~5s cache, plus our 5s server-side per-character cache stacked on top of it, plus the 10s client poll. The server cache could be made to expire on ESI's `Expires` header rather than a flat 5s from receipt, which would remove up to 5s of that without any extra ESI traffic. Left out of this PR as a separate change.

## Testing

`tsc -b` clean, `eslint src` 0 errors (43 pre-existing warnings). Verified against production data by measurement; the label change itself is verified by construction, not a click-through.