### PR TITLE
Fix: overwrite-paste sig removals were cancelled instead of carried out

### DIFF
--- a/web/src/components/ui/SignaturePane.tsx
+++ b/web/src/components/ui/SignaturePane.tsx
@@ -22,6 +22,9 @@ import { alertInboundK162 } from '../../utils/k162Alert';
 import { formatBookmarkName, DEFAULT_BOOKMARK_FORMAT, formatSiteBookmarkName, DEFAULT_SITE_BOOKMARK_FORMAT } from '../../utils/signatureBookmark';
 import { useWormholeTypes } from '../../hooks/useWormholeTypes';
 import { duration, DASH } from '../../i18n/format';
+import {
+  scheduleSigRemoval, cancelSigRemoval, pendingRemovalIds, subscribeSigRemovals,
+} from '../../store/sigRemovalQueue';
 
 // Aging bands for wormhole signatures, anchored to the WH type's known
 // lifetime from the SDE catalog (useWormholeTypes) — the single source, so
@@ -426,16 +429,31 @@ export function SignaturePane({ systemId }: { systemId: string }) {
       .catch(() => toast.error(t('signatures.bookmarkCopyFailed')));
   }, [siteBookmarkFormat, t]);
 
-  // Sigs currently shown with the pending-removal indicator, plus the timers
-  // that delete them once the grace period elapses.
+  // Sigs currently drawn with the pending-removal indicator. The timers that
+  // actually delete them live in the removal queue — unmounting this pane (or
+  // switching system) must not cancel a deletion the user has already asked
+  // for, which is what used to leave despawned sigs behind.
   const [removing, setRemoving] = useState<Set<string>>(new Set());
-  const removalTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
-  // Clear any outstanding removal timers when the pane unmounts.
-  useEffect(() => () => {
-    for (const tm of removalTimers.current.values()) clearTimeout(tm);
-    removalTimers.current.clear();
-  }, []);
+  // Follow the queue: drop the row when its removal lands, and keep the
+  // indicator in step when another pane instance schedules or cancels one.
+  useEffect(() => subscribeSigRemovals((e) => {
+    if (e.systemId !== systemId) return;
+    if (e.kind === 'removed') {
+      setSigs((prev) => prev.filter((s) => s.id !== e.sigRowId));
+      setSelected((prev) => { const next = new Set(prev); next.delete(e.sigRowId); return next; });
+      // A sig backing a wormhole vanishing means the hole collapsed: sever the
+      // connection but keep it on the map.
+      if (e.sig?.whType && e.sig.whLeadsTo) {
+        reevaluateConnectionsForSystem(systemId, sigsRef.current.filter((s) => s.id !== e.sigRowId), e.sig, true);
+      }
+    }
+    setRemoving((prev) => {
+      const next = new Set(prev);
+      if (e.kind === 'scheduled') next.add(e.sigRowId); else next.delete(e.sigRowId);
+      return next;
+    });
+  }), [systemId]);
 
   // Track whether Shift is physically held — the `paste` ClipboardEvent itself
   // carries no modifier state, so Shift+Ctrl+V is detected via this ref.
