### PR TITLE
Diagnostic: log every contentless signature write

### DIFF
--- a/server/src/services/mapWrite.ts
+++ b/server/src/services/mapWrite.ts
@@ -2,6 +2,9 @@ import { db } from '../db.js';
 import { publishToMap } from './mapEvents.js';
 import { syncSignature, syncAnomaly } from './crossMapSync.js';
 import { recordGhostSiteIfMatch } from './ghostSites.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('map-write');
 
 // Shared per-system CONTENT writes (signatures, anomalies, structures) — the
 // single source of truth behind both the cookie map routes and the external
@@ -33,7 +36,22 @@ export interface SignatureInput {
   sigId: string; sigType: string; name: string; notes: string; whType: string; whLeadsTo: string;
 }
 
+// A signature carrying nothing at all — no scan id, no name, no notes, no
+// wormhole data. "Add signature" legitimately creates one (an empty row to type
+// into), but they have also been appearing on live maps that nobody added by
+// hand, so log every one with the actor and client that asked for it. clientId
+// is the browser tab's x-client-id and is null for API-key writes, which
+// separates the app from an integration. Diagnostic — remove once the source of
+// the unexplained ones is identified.
+function logIfContentless(mapId: string, systemId: string, d: SignatureInput, actor: WriteActor): void {
+  if (d.sigId || d.name || d.notes || d.whType || d.whLeadsTo) return;
+  log.warn('contentless signature created', JSON.stringify({
+    mapId, systemId, sigType: d.sigType, userId: actor.userId, clientId: actor.clientId,
+  }));
+}
+
 export async function createSignature(mapId: string, systemId: string, d: SignatureInput, actor: WriteActor) {
+  logIfContentless(mapId, systemId, d, actor);
   const { rows } = await db.query(
     `INSERT INTO map_signatures (system_id, sig_id, sig_type, name, notes, wh_type, wh_leads_to, created_by_user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
@@ -65,6 +83,16 @@ export async function updateSignature(
     const { rows: prev } = await db.query<{ wh_type: string | null }>(
       `SELECT wh_type FROM map_signatures WHERE id = $1 AND system_id = $2`, [sigId, systemId]);
     prevWasK162 = (prev[0]?.wh_type ?? '').toUpperCase() === 'K162';
+  }
+
+  // The other way a blank row can appear: an existing signature's scan id being
+  // cleared. Only the ID input writes this, on every keystroke, so a legitimate
+  // retype logs one line — worth the noise while the unexplained blanks are
+  // being traced. Diagnostic, paired with logIfContentless above.
+  if ('sigId' in updates && !updates.sigId) {
+    log.warn('signature scan id cleared', JSON.stringify({
+      mapId, systemId, sigRowId: sigId, userId: actor.userId, clientId: actor.clientId,
+    }));
   }
 
   const sets: string[] = ['updated_at = NOW()'];


### PR DESCRIPTION
## Why

Blank signature rows keep appearing on a live map that nobody added by hand. Pulled from production:

- 9 blank-id rows on one map (202 sigs); **0** on the account's three other maps.
- Still accruing: 5 in one afternoon, roughly one per system visited.
- In 4 of 5 recent cases the blank lands **3-4s before** a real sig in that system. A paste writes its rows in the same millisecond, so the blank isn't part of the paste batch.
- The two oldest carry `sigType: "wormhole"`, which the "Add signature" button can't produce (it defaults to `unknown`).

Ruled out by reading the code: the paste parser (`^[A-Z]{3}-\d{3}$`), cross-map sync (`if (!sig || !sig.sig_id) return`), map merge (never writes `sig_id`), every server-side sweep, and the wormhole-jump flow (PATCH only). Selecting a system in the UI fires no signature write at all — verified live against production.

That leaves the "Add signature" button and the ID input, neither of which the reporter is touching. So: catch it in the act.

## What

Two `log.warn` lines in the shared write layer, so they cover the cookie routes and the `/api/v1` routes equally:

- `createSignature` - a row created with no scan id, name, notes or wormhole data, logged with `userId` and `clientId`. `clientId` is the browser tab's `x-client-id` and is `null` for API-key writes, which separates the app from an integration.
- `updateSignature` - an existing row's scan id being cleared, the only other way a blank row can appear.

`sigType` is included: a contentless row logged as `wormhole` immediately rules the "Add signature" button out.

## Notes

- Diagnostic only, no behaviour change. To be reverted once the source is found.
- The ID input PATCHes per keystroke, so a legitimate retype of a scan id logs one line. Acceptable noise while tracing.

## Testing

`tsc --noEmit` clean; server tests pass (46 passed, 61 skipped - the skipped ones need a DB).