### PR TITLE
Pilots Online: cards instead of a single row

### DIFF
--- a/web/src/components/ui/PilotsOnlinePane.tsx
+++ b/web/src/components/ui/PilotsOnlinePane.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { charPortrait } from '../../utils/eveImages';
+import { CLASS_COLORS } from '../../data/wormholes';
+import type { SystemClass } from '../../types';
 import { usePilotsOnline } from '../../hooks/usePilotsOnline';
 import { useSystemAlias } from '../../hooks/useSystemAlias';
 import { timeAgo } from '../../i18n/format';
@@ -62,27 +64,46 @@ export function PilotsOnlinePane() {
                   : p.shipTypeName)
               : null;
             const where = p.systemName ? aliasName(p.systemName) : null;
+            const classColor = p.systemClass
+              ? CLASS_COLORS[p.systemClass as SystemClass]
+              : undefined;
             return (
-              <li key={p.characterId} className="fleet-pane__row">
+              <li key={p.characterId} className="pilots-card">
                 <img
-                  className="fleet-pane__avatar"
-                  src={charPortrait(p.characterId, 32)}
+                  className="pilots-card__avatar"
+                  src={charPortrait(p.characterId, 64)}
                   alt=""
                   loading="lazy"
                 />
-                <span className="fleet-pane__name" title={p.characterName}>{p.characterName}</span>
-                <span className="fleet-pane__loc" title={ship ?? undefined}>
-                  {ship ?? DASH}
-                </span>
-                <span
-                  className="fleet-pane__loc"
-                  title={p.regionName ? `${where} — ${p.regionName}` : undefined}
-                >
-                  {where ?? t('pilotsOnline.unknownLoc')}
-                </span>
-                <span className="fleet-pane__jumps" title={new Date(p.lastSeenAt).toLocaleString()}>
-                  {timeAgo(t, new Date(p.lastSeenAt))}
-                </span>
+                <div className="pilots-card__body">
+                  {/* The name gets the whole first line. It's the field you
+                      scan for, and sharing the line with the age cost it ~50px
+                      in a 239px sidebar — enough to truncate most EVE names.
+                      The age moves to the location line, where losing a few
+                      characters off a region name matters far less. */}
+                  <div className="pilots-card__name" title={p.characterName}>
+                    {p.characterName}
+                  </div>
+                  <div className="pilots-card__ship" title={ship ?? undefined}>
+                    {ship ?? DASH}
+                  </div>
+                  <div className="pilots-card__line">
+                    <span className="pilots-card__loc">
+                      <span style={classColor ? { color: classColor } : undefined}>
+                        {where ?? t('pilotsOnline.unknownLoc')}
+                      </span>
+                      {p.regionName && (
+                        <span className="pilots-card__region"> {p.regionName}</span>
+                      )}
+                    </span>
+                    <span
+                      className="pilots-card__age"
+                      title={new Date(p.lastSeenAt).toLocaleString()}
+                    >
+                      {timeAgo(t, new Date(p.lastSeenAt))}
+                    </span>
+                  </div>
+                </div>
               </li>
             );
           })}

--- a/web/src/styles/scout.css
+++ b/web/src/styles/scout.css
@@ -361,6 +361,68 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* ── Pilots Online cards ──────────────────────────────────────────────────
+   The fleet row packs name / location / jumps onto one line, which works for
+   three short fields. Pilots Online carries four — name, ship, system and how
+   long ago — and squeezing those into a row truncated every one of them (the
+   name lost outright, since .fleet-pane__loc alone claims 42% twice over).
+   A card gives each its own line and full width. Sizes use --font-scale like
+   the rest of the panel so they follow the user's own scaling. */
+.pilots-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 6px;
+  background: var(--surface-raised);
+}
+.pilots-card:hover { background: var(--surface-hover); }
+.pilots-card__avatar {
+  width: calc(40px * var(--font-scale, 1));
+  height: calc(40px * var(--font-scale, 1));
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.pilots-card__body {
+  flex: 1;
+  min-width: 0;          /* lets the ellipsis work inside a flex child */
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.pilots-card__line {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+  min-width: 0;
+}
+.pilots-card__name {
+  min-width: 0;
+  max-width: 100%;
+  color: var(--text-default);
+  font-size: calc(13px * var(--font-scale, 1));
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pilots-card__age {
+  flex-shrink: 0;
+  color: var(--text-faintest);
+  font-size: calc(11px * var(--font-scale, 1));
+  white-space: nowrap;
+}
+.pilots-card__ship,
+.pilots-card__loc {
+  color: var(--text-subtle);
+  font-size: calc(12px * var(--font-scale, 1));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pilots-card__region { color: var(--text-faintest); }
+
 .fleet-pane__jumps {
   flex-shrink: 0;
   color: #9fb3cd;


### PR DESCRIPTION
## Problem

The row layout was wrong for this data, and your screenshot showed it plainly — four fields on one line at a 239px sidebar width truncated all of them, and the pilot's **name** was squeezed out entirely:

```
[o]  Capsule – Ge…   At…   13s ago
```

Reusing `.fleet-pane__row` was my mistake. It's built for three short fields, and `.fleet-pane__loc` alone claims `max-width: 42%` — which I then used twice.

## Now

Portrait beside three full-width lines:

```
Aurelia Vanguardsson
Stiletto · Scout One — Chain Watch
J150137  B-R00005                41s ago
```

The name gets the whole first line. It shared it with the age in my first pass, which still cost ~50px and truncated most EVE names ("Aurelia Vangu…"), so the age moved to the location line — losing a few characters off a region name matters far less than losing the name. The system is coloured by class, matching the rest of the app.

New `.pilots-card-*` classes rather than edits to the fleet ones, so the Fleet panel is untouched. Sizes go through `--font-scale` like the surrounding panel, so they follow your scaling rather than overriding it.

## Verified in a browser this time

I shipped the last one without looking at it, which is how the broken layout got through. This was checked against the real stylesheet at the real sidebar width, with the endpoint stubbed for content that stresses it: a long name, a long ship name, and a pilot with no ship and no known location (falls back to `—` and "Unknown").

`tsc`, eslint and build all clean.