### PR TITLE
Systems: class, effect and statics come from the SDE, not the client

### DIFF
--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -14,6 +14,7 @@ import { audit } from '../services/audit.js';
 import { publishToMap } from '../services/mapEvents.js';
 import { streamMapEvents } from '../services/mapStream.js';
 import { listVisibleMaps, loadFullMap, loadSystemSignatures, loadSystemAnomalies, loadSystemStructures, CONNECTION_COLS } from '../services/mapRead.js';
+import { sdeSystemFacts } from '../services/sdeFacts.js';
 import { listConnectionJumps, recordConnectionJump, setConnectionJumpHot, clearConnectionJumps } from '../services/connectionJumps.js';
 import {
   createSignature, updateSignature, deleteSignature,
@@ -2427,6 +2428,15 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
 
   const resolvedEveId = await resolveEveSystemId(eveSystemId, name);
 
+  // Class / effect / statics are CCP's, not the caller's: when the system
+  // resolves to a real one the SDE row wins. Unresolved systems (custom nodes,
+  // unmapped-wormhole placeholders) keep what was sent — there's nothing to
+  // defer to, and those are exactly the ones that need to stay editable.
+  const facts = await sdeSystemFacts(resolvedEveId);
+  const finalClass   = facts?.systemClass ?? systemClass;
+  const finalEffect  = facts ? facts.effect  : (effect ?? 'none');
+  const finalStatics = facts ? facts.statics : (statics ?? []);
+
   try {
     await db.query(
       `INSERT INTO map_systems
@@ -2434,8 +2444,8 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
           position_x, position_y, status, is_home, locked, notes)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
        ON CONFLICT (id) DO NOTHING`,
-      [id, mapId, resolvedEveId, name, systemClass, effect ?? 'none',
-       statics ?? [], regionName ?? null, npcType ?? null,
+      [id, mapId, resolvedEveId, name, finalClass, finalEffect,
+       finalStatics, regionName ?? null, npcType ?? null,
        position?.x ?? 0, position?.y ?? 0,
        status ?? 'unknown', isHome ?? false, locked ?? false, notes ?? ''],
     );
@@ -2495,7 +2505,23 @@ mapsRouter.post('/:mapId/systems', async (req, res) => {
 
 mapsRouter.patch('/:mapId/systems/:systemId', async (req, res) => {
   const { mapId, systemId } = req.params;
-  const updates = req.body as Record<string, unknown>;
+  const updates = { ...(req.body as Record<string, unknown>) };
+
+  // Same rule as create: for a system that resolves to a real one, the SDE owns
+  // class / effect / statics, so drop any attempt to edit them rather than
+  // letting the map drift from the game. Everything else on the row is the
+  // user's (name, notes, status, home, lock, alias, intel).
+  if ('systemClass' in updates || 'effect' in updates || 'statics' in updates) {
+    const { rows } = await db.query<{ eve: number | null }>(
+      `SELECT eve_system_id AS eve FROM map_systems WHERE id = $1 AND map_id = $2`,
+      [systemId, mapId],
+    );
+    if (rows.length && await sdeSystemFacts(rows[0].eve)) {
+      delete updates.systemClass;
+      delete updates.effect;
+      delete updates.statics;
+    }
+  }
 
   // map camelCase → snake_case for the DB columns we accept
   const colMap: Record<string, string> = {

--- a/server/src/services/sdeFacts.ts
+++ b/server/src/services/sdeFacts.ts
@@ -1,0 +1,39 @@
+import { db } from '../db.js';
+
+/**
+ * The facts about a solar system that come from CCP, not from the user: its
+ * class, its wormhole effect, and its statics.
+ *
+ * These were accepted verbatim on every system write, so a real system could be
+ * relabelled into something that doesn't exist — a C5 pulsar saved as a C1
+ * wolf-rayet, or a C3 saved as hi-sec. Both were reported from the field and
+ * both were found in live data.
+ *
+ * They're derived, not entered: whenever a system resolves to a real EVE id the
+ * SDE row wins and whatever the client sent is ignored. Systems with no EVE id —
+ * custom nodes, and the unmapped-wormhole placeholders — have no SDE row to
+ * defer to, so they stay fully editable, which is what they're for.
+ */
+export interface SdeSystemFacts {
+  systemClass: string | null;
+  effect:      string;
+  statics:     string[];
+}
+
+export async function sdeSystemFacts(eveSystemId: number | null | undefined): Promise<SdeSystemFacts | null> {
+  if (eveSystemId == null) return null;
+  try {
+    const { rows } = await db.query<{ systemClass: string | null; effect: string | null; statics: string[] | null }>(
+      `SELECT class AS "systemClass", effect, statics FROM solar_systems WHERE id = $1`,
+      [eveSystemId],
+    );
+    if (!rows.length) return null;   // not in this SDE seed — nothing to defer to
+    return {
+      systemClass: rows[0].systemClass,
+      effect:      rows[0].effect ?? 'none',
+      statics:     rows[0].statics ?? [],
+    };
+  } catch {
+    return null;                     // SDE unavailable — keep the client's values
+  }
+}

--- a/web/src/components/ui/AddSystemModal.tsx
+++ b/web/src/components/ui/AddSystemModal.tsx
@@ -226,7 +226,7 @@ export function AddSystemModal({ position, onClose, onSubmit }: Props) {
               <Select
                 value={systemClass}
                 onChange={(v) => setSystemClass(v as SystemClass)}
-                disabled={loadingDetail}
+                disabled={loadingDetail || isSelected}
                 options={SYSTEM_CLASSES.map((c) => ({ value: c, label: CLASS_LABELS[c] }))}
               />
             </label>
@@ -236,7 +236,7 @@ export function AddSystemModal({ position, onClose, onSubmit }: Props) {
               <Select
                 value={effect}
                 onChange={(v) => setEffect(v as WormholeEffect)}
-                disabled={loadingDetail}
+                disabled={loadingDetail || isSelected}
                 options={WORMHOLE_EFFECTS.map((ef) => ({ value: ef, label: EFFECT_LABELS[ef] || t('addSystem.effectNone') }))}
               />
             </label>
@@ -251,6 +251,7 @@ export function AddSystemModal({ position, onClose, onSubmit }: Props) {
                 value={statics}
                 onChange={(e) => setStatics(e.target.value)}
                 placeholder={t('addSystem.staticsPlaceholder')}
+                readOnly
                 disabled={loadingDetail || !isSelected}
               />
             </label>


### PR DESCRIPTION
## Problem

From the field:

> I think validation of input is necessary, static WHs and other data are known so I think mapper shouldn't allow to change Lazerhawks home 5-5 pulsar to 1-5-1 wr or 3-L to highsec

It did allow it — `POST /:mapId/systems` took `systemClass`/`effect`/`statics` straight from the body, and the PATCH route accepted them through its colMap with no checks. Both examples are sitting in live data:

| system | SDE says | map says |
|---|---|---|
| J151909 | C5, pulsar, `{H296}` | C1, wolf_rayet, `{H296,Q317}` |
| J222222 | C3, none, `{U210}` | HS, wolf_rayet, `{U210}` |

## Fix

These are facts about the game, so they're derived rather than entered. When a system resolves to a real EVE id, the `solar_systems` row wins and the client's values are ignored — on create *and* update, so the API can't route around it.

Permissive where it should be:

- No EVE id (custom node, unmapped-wormhole placeholder) → nothing to defer to, stays fully editable. That's the whole point of those nodes.
- System not in this SDE seed → keeps the client's values rather than being blanked.

## Why this is safe — measured first

Of **13,748** systems on live maps that resolve to a real one, exactly **4** disagree with the SDE: the two above, plus two carrying stale statics from the old hardcoded starter map (`J160225` missing `N766`, `J164417` missing `O477`).

A further ~1,500 rows (about 375 accounts x 4 systems) are old starter-map rows with `eve_system_id` NULL, and each name shows exactly **one** statics variant — not a single user has ever edited one.

So nobody is using these fields to annotate, and the overlay takes nothing away.

## UI

The add-system modal still shows class, effect and statics for a resolved system but no longer lets them be edited. They only ever rendered for a resolved wormhole (`isSelected && isWormhole`), so the custom-node path is untouched.

## Scope

Existing rows are not corrected here — that's the backfill PR.

## Testing

`tsc` clean both sides, server tests pass, eslint clean, `yarn build` clean.