### PR TITLE
Run the SDE system backfill on boot, not from a manual script

### DIFF
--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -31,6 +31,14 @@ async function encryptLegacyTokens() {
 // connections whose jump type the SDE contradicts, which this pass leaves
 // alone.
 async function syncSystemFactsFromSde() {
+  // solar_systems is created by the SDE importer (setup-db), NOT by migrate, so
+  // on a database that has never imported it the table simply isn't there —
+  // a fresh self-host, and the integration-test databases. Querying it anyway
+  // throws 42P01 and takes the whole migration (and the server start) with it.
+  const { rows: [sde] } = await db.query<{ present: boolean }>(
+    `SELECT to_regclass('public.solar_systems') IS NOT NULL AS present`);
+  if (!sde?.present) return;
+
   // Sorted so a difference in order alone doesn't count as drift.
   const sorted = (col: string) =>
     `COALESCE((SELECT array_agg(x ORDER BY x) FROM unnest(${col}) x), '{}')`;

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -19,6 +19,75 @@ async function encryptLegacyTokens() {
   console.log(`Encrypted OAuth tokens for ${rows.length} legacy user row(s)`);
 }
 
+// One-shot pass that makes existing map systems agree with the SDE. Idempotent
+// and self-limiting — both statements only match rows that are still wrong, so
+// after the first boot they update nothing and stay silent. Safe on a database
+// with no SDE seeded: every join simply finds nothing.
+//
+// This lives here rather than in scripts/backfill-system-facts.ts because
+// deployments are docker builds — nobody runs a manual script inside a
+// container, and self-hosters would never see one. The script remains for
+// inspecting a database on demand — it dry-runs by default and also reports
+// connections whose jump type the SDE contradicts, which this pass leaves
+// alone.
+async function syncSystemFactsFromSde() {
+  // Sorted so a difference in order alone doesn't count as drift.
+  const sorted = (col: string) =>
+    `COALESCE((SELECT array_agg(x ORDER BY x) FROM unnest(${col}) x), '{}')`;
+
+  // J-code nodes stored with no eve_system_id — the old hardcoded starter map
+  // wrote thousands of them. Detached placeholders: no routing, no ESI identity,
+  // and whatever statics the seeder happened to carry. Only ^J\d{6}$ names are
+  // matched: a J-code is unambiguous, whereas resolving arbitrary names risks
+  // re-pointing a custom node someone named after a real system.
+  //
+  // map_systems is unique on (map_id, eve_system_id), so rows whose map already
+  // holds that system are left alone, and where several rows in one map would
+  // resolve to the same system only the oldest is taken.
+  const resolved = await db.query(`
+    UPDATE map_systems ms
+       SET eve_system_id = c.eve_id,
+           system_class  = c.class,
+           effect        = c.effect,
+           statics       = c.statics
+      FROM (
+        SELECT ms2.id,
+               ss.id AS eve_id,
+               ss.class,
+               COALESCE(ss.effect, 'none') AS effect,
+               COALESCE(ss.statics, '{}')  AS statics,
+               ROW_NUMBER() OVER (PARTITION BY ms2.map_id, ss.id
+                                  ORDER BY ms2.created_at, ms2.id) AS rn
+          FROM map_systems ms2
+          JOIN solar_systems ss ON ss.name = ms2.name
+         WHERE ms2.eve_system_id IS NULL
+           AND ms2.name ~ '^J[0-9]{6}$'
+           AND NOT EXISTS (SELECT 1 FROM map_systems x
+                            WHERE x.map_id = ms2.map_id AND x.eve_system_id = ss.id)
+      ) c
+     WHERE ms.id = c.id AND c.rn = 1`);
+  if ((resolved.rowCount ?? 0) > 0) {
+    console.log(`Resolved ${resolved.rowCount} placeholder wormhole system(s) to their real system`);
+  }
+
+  // Systems that resolve to a real one but disagree with it — class, effect or
+  // statics typed over before those fields became SDE-derived.
+  const resynced = await db.query(`
+    UPDATE map_systems ms
+       SET system_class = ss.class,
+           effect       = COALESCE(ss.effect, 'none'),
+           statics      = COALESCE(ss.statics, '{}')
+      FROM solar_systems ss
+     WHERE ss.id = ms.eve_system_id
+       AND (upper(ms.system_class) IS DISTINCT FROM upper(ss.class)
+         OR COALESCE(ms.effect, 'none') IS DISTINCT FROM COALESCE(ss.effect, 'none')
+         OR ${sorted('ms.statics')} IS DISTINCT FROM ${sorted('ss.statics')})`);
+  if ((resynced.rowCount ?? 0) > 0) {
+    console.log(`Re-synced ${resynced.rowCount} map system(s) to the SDE`);
+  }
+
+}
+
 export async function migrate() {
   await db.query(`
     CREATE TABLE IF NOT EXISTS users (
@@ -965,4 +1034,5 @@ export async function migrate() {
   `);
 
   await encryptLegacyTokens();
+  await syncSystemFactsFromSde();
 }


### PR DESCRIPTION
## Problem

The backfill shipped in v3.34.0 as `scripts/backfill-system-facts.ts` — a manual command. That doesn't work for how this is actually deployed:

> People are running in docker containers and the build runs everything

Right. The container rebuilds and starts; a script sitting in the image never executes, and a self-hoster would never know it was there. So the ~1,500 detached placeholder systems and the handful of drifted ones stay broken everywhere except a machine where someone read the release notes and typed the command.

## Fix

It runs from `migrate()` now, right after `encryptLegacyTokens` — the existing precedent in this codebase for a one-shot data fix that happens on every boot.

Two statements, both self-limiting: they only match rows that are still wrong, so after the first boot they update nothing and log nothing. A database with no SDE seeded is a no-op as well, since every join finds nothing.

## Verified against a real database

Not just typechecked:

- On a clean database both statements report `UPDATE 0` — the steady-state path.
- Against deliberately broken rows, in a rolled-back transaction:
  - placeholder `J164417` (no eve id, statics `{B274}`) -> real system `31000355`, statics `{B274,O477}`
  - a system typed over as `C1 / wolf_rayet / {H296,Q317}` -> back to its real `NS / none / {}`
- Rollback confirmed clean afterwards; the dev database is unchanged.

## Deliberately left out

The boot pass no longer counts connections whose jump type the SDE contradicts. That was two joins against `map_stargates` on every start, to warn about something it won't fix anyway — and with one real instance in production it isn't worth the boot cost. The script still reports them on demand, and #618 stops new ones being created.

`scripts/backfill-system-facts.ts` stays as the inspection tool: dry-run by default, still lists the connection problems.

## Testing

`tsc` clean, server tests pass.