### PR TITLE
Fix: the signature Updated column never had any data

### DIFF
--- a/server/src/services/mapRead.ts
+++ b/server/src/services/mapRead.ts
@@ -168,7 +168,8 @@ export async function isSystemInMap(systemId: string, mapId: string): Promise<bo
 export async function loadSystemSignatures(systemId: string) {
   const { rows } = await db.query(
     `SELECT id, sig_id AS "sigId", sig_type AS "sigType", name, notes,
-            wh_type AS "whType", wh_leads_to AS "whLeadsTo", created_at AS "createdAt"
+            wh_type AS "whType", wh_leads_to AS "whLeadsTo",
+            created_at AS "createdAt", updated_at AS "updatedAt"
        FROM map_signatures WHERE system_id = $1 ORDER BY created_at`,
     [systemId],
   );


### PR DESCRIPTION
## Problem

The signature pane renders an **Updated** column - sortable (`SortCol` includes `'updatedAt'`), hideable (`HIDEABLE_COLS`), and `updatedAt` is a required field on the `Signature` type:

```tsx
<ElapsedCell iso={sig.updatedAt} className="sig-td--time sig-td--updated" />
```

But `loadSystemSignatures` never selected it:

```sql
SELECT id, sig_id, sig_type, name, notes, wh_type, wh_leads_to, created_at
```

So `updatedAt` was `undefined` on every row the server returned. The column only showed anything for a row edited in the current session (where `updateSig` stamps `updatedAt` optimistically client-side), and a reload blanked it again.

## Fix

Select `updated_at`. Both signature reads go through this function, so the `/api/v1` route picks it up too.

## Why now

It also answers a live question: it distinguishes a signature that was **created** empty from one that was **emptied later**. Blank rows keep appearing on a production map, and the two oldest still carry `sigType: "wormhole"` while their id, name and wormhole data are gone - `updated_at > created_at` would confirm they were wiped rather than born blank, which decides where to look next.

## Testing

`tsc --noEmit` clean; server tests pass.