### PR TITLE
Fix: demo maps used invented systems with impossible statics

### DIFF
--- a/server/src/services/demoMap.ts
+++ b/server/src/services/demoMap.ts
@@ -2,11 +2,20 @@ import { randomUUID } from 'node:crypto';
 import { db } from '../db.js';
 
 // First-login starter map. A small chain so new users land on something
-// readable instead of a blank canvas: Jita (home) → C2 → C4 → C5 main line,
-// with a C3 → lowsec side branch off the C4.
+// readable instead of a blank canvas:
 //
-// Real EVE system IDs are populated where they exist (Jita, Amamake); J-codes
-// leave eve_system_id null, matching how the import path handles unknowns.
+//   Jita ──B274── J150137 (C2) ──Y683── J150026 (C4) ──C247── J150048 (C3) ──U210── Amamake
+//                                            └──X877── J150044 (C4)
+//
+// Every system is real and every connection is one of its actual statics. The
+// class/effect/statics below are only a fallback: seedDemoMap looks each system
+// up in the SDE and uses the live row, so the starter map can't drift from the
+// game the way the previous hand-written data had (it carried static sets that
+// can't occur — the wormhole catalogue's `src` records which class each code
+// comes from, and wormholers spot an impossible one immediately).
+//
+// eve_system_id is filled from the SDE too, J-codes included, so the starter
+// map behaves like a real one rather than a set of detached placeholders.
 //
 // No-op when the user already has any map.
 export async function seedDemoMap(userId: number): Promise<void> {
@@ -34,7 +43,7 @@ export async function seedDemoMap(userId: number): Promise<void> {
       jita:    randomUUID(),
       c2:      randomUUID(),
       c4:      randomUUID(),
-      c5:      randomUUID(),
+      c4b:     randomUUID(),
       c3:      randomUUID(),
       amamake: randomUUID(),
     };
@@ -53,13 +62,33 @@ export async function seedDemoMap(userId: number): Promise<void> {
       status:   string;
     }
     const systems: DemoSystem[] = [
-      { id: ids.jita,    eveId: 30000142, name: 'Jita',    cls: 'HS', effect: 'none',   statics: [],       region: 'The Forge', x: 0,   y: 0,    home: true,  status: 'visited' },
-      { id: ids.c2,      eveId: null,     name: 'J164417', cls: 'C2', effect: 'none',   statics: ['B274'], region: null,        x: 240, y: 0,    home: false, status: 'visited' },
-      { id: ids.c4,      eveId: null,     name: 'J160225', cls: 'C4', effect: 'none',   statics: ['X877'], region: null,        x: 480, y: 0,    home: false, status: 'visited' },
-      { id: ids.c5,      eveId: null,     name: 'J152820', cls: 'C5', effect: 'pulsar', statics: ['H296'], region: null,        x: 720, y: -80,  home: false, status: 'unknown' },
-      { id: ids.c3,      eveId: null,     name: 'J160650', cls: 'C3', effect: 'none',   statics: ['U210'], region: null,        x: 480, y: 200,  home: false, status: 'visited' },
-      { id: ids.amamake, eveId: 30002537, name: 'Amamake', cls: 'LS', effect: 'none',   statics: [],       region: 'Heimatar',  x: 720, y: 200,  home: false, status: 'unknown' },
+      { id: ids.jita,    eveId: 30000142, name: 'Jita',    cls: 'HS', effect: 'none',       statics: [],               region: 'The Forge', x: 0,   y: 0,    home: true,  status: 'visited' },
+      { id: ids.c2,      eveId: null,     name: 'J150137', cls: 'C2', effect: 'none',       statics: ['B274', 'Y683'], region: null,        x: 240, y: 0,    home: false, status: 'visited' },
+      { id: ids.c4,      eveId: null,     name: 'J150026', cls: 'C4', effect: 'wolf_rayet', statics: ['C247', 'X877'], region: null,        x: 480, y: 0,    home: false, status: 'visited' },
+      { id: ids.c4b,     eveId: null,     name: 'J150044', cls: 'C4', effect: 'none',       statics: ['C247', 'X877'], region: null,        x: 720, y: -80,  home: false, status: 'unknown' },
+      { id: ids.c3,      eveId: null,     name: 'J150048', cls: 'C3', effect: 'none',       statics: ['U210'],         region: null,        x: 480, y: 200,  home: false, status: 'visited' },
+      { id: ids.amamake, eveId: 30002537, name: 'Amamake', cls: 'LS', effect: 'none',       statics: [],               region: 'Heimatar',  x: 720, y: 200,  home: false, status: 'unknown' },
     ];
+
+    // Overlay the SDE's own row for each system, so class / effect / statics and
+    // the EVE id are whatever the game actually says. Systems missing from the
+    // SDE (not seeded yet) keep the fallback values above.
+    const { rows: sde } = await client.query<{
+      id: number; name: string; systemClass: string | null; effect: string | null; statics: string[] | null;
+    }>(
+      `SELECT id, name, class AS "systemClass", effect, statics
+         FROM solar_systems WHERE name = ANY($1::text[])`,
+      [systems.map((s) => s.name)],
+    );
+    const sdeByName = new Map(sde.map((r) => [r.name, r]));
+    for (const sys of systems) {
+      const row = sdeByName.get(sys.name);
+      if (!row) continue;
+      sys.eveId = row.id;
+      if (row.systemClass) sys.cls = row.systemClass;
+      sys.effect = row.effect ?? 'none';
+      if (row.statics) sys.statics = row.statics;
+    }
 
     const sysCols = 15;
     const sysPlaceholders: string[] = [];
@@ -81,11 +110,14 @@ export async function seedDemoMap(userId: number): Promise<void> {
       sysValues,
     );
 
+    // Each hop is the static of the system it leaves from. All five codes have a
+    // 375 Mkg jump limit in the SDE, i.e. 'large' — the previous X877 'xl' was
+    // wrong, that size belongs to capital-passable holes like H296 (2 Gkg).
     const connections: Array<{ src: string; tgt: string; size: string; whType: string }> = [
       { src: ids.jita,  tgt: ids.c2,      size: 'large', whType: 'B274' },
-      { src: ids.c2,    tgt: ids.c4,      size: 'large', whType: 'K162' },
-      { src: ids.c4,    tgt: ids.c5,      size: 'xl',    whType: 'X877' },
-      { src: ids.c4,    tgt: ids.c3,      size: 'large', whType: 'K162' },
+      { src: ids.c2,    tgt: ids.c4,      size: 'large', whType: 'Y683' },
+      { src: ids.c4,    tgt: ids.c3,      size: 'large', whType: 'C247' },
+      { src: ids.c4,    tgt: ids.c4b,     size: 'large', whType: 'X877' },
       { src: ids.c3,    tgt: ids.amamake, size: 'large', whType: 'U210' },
     ];
     const connCols = 7;
@@ -105,7 +137,7 @@ export async function seedDemoMap(userId: number): Promise<void> {
 
     await client.query(
       `INSERT INTO map_signatures (system_id, sig_id, sig_type, name, wh_type, wh_leads_to)
-       VALUES ($1, 'ABC-123', 'wormhole', 'Outbound to lowsec', 'U210', 'Amamake')`,
+       VALUES ($1, 'LPZ-471', 'wormhole', 'Outbound to lowsec', 'U210', 'Amamake')`,
       [ids.c3],
     );
 

--- a/web/src/components/ui/DemoMap.tsx
+++ b/web/src/components/ui/DemoMap.tsx
@@ -29,20 +29,34 @@ interface DemoSys {
 
 // ── pre-populated chain ──────────────────────────────────────
 
+// Real systems, taken from the SDE the app itself runs on — J-codes, classes,
+// effects and statics all match live data. The invented ones this replaced had
+// static sets that can't occur: the wormhole catalogue records which class each
+// code originates FROM (`src`), and by that measure a C3 can hold neither C247
+// (src c4) nor Z971 (src hs/ls/ns), and a C2 can hold neither D364 (src c5) nor
+// N766 (src c4). Wormholers spot that instantly, so the demo read as fake.
+//
+// The chain is consistent end to end — every connection below is one of these
+// systems' actual statics:
+//
+//   Jita ──B274── J150137 (C2) ──Y683── J150026 (C4) ──C247── J150048 (C3) ──U210── Amamake
+//
+// J150026's second static (X877 → C4) is deliberately left unopened, which is
+// what a chain mid-scan actually looks like.
 const SEED_SYSTEMS: DemoSys[] = [
-  { id: 'ds1', name: 'J213422',  systemClass: 'C3', effect: 'pulsar',     statics: ['C247', 'Z971'], regionName: null },
-  { id: 'ds2', name: 'J123456',  systemClass: 'C2', effect: 'none',       statics: ['D364', 'N766'], regionName: null },
-  { id: 'ds3', name: 'J456789',  systemClass: 'C5', effect: 'magnetar',   statics: ['H296'],         regionName: null },
-  { id: 'ds4', name: 'Jita',     systemClass: 'HS', effect: 'none',       statics: [],               regionName: 'The Forge' },
-  { id: 'ds5', name: 'J789012',  systemClass: 'C4', effect: 'wolf_rayet', statics: ['E175', 'X877'], regionName: null },
+  { id: 'ds1', name: 'Jita',     systemClass: 'HS', effect: 'none',       statics: [],               regionName: 'The Forge' },
+  { id: 'ds2', name: 'J150137',  systemClass: 'C2', effect: 'none',       statics: ['B274', 'Y683'], regionName: null },
+  { id: 'ds3', name: 'J150026',  systemClass: 'C4', effect: 'wolf_rayet', statics: ['C247', 'X877'], regionName: null },
+  { id: 'ds4', name: 'J150048',  systemClass: 'C3', effect: 'none',       statics: ['U210'],         regionName: null },
+  { id: 'ds5', name: 'Amamake',  systemClass: 'LS', effect: 'none',       statics: [],               regionName: 'Heimatar' },
 ];
 
 const SEED_POSITIONS: { x: number; y: number }[] = [
-  { x: 300, y: 140 },
-  { x: 60,  y: 290 },
-  { x: 540, y: 290 },
-  { x: -80, y: 430 },
-  { x: 700, y: 80  },
+  { x: -80, y: 330 },
+  { x: 170, y: 300 },
+  { x: 420, y: 150 },
+  { x: 660, y: 310 },
+  { x: 880, y: 400 },
 ];
 
 const INITIAL_NODES: Node[] = SEED_SYSTEMS.map((s, i) => ({
@@ -52,10 +66,12 @@ const INITIAL_NODES: Node[] = SEED_SYSTEMS.map((s, i) => ({
   data: s as unknown as Record<string, unknown>,
 }));
 
+// One edge per opened static, in chain order.
 const INITIAL_EDGES: Edge[] = [
   { id: 'de1', source: 'ds1', target: 'ds2', type: 'demoConnection', ...pickHandles(SEED_POSITIONS[0], SEED_POSITIONS[1]) },
-  { id: 'de2', source: 'ds1', target: 'ds3', type: 'demoConnection', ...pickHandles(SEED_POSITIONS[0], SEED_POSITIONS[2]) },
-  { id: 'de3', source: 'ds2', target: 'ds4', type: 'demoConnection', ...pickHandles(SEED_POSITIONS[1], SEED_POSITIONS[3]) },
+  { id: 'de2', source: 'ds2', target: 'ds3', type: 'demoConnection', ...pickHandles(SEED_POSITIONS[1], SEED_POSITIONS[2]) },
+  { id: 'de3', source: 'ds3', target: 'ds4', type: 'demoConnection', ...pickHandles(SEED_POSITIONS[2], SEED_POSITIONS[3]) },
+  { id: 'de4', source: 'ds4', target: 'ds5', type: 'demoConnection', ...pickHandles(SEED_POSITIONS[3], SEED_POSITIONS[4]) },
 ];
 
 // ── demo edge ────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Reported on Discord by a wormholer, who spotted it instantly:

> in demo i think something wrong... I was in wormholes a lot but never saw 4-4-4, 2-2-2 and not shattered 3-3-1

The landing-page demo (`DemoMap.tsx`) used invented J-codes with invented statics. The app's own wormhole catalogue settles it — every code records the class it can originate **from** (`src`):

| shown as | code | `src` (only class it can come from) | verdict |
|---|---|---|---|
| C3 `J213422` | C247 | c4 | impossible |
| C3 `J213422` | Z971 | hs, ls, ns | impossible |
| C2 `J123456` | D364 | c5 | impossible |
| C2 `J123456` | N766 | c4 | impossible |
| C4 `J789012` | E175 | c5 | impossible |

Five of seven statics were impossible for the class displayed next to them. Three of the four wormhole systems also carried an effect, where the large majority of real ones have none. The connections matched no static at all.

The seeded starter map (`services/demoMap.ts`) had the same weakness: hand-written J-codes, statics that were never checked, and `eve_system_id` left null.

## Fix

Both demos now use real systems, read from the SDE this app already ships:

```
Jita ──B274── J150137 (C2) ──Y683── J150026 (C4) ──C247── J150048 (C3) ──U210── Amamake
```

Every hop is the static of the system it leaves from, and each code's `src` matches that system's class:

- `B274` dest hs, src c2 — J150137 is a C2
- `Y683` dest c4, src c2 — leads to J150026, a C4
- `C247` dest c3, src c4 — leads to J150048, a C3
- `U210` dest ls, src c3 — leads to Amamake, low-sec

J150026's second static (`X877` → C4) is left unopened on the landing page, which is what a chain mid-scan looks like. The starter map opens it to a real C4 (J150044).

Only one system carries an effect (J150026, wolf-rayet) and it's the effect that system really has.

**The starter map no longer hardcodes any of it**: `seedDemoMap` looks each system up in `solar_systems` and uses the live row for class, effect, statics and `eve_system_id`, so it cannot drift from the game again. The literals stay as a fallback for a database without the SDE seeded. J-codes now get a real `eve_system_id` rather than null, so the starter map behaves like a real one.

Also: the starter map marked the `X877` connection `'xl'`. The SDE gives X877 a 375 Mkg jump limit, i.e. `'large'`; XL belongs to capital-passable holes like H296 (2 Gkg). Fixed.

## Verification

Every system and code above was read from the running production SDE via `/api/systems/:id` and `/api/wormholes/types` — nothing here is from memory.

Rendered locally against the landing page (screenshot in the PR thread): the chain reads HI-SEC -> C2 -> C4 -> C3 -> LOW-SEC with the statics shown on each node.

`tsc` clean both sides, `eslint` clean, `yarn build` clean, server tests pass.