### PR TITLE
Connections: reject jump types the SDE says are impossible

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -14,6 +14,7 @@ import { audit } from '../services/audit.js';
 import { publishToMap } from '../services/mapEvents.js';
 import { streamMapEvents } from '../services/mapStream.js';
 import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures, CONNECTION_COLS } from '../services/mapRead.js';
+import { connectionTypeError, connectionEndpointEveIds, systemEveIds } from '../services/connectionRules.js';
 import { listConnectionJumps, recordConnectionJump, setConnectionJumpHot, clearConnectionJumps } from '../services/connectionJumps.js';
 import {
   createSignature, updateSignature, deleteSignature,
@@ -2680,6 +2681,17 @@ mapsRouter.post('/:mapId/connections', async (req, res) => {
     } catch { /* stargate table absent / query failed — keep client's type */ }
   }
 
+  // A client-supplied 'gate'/'jumpgate'/'cyno' was previously taken on trust, so
+  // an impossible edge (a stargate between two wormhole systems) could be
+  // created outright. Anything auto-classified above passes by construction.
+  const typeError = await connectionTypeError(
+    effectiveType,
+    (typeof sourceEveId === 'number' && typeof targetEveId === 'number')
+      ? { sourceEveId, targetEveId }
+      : await systemEveIds(sourceId, targetId),
+  );
+  if (typeError) { res.status(400).json({ error: typeError }); return; }
+
   let inserted = 0;
   try {
     const ins = await db.query(
@@ -3243,6 +3255,18 @@ mapsRouter.patch('/:mapId/connections/:connectionId', async (req, res) => {
   };
 
   const updates: Record<string, unknown> = { ...(req.body as Record<string, unknown>) };
+
+  // Jump type: the same SDE rules the create route applies. Without this an edge
+  // that couldn't be created as a gate could still be switched to one afterwards.
+  if ('connectionType' in updates) {
+    const next = updates.connectionType;
+    if (typeof next !== 'string') { res.status(400).json({ error: 'invalid connectionType' }); return; }
+    const ep = await connectionEndpointEveIds(mapId, connectionId);
+    if (ep) {
+      const err = await connectionTypeError(next, ep);
+      if (err) { res.status(400).json({ error: err }); return; }
+    }
+  }
 
   // Validate the two time-bucket fields. The whitelist below trusts values
   // verbatim, so reject anything malformed here (a bad ISO string would 22007

--- a/server/src/services/connectionRules.ts
+++ b/server/src/services/connectionRules.ts
@@ -1,0 +1,111 @@
+import { db } from '../db.js';
+import { TtlValue } from '../utils/cache.js';
+
+/**
+ * What a connection type is allowed to claim, checked against the SDE.
+ *
+ * The map lets you set a connection's jump type by hand, and nothing stopped it
+ * disagreeing with the game: a "gate" between two wormhole systems (reported
+ * from the field, and found in live data), or between two k-space systems that
+ * aren't actually neighbours. Both mislead routing and the chain view.
+ *
+ * The rules, all derived from map_stargates rather than guessed from class
+ * strings — a system with stargates is k-space, a pair joined by one are
+ * neighbours:
+ *
+ *   gate      — the two systems must be stargate neighbours in EVE
+ *   jumpgate  — both ends k-space (an Ansiblex is a nullsec structure)
+ *   cyno      — both ends k-space (a cyno can't be lit in wormhole space)
+ *   standard  — always allowed; a wormhole can join anything to anything
+ *
+ * Deliberately permissive where it can't know: an endpoint with no eve_system_id
+ * (a custom node, or an unmapped-wormhole placeholder) is unverifiable and
+ * passes, and so does everything if map_stargates hasn't been seeded — the same
+ * way the create route's gate auto-classifier already degrades.
+ */
+
+export interface EndpointEveIds {
+  sourceEveId: number | null;
+  targetEveId: number | null;
+}
+
+// map_stargates only changes on an SDE re-seed, so the "is it populated at all"
+// answer is worth holding briefly rather than asking on every write.
+const seeded = new TtlValue<boolean>(5 * 60_000);
+
+async function stargatesSeeded(): Promise<boolean> {
+  const hit = seeded.get();
+  if (hit !== null) return hit;
+  try {
+    const { rowCount } = await db.query(`SELECT 1 FROM map_stargates LIMIT 1`);
+    const populated = (rowCount ?? 0) > 0;
+    seeded.set(populated);
+    return populated;
+  } catch {
+    return false; // table absent → can't validate → allow
+  }
+}
+
+/** The endpoints' EVE ids for an existing connection (null when unresolved). */
+export async function connectionEndpointEveIds(
+  mapId: string, connectionId: string,
+): Promise<EndpointEveIds | null> {
+  const { rows } = await db.query<{ src: number | null; tgt: number | null }>(
+    `SELECT s.eve_system_id AS src, t.eve_system_id AS tgt
+       FROM map_connections c
+       JOIN map_systems s ON s.id = c.source_id
+       JOIN map_systems t ON t.id = c.target_id
+      WHERE c.id = $1 AND c.map_id = $2`,
+    [connectionId, mapId],
+  );
+  if (!rows.length) return null;
+  return { sourceEveId: rows[0].src, targetEveId: rows[0].tgt };
+}
+
+/** The endpoints' EVE ids for two map_systems rows (used on create). */
+export async function systemEveIds(sourceId: string, targetId: string): Promise<EndpointEveIds> {
+  const { rows } = await db.query<{ id: string; eve: number | null }>(
+    `SELECT id, eve_system_id AS eve FROM map_systems WHERE id = ANY($1::uuid[])`,
+    [[sourceId, targetId]],
+  );
+  const byId = new Map(rows.map((r) => [r.id, r.eve]));
+  return { sourceEveId: byId.get(sourceId) ?? null, targetEveId: byId.get(targetId) ?? null };
+}
+
+/**
+ * null when the type is allowed, else a human-readable reason for a 400.
+ */
+export async function connectionTypeError(
+  connectionType: string, ep: EndpointEveIds,
+): Promise<string | null> {
+  if (connectionType !== 'gate' && connectionType !== 'jumpgate' && connectionType !== 'cyno') {
+    return null;
+  }
+  const { sourceEveId, targetEveId } = ep;
+  if (sourceEveId == null || targetEveId == null) return null;  // unresolved endpoint
+  if (!(await stargatesSeeded())) return null;                  // no SDE to check against
+
+  if (connectionType === 'gate') {
+    const { rowCount } = await db.query(
+      `SELECT 1 FROM map_stargates
+        WHERE (system_id = $1 AND destination_system_id = $2)
+           OR (system_id = $2 AND destination_system_id = $1)
+        LIMIT 1`,
+      [sourceEveId, targetEveId],
+    );
+    return (rowCount ?? 0) > 0
+      ? null
+      : 'A stargate connection needs two systems that are stargate neighbours in EVE';
+  }
+
+  // jumpgate / cyno: both ends must be k-space, i.e. have stargates of their own.
+  const { rows } = await db.query<{ id: number }>(
+    `SELECT DISTINCT system_id AS id FROM map_stargates WHERE system_id = ANY($1::int[])`,
+    [[sourceEveId, targetEveId]],
+  );
+  const kspace = new Set(rows.map((r) => r.id));
+  if (kspace.has(sourceEveId) && kspace.has(targetEveId)) return null;
+  return connectionType === 'cyno'
+    ? 'A cynosural field cannot be lit in wormhole space'
+    : 'An Ansiblex jump bridge can only link k-space systems';
+}

--- a/web/src/components/map/MapCanvas.tsx
+++ b/web/src/components/map/MapCanvas.tsx
@@ -50,6 +50,7 @@ type AdjacentSystem = {
 import { CustomLabelDialog } from '../ui/CustomLabelDialog';
 import { PromptModal } from '../ui/PromptModal';
 import type { MapSystem, SystemIntel, SystemClass } from '../../types';
+import { isDefiniteWormholeHop, prefetchStargateNeighbors } from '../../utils/stargateAdjacency';
 import { api } from '../../api/client';
 import { truesecColor } from '../../utils/truesec';
 import { readUserSetting } from '../../hooks/useUserSetting';
@@ -941,9 +942,16 @@ export function MapCanvas() {
       if (isShareMode) return;
       e.preventDefault();
       e.stopPropagation();
+      // Warm this pair's stargate neighbours so the jump-type submenu can tell a
+      // real gate from an impossible one. Fire-and-forget and cached — if it
+      // hasn't landed by the time the menu renders, the option stays enabled and
+      // the server rejects it instead.
+      const conn = connections.find((c) => c.id === edge.id);
+      const srcEve = systems.find((x) => x.id === conn?.sourceId)?.eveSystemId;
+      if (srcEve != null) prefetchStargateNeighbors(srcEve);
       setContextMenu({ screenX: e.clientX, screenY: e.clientY, flowX: 0, flowY: 0, edgeId: edge.id, openedAt: Date.now() });
     },
-    [isShareMode],
+    [isShareMode, connections, systems],
   );
 
   // Click on the SVG edge path itself (the curve) selects the connection so
@@ -1007,6 +1015,22 @@ export function MapCanvas() {
     if (contextMenu.edgeId) {
       const conn = connections.find((c) => c.id === contextMenu.edgeId);
       const connType    = conn?.connectionType ?? 'standard';
+      // Jump types the SDE rules out for this pair, greyed rather than offered
+      // and rejected by the server: a stargate needs actual stargate
+      // neighbours, and an Ansiblex / cyno can't touch wormhole space.
+      // Conservative on both counts — an unresolved endpoint, or neighbours not
+      // in the client cache yet, leaves the option enabled and the server has
+      // the final say.
+      const edgeSrc = systems.find((x) => x.id === conn?.sourceId);
+      const edgeTgt = systems.find((x) => x.id === conn?.targetId);
+      const jspace = (c?: SystemClass) => c !== undefined && c !== 'unknown'
+        && !['HS', 'LS', 'NS', 'Pochven'].includes(c);
+      const touchesJspace = jspace(edgeSrc?.systemClass as SystemClass | undefined)
+        || jspace(edgeTgt?.systemClass as SystemClass | undefined);
+      const noGate = touchesJspace || (
+        edgeSrc?.eveSystemId != null && edgeTgt?.eveSystemId != null
+        && isDefiniteWormholeHop(edgeSrc.eveSystemId, edgeTgt.eveSystemId)
+      );
       const timeStatus  = conn?.timeStatus  ?? 'fresh';
       const massStatus  = conn?.massStatus  ?? 'stable';
       const eid = contextMenu.edgeId;
@@ -1028,16 +1052,19 @@ export function MapCanvas() {
             {
               label: t('ctxMenu.jumpStargate'),
               checked: connType === 'gate',
+              disabled: noGate && connType !== 'gate',
               action: () => updateConnection(eid, { connectionType: 'gate' }),
             },
             {
               label: t('ctxMenu.jumpAnsiblex'),
               checked: connType === 'jumpgate',
+              disabled: touchesJspace && connType !== 'jumpgate',
               action: () => updateConnection(eid, { connectionType: 'jumpgate' }),
             },
             {
               label: t('ctxMenu.jumpCyno'),
               checked: connType === 'cyno',
+              disabled: touchesJspace && connType !== 'cyno',
               action: () => updateConnection(eid, { connectionType: 'cyno' }),
             },
           ],


### PR DESCRIPTION
## Problem

From the field:

> Also gate connection with 2 WHs is impossible

Correct, and the map allowed it. A query against live data found one on a real user's map — `Jita <-> Umokka` marked as a stargate. Jita's actual gates are Maurasi, Perimeter, New Caldari, Sobaseki, Muvolailen, Niyabainen, Ikuchi. Umokka is not among them.

Two routes let it through:

- **Create** auto-classified `'standard'` to `'gate'` when the endpoints were stargate-adjacent, but an explicit `'gate'`/`'jumpgate'`/`'cyno'` from the client was *respected* with no check.
- **Update** validated `timeStatus`, `lifetimeExpiresAt`, `flagIcon` and `flagNote` — but `connectionType` went straight through the colMap into the column. So an edge that couldn't be *created* as a gate could still be *switched* to one.

## Rules

All derived from `map_stargates` rather than guessed from class strings — a system with stargates is k-space, a pair joined by one are neighbours:

| type | rule |
|---|---|
| `gate` | the two systems must be stargate neighbours in EVE |
| `jumpgate` | both ends k-space (an Ansiblex is a nullsec structure) |
| `cyno` | both ends k-space (a cyno can't be lit in wormhole space) |
| `standard` | unchanged — a wormhole can join anything to anything |

Deliberately permissive where it can't know: an endpoint with no `eve_system_id` (custom node, unmapped-wormhole placeholder) passes, and so does everything when `map_stargates` isn't seeded — the same way the existing auto-classifier already degrades on a missing table. Anything auto-classified as a gate passes by construction.

## UI

The jump-type context menu greys out what the rules would refuse, so the option isn't offered and then rejected — which also avoids a doomed PATCH being retried by the offline queue. Conservative in the other direction: an unresolved endpoint, or neighbours not yet in the client cache, leaves the entry enabled and lets the server decide. Opening the menu warms that cache for the pair.

The currently-set type is never disabled, so an existing bad edge can still be corrected to something valid.

## Scope

`/api/v1` deliberately doesn't expose connection writes ("those stay human-only"), so there's no third path to guard.

This does **not** clean up the two bad rows already in live data — that's the backfill PR.

## Testing

`tsc` clean both sides, server tests pass, `eslint` no new warnings (one pre-existing in MapCanvas), `yarn build` clean.