@@ -471,11 +489,12 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
   useEffect(() => {
     if (!activeMapId) return;
-    // Cancel any pending overwrite-removals carried over from the previous
-    // system — their timers reference rows that are about to be cleared.
-    for (const tm of removalTimers.current.values()) clearTimeout(tm);
-    removalTimers.current.clear();
-    setRemoving(new Set());
+    // Pending overwrite-removals are NOT cancelled here. They live in the
+    // module-level queue with the map + system they belong to, so switching
+    // system just changes which of them this pane draws — it no longer abandons
+    // deletions the user has already asked for (which is what left despawned
+    // sigs behind: clearing bookmarks means hopping the chain).
+    setRemoving(pendingRemovalIds(systemId));
     setSigs([]);
     setSelected(new Set());
 
@@ -619,8 +638,7 @@ export function SignaturePane({ systemId }: { systemId: string }) {
   // Drop any pending overwrite-removal timer/indicator for this id (the row is
   // being deleted now, whether by the timer firing or a manual delete).
   const clearRemoval = (id: string) => {
-    const tm = removalTimers.current.get(id);
-    if (tm) { clearTimeout(tm); removalTimers.current.delete(id); }
+    cancelSigRemoval(id);
     setRemoving((prev) => {
       if (!prev.has(id)) return prev;
       const next = new Set(prev); next.delete(id); return next;
@@ -647,18 +665,15 @@ export function SignaturePane({ systemId }: { systemId: string }) {
 
   // Mark a despawned sig for removal after `delaySec`, keeping it visible with
   // the indicator meanwhile. delaySec <= 0 deletes immediately. Reschedules
-  // cleanly if the sig was already pending.
+  // cleanly if the sig was already pending. The timer lives in the removal
+  // queue, not this component, so navigating away doesn't drop the deletion —
+  // the pane's own subscription (below) drops the row when it lands.
   const scheduleRemoval = (id: string, delaySec: number) => {
-    const existing = removalTimers.current.get(id);
-    if (existing) clearTimeout(existing);
-    if (delaySec <= 0) {
-      removalTimers.current.delete(id);
-      deleteSig(id);
-      return;
-    }
-    setRemoving((prev) => { const next = new Set(prev); next.add(id); return next; });
-    const tm = setTimeout(() => deleteSig(id), delaySec * 1000);
-    removalTimers.current.set(id, tm);
+    if (!activeMapId) return;
+    const sig = sigsRef.current.find((s) => s.id === id);
+    if (!sig) return;
+    if (delaySec > 0) setRemoving((prev) => { const next = new Set(prev); next.add(id); return next; });
+    scheduleSigRemoval(activeMapId, systemId, sig, delaySec);
   };
 
   const processPaste = useCallback(async (parsed: ParsedSig[], overwrite: boolean, delaySec: number) => {

--- a/web/src/store/sigRemovalQueue.ts
+++ b/web/src/store/sigRemovalQueue.ts
@@ -1,0 +1,116 @@
+import { api } from '../api/client';
+import type { Signature } from '../types';
+
+/**
+ * Pending overwrite-paste signature removals.
+ *
+ * An overwrite paste doesn't delete a despawned sig outright: it marks the row
+ * struck-through and deletes it after a grace period (default 10 s, up to 2 min)
+ * so the user can see what's going and clear the in-game bookmarks first.
+ *
+ * That grace period used to be a setTimeout owned by SignaturePane, which made
+ * the deletion conditional on the pane staying mounted on that system until the
+ * timer fired — and the pane clears its timers on every system switch. Clearing
+ * bookmarks means hopping the chain, so the normal workflow cancelled the very
+ * deletions it had just scheduled and the despawned sigs silently survived.
+ *
+ * The queue owns them instead: each entry carries the map + system it belongs
+ * to, so it fires wherever the user has navigated to, and a page close flushes
+ * what's still outstanding rather than dropping it.
+ */
+
+interface Pending {
+  mapId:    string;
+  systemId: string;
+  sig:      Signature;
+  timer:    ReturnType<typeof setTimeout> | null;
+}
+
+/** Keyed by signature row id (a UUID — unique across systems). */
+const pending = new Map<string, Pending>();
+const listeners = new Set<(e: RemovalEvent) => void>();
+
+export interface RemovalEvent {
+  /** 'scheduled' / 'cancelled' only move the indicator; 'removed' means the row is gone. */
+  kind:     'scheduled' | 'cancelled' | 'removed';
+  sigRowId: string;
+  systemId: string;
+  /** The removed signature — subscribers need it to re-evaluate connections. */
+  sig?:     Signature;
+}
+
+function emit(e: RemovalEvent): void {
+  listeners.forEach((fn) => fn(e));
+}
+
+/** Notified when a pending removal is scheduled, cancelled, or carried out. */
+export function subscribeSigRemovals(cb: (e: RemovalEvent) => void): () => void {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+/** Row ids currently marked for removal in `systemId` — drives the row styling. */
+export function pendingRemovalIds(systemId: string): Set<string> {
+  const out = new Set<string>();
+  for (const p of pending.values()) if (p.systemId === systemId) out.add(p.sig.id);
+  return out;
+}
+
+// Carry out one removal. `keepalive` lets it survive the page unloading.
+function commit(p: Pending, keepalive = false): void {
+  if (p.timer) clearTimeout(p.timer);
+  pending.delete(p.sig.id);
+  api(`/api/maps/${p.mapId}/systems/${p.systemId}/signatures/${p.sig.id}`, { method: 'DELETE', keepalive })
+    .catch(() => { /* best-effort: a failed delete leaves the row for the next paste to re-flag */ });
+  // Subscribers drop the row locally and, when the pane is mounted on this
+  // system, quarantine any connection the sig was backing. When it isn't, the
+  // pane's own orphaned-wormhole sweep catches it on the next visit.
+  emit({ kind: 'removed', sigRowId: p.sig.id, systemId: p.systemId, sig: p.sig });
+}
+
+/**
+ * Mark a despawned sig for removal after `delaySec`. `delaySec <= 0` removes it
+ * at once. Rescheduling an already-pending sig restarts its grace period.
+ */
+export function scheduleSigRemoval(mapId: string, systemId: string, sig: Signature, delaySec: number): void {
+  const existing = pending.get(sig.id);
+  if (existing?.timer) clearTimeout(existing.timer);
+
+  const entry: Pending = { mapId, systemId, sig, timer: null };
+  if (delaySec <= 0) {
+    pending.set(sig.id, entry);
+    commit(entry);
+    return;
+  }
+  entry.timer = setTimeout(() => commit(entry), delaySec * 1000);
+  pending.set(sig.id, entry);
+  emit({ kind: 'scheduled', sigRowId: sig.id, systemId });
+}
+
+/**
+ * Drop a pending removal without deleting — the sig came back in a later paste,
+ * or the row has already gone (manual delete).
+ */
+export function cancelSigRemoval(sigRowId: string): void {
+  const p = pending.get(sigRowId);
+  if (!p) return;
+  if (p.timer) clearTimeout(p.timer);
+  pending.delete(sigRowId);
+  emit({ kind: 'cancelled', sigRowId, systemId: p.systemId });
+}
+
+/**
+ * Carry out every outstanding removal immediately. Bound to `pagehide` below:
+ * the user asked for these sigs to go, so a closed tab must commit them rather
+ * than lose them. keepalive keeps the DELETEs alive past the unload.
+ */
+export function flushSigRemovals(): void {
+  for (const p of [...pending.values()]) commit(p, true);
+}
+
+if (typeof window !== 'undefined') {
+  // pagehide (not beforeunload) — it fires for bfcache navigations and mobile
+  // tab eviction too, which is where the "closed the tab and the sigs came
+  // back" reports come from.
+  window.addEventListener('pagehide', flushSigRemovals);
+}


### PR DESCRIPTION
## Problem

An overwrite paste doesn't delete a despawned signature outright — it strikes the row through and deletes it after a grace period (10s default, up to 2m) so you can clear the in-game bookmarks first.

That timer lived in `SignaturePane`, and the pane cancelled every pending timer in two places:

```js
// on unmount
useEffect(() => () => { for (const tm of removalTimers.current.values()) clearTimeout(tm); ... }, []);

// and at the top of the system-switch effect
for (const tm of removalTimers.current.values()) clearTimeout(tm);
removalTimers.current.clear();
```

Clearing bookmarks means hopping the chain — so the normal workflow cancelled the very deletions it had just scheduled. The despawned sigs survived on the server and were still sitting there on the next visit. Closing the tab lost them the same way.

This is what leaves stale rows behind, including the blank/contentless rows that the clear-down sweep is supposed to remove (`isContentlessSig` → `scheduleRemoval` → cancelled by the next system switch).

## Fix

New `store/sigRemovalQueue.ts` owns the pending removals. Each entry carries the map + system it belongs to, so it fires wherever the user has navigated to.

- The pane draws the indicator for its own system only, and drops the row when the removal lands (running the same connection quarantine `deleteSig` did).
- Switching system re-reads which of the new system's rows are pending instead of cancelling everything.
- `pagehide` flushes what's still outstanding with `keepalive` DELETEs, so a closed tab commits rather than drops them.
- Cancel-on-reappear and cancel-on-manual-delete unchanged. Grace-period lengths, indicator and styling unchanged.

## Note on the blank row that prompted this — CORRECTED after merge

The original text here claimed a blank row can only come from "Add signature" (or a merge / cross-map sync of one). **That claim was not verified and looks wrong.** Data pulled from production afterwards:

- 9 blank-id rows on one map (202 sigs); 0 on the account's three other maps.
- They are still being created — 5 in one afternoon, roughly one per system visited.
- In 4 of 5 recent cases the blank row is created 3-4 s *before* a real signature in that system. A paste writes its rows in the same millisecond, so the blank is not part of the paste batch.
- The two oldest carry `sigType: "wormhole"`, which the "Add signature" button cannot produce — it defaults to `unknown`.

Ruled out by reading the code: the paste parser (requires `^[A-Z]{3}-\d{3}$`), cross-map sync (`if (!sig || !sig.sig_id) return`), map merge (never writes `sig_id`), and every server-side sweep. What actually mints them is still unidentified — it is being traced separately.

**This PR is unaffected.** It fixes why such rows never get *swept* once they exist; it does not address whatever creates them.

## Testing

`tsc -b` clean, `yarn build` clean, `eslint` 0 errors and no new warnings (same 4 pre-existing ones).
