### PR TITLE
Clones panel: waypoint buttons, implant list, and no dash on the medical clone

### DIFF
--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -348,11 +348,23 @@ characterRouter.get('/clones', async (req, res) => {
 
     const homeSystemId = await locationToSystemId(userId, data.home_location?.location_id, data.home_location?.location_type);
     const jumps = await Promise.all((data.jump_clones ?? []).map(async (jc) => ({
-      id:         jc.jump_clone_id,
-      name:       jc.name ?? null,
-      implants:   (jc.implants ?? []).length,
-      systemId:   await locationToSystemId(userId, jc.location_id, jc.location_type),
+      id:          jc.jump_clone_id,
+      name:        jc.name ?? null,
+      implantIds:  jc.implants ?? [],
+      systemId:    await locationToSystemId(userId, jc.location_id, jc.location_type),
     })));
+
+    // Implant NAMES come from the SDE, not another ESI call. The type ids are
+    // already in the /clones/ payload under esi-clones.read_clones — the separate
+    // read_implants scope is for the ACTIVE clone's implants, which this panel
+    // doesn't show, so it isn't needed.
+    const implantIds = [...new Set(jumps.flatMap((j) => j.implantIds))];
+    const implantName = new Map<number, string>();
+    if (implantIds.length) {
+      const { rows } = await db.query<{ id: number; name: string }>(
+        `SELECT id, name FROM item_types WHERE id = ANY($1::int[])`, [implantIds]);
+      for (const r of rows) implantName.set(r.id, r.name);
+    }
 
     // Enrich every resolved system in one query.
     const ids = [homeSystemId, ...jumps.map((j) => j.systemId)].filter((x): x is number => x != null);
@@ -370,7 +382,16 @@ characterRouter.get('/clones', async (req, res) => {
       enabled: true,
       lastCloneJumpDate: data.last_clone_jump_date ?? null,
       home: enrich(homeSystemId),
-      jumpClones: jumps.map((j) => ({ id: j.id, name: j.name, implants: j.implants, system: enrich(j.systemId) })),
+      jumpClones: jumps.map((j) => ({
+        id:     j.id,
+        name:   j.name,
+        system: enrich(j.systemId),
+        // Sorted by name so the list reads consistently; an id the SDE doesn't
+        // know (a very new implant) still shows rather than vanishing.
+        implants: j.implantIds
+          .map((id) => ({ typeId: id, name: implantName.get(id) ?? `Type ${id}` }))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      })),
     };
     clonesCache.set(userId, payload);
     res.json(payload);

--- a/web/src/components/ui/ClonesPane.tsx
+++ b/web/src/components/ui/ClonesPane.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useClones } from '../../hooks/useClones';
 import { useRoute } from '../../hooks/useRoute';
@@ -8,6 +8,9 @@ import { CLASS_COLORS } from '../../data/wormholes';
 import type { SystemClass } from '../../types';
 import { jumps as jumpsLabel } from '../../i18n/format';
 import { DASH } from '../../i18n/format';
+import { setWaypoint, canSetAutopilot } from './routeUi';
+import { MapPinSimpleIcon, PathIcon, CaretDownIcon, CaretRightIcon } from '../../icons';
+import type { Implant } from '../../hooks/useClones';
 
 // Where this pilot's clones are, and how far each is from where they're standing.
 // Medical clone first — it's the one that decides where you wake up — then jump
@@ -18,8 +21,19 @@ export function ClonesPane() {
   const aliasName = useSystemAlias();
   const origin = useRouteOrigin();
 
+  // Which clones have their implant list expanded.
+  const [open, setOpen] = useState<Set<string>>(new Set());
+  const toggle = (key: string) => setOpen((prev) => {
+    const next = new Set(prev);
+    if (next.has(key)) next.delete(key); else next.add(key);
+    return next;
+  });
+
   const rows = useMemo(() => [
-    ...(clones.home ? [{ key: 'home', label: t('clones.medical'), system: clones.home, implants: null as number | null }] : []),
+    // The medical clone carries no implant list: it's where you RESPAWN, and a
+    // fresh clone has none. Implants live in the body you're flying, which is a
+    // different endpoint and a scope we deliberately don't request.
+    ...(clones.home ? [{ key: 'home', label: t('clones.medical'), system: clones.home, implants: [] as Implant[] }] : []),
     ...clones.jumpClones.map((jc) => ({
       key: `jc-${jc.id}`,
       label: jc.name || t('clones.jumpClone'),
@@ -51,6 +65,10 @@ export function ClonesPane() {
           const sys = r.system;
           const route = sys ? routes[String(sys.eveSystemId)] : undefined;
           const color = sys?.systemClass ? CLASS_COLORS[sys.systemClass as SystemClass] : undefined;
+          // Same rule the scout pane uses: a wormhole-class destination can't be
+          // an autopilot waypoint, and neither can a clone we couldn't resolve.
+          const canAutopilot = !!sys && canSetAutopilot(route);
+          const isOpen = open.has(r.key);
           return (
             <li key={r.key} className="pilots-card">
               <div className="pilots-card__body">
@@ -64,14 +82,65 @@ export function ClonesPane() {
                     : t('clones.unknownLocation')}
                   {sys?.regionName && <span className="pilots-card__region"> {sys.regionName}</span>}
                 </div>
+
                 <div className="pilots-card__line">
-                  <span className="pilots-card__loc">
-                    {r.implants != null ? t('clones.implants', { count: r.implants }) : DASH}
-                  </span>
+                  {/* Implant count doubles as the disclosure control when there's
+                      something to disclose; a clone with none is plain text so
+                      it doesn't invite a click that would open nothing. */}
+                  {r.implants.length > 0 ? (
+                    <button
+                      type="button"
+                      className="clones-card__implant-toggle"
+                      onClick={() => toggle(r.key)}
+                      aria-expanded={isOpen}
+                    >
+                      {isOpen
+                        ? <CaretDownIcon size={11} weight="bold" />
+                        : <CaretRightIcon size={11} weight="bold" />}
+                      {t('clones.implants', { count: r.implants.length })}
+                    </button>
+                  ) : (
+                    <span className="pilots-card__loc">
+                      {r.key === 'home' ? DASH : t('clones.implants', { count: 0 })}
+                    </span>
+                  )}
                   <span className="pilots-card__age">
                     {route ? jumpsLabel(t, route.jumps) : DASH}
                   </span>
                 </div>
+
+                {isOpen && (
+                  <ul className="clones-card__implants">
+                    {r.implants.map((im) => (
+                      <li key={im.typeId} title={im.name}>{im.name}</li>
+                    ))}
+                  </ul>
+                )}
+
+                {sys && (
+                  <div className="clones-card__actions">
+                    <button
+                      type="button"
+                      className="sys-btn scout-row__btn scout-row__btn--icon"
+                      onClick={() => setWaypoint(sys.eveSystemId, sys.name ?? '', true)}
+                      disabled={!canAutopilot}
+                      aria-label={t('waypoint.setDestination')}
+                      data-tooltip={canAutopilot ? t('waypoint.setDestination') : t('route.jspaceNoWaypoint')}
+                    >
+                      <MapPinSimpleIcon size={14} weight="regular" color="#3ddc84" />
+                    </button>
+                    <button
+                      type="button"
+                      className="sys-btn scout-row__btn scout-row__btn--icon"
+                      onClick={() => setWaypoint(sys.eveSystemId, sys.name ?? '', false)}
+                      disabled={!canAutopilot}
+                      aria-label={t('waypoint.addWaypoint')}
+                      data-tooltip={canAutopilot ? t('waypoint.addWaypoint') : t('route.jspaceNoWaypoint')}
+                    >
+                      <PathIcon size={14} weight="regular" color="#5a9af8" />
+                    </button>
+                  </div>
+                )}
               </div>
             </li>
           );

--- a/web/src/components/ui/ClonesPane.tsx
+++ b/web/src/components/ui/ClonesPane.tsx
@@ -99,10 +99,14 @@ export function ClonesPane() {
                         : <CaretRightIcon size={11} weight="bold" />}
                       {t('clones.implants', { count: r.implants.length })}
                     </button>
+                  ) : r.key === 'home' ? (
+                    // Nothing at all for the medical clone. It's where you
+                    // respawn, so it has no implants by definition — printing a
+                    // dash or a zero implies the number means something here.
+                    // The empty span keeps the jump count right-aligned.
+                    <span />
                   ) : (
-                    <span className="pilots-card__loc">
-                      {r.key === 'home' ? DASH : t('clones.implants', { count: 0 })}
-                    </span>
+                    <span className="pilots-card__loc">{t('clones.implants', { count: 0 })}</span>
                   )}
                   <span className="pilots-card__age">
                     {route ? jumpsLabel(t, route.jumps) : DASH}

--- a/web/src/hooks/useClones.ts
+++ b/web/src/hooks/useClones.ts
@@ -7,10 +7,16 @@ export interface CloneSystem {
   systemClass: string | null;
   regionName:  string | null;
 }
+export interface Implant {
+  typeId: number;
+  name:   string;
+}
 export interface JumpClone {
   id:       number;
   name:     string | null;
-  implants: number;
+  /** The implants plugged into THIS clone, from the /clones/ payload — not the
+   *  active body's, which would need a separate scope we don't request. */
+  implants: Implant[];
   system:   CloneSystem | null;
 }
 export interface Clones {

--- a/web/src/styles/scout.css
+++ b/web/src/styles/scout.css
@@ -467,3 +467,40 @@
   background: rgba(200, 164, 90, 0.08);
 }
 
+/* ── Clones panel ─────────────────────────────────────────────────────────
+   Builds on the pilots-card layout; only the bits unique to clones live here. */
+.clones-card__implant-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--text-subtle);
+  font-size: calc(12px * var(--font-scale, 1));
+  font-family: inherit;
+}
+.clones-card__implant-toggle:hover { color: var(--text-default); }
+.clones-card__implants {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0 0 0 14px;   /* aligns under the caret, not the card edge */
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  color: var(--text-faint);
+  font-size: calc(12px * var(--font-scale, 1));
+}
+/* Implant names are long ("Ocular Filter - Improved"); a docked sidebar can't
+   show them whole, and the title attribute carries the full text. */
+.clones-card__implants li {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.clones-card__actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}


### PR DESCRIPTION
The three panel changes you asked for after #632 had already merged. They were committed to that branch afterwards, which meant they never reached `qa` and CI never ran on them — a closed PR fires no `pull_request` event. Cherry-picked onto `qa` here.

## Changes

**Set destination / add waypoint on each clone.** Same two icon buttons and the same autopilot rule as the scout panes — disabled rather than broken when a clone's location couldn't be resolved or the destination can't take a waypoint.

**Implant count is now a disclosure.** Clones with implants expand to list them by name. Clones without stay as plain text, so there's nothing to click that would open nothing.

**The medical clone shows nothing at all in the implant slot** — no dash, no zero. It's where you respawn, so it has no implants by definition, and either symbol implies the number means something. An empty span keeps the jump count right-aligned. Jump clones with none still show "0 implants", where zero is a real answer.

## No second scope

Contrary to first impressions, `esi-clones.read_implants.v1` is **not** needed. `/characters/{id}/clones/` returns `jump_clones[].implants` under `esi-clones.read_clones.v1` — that's where the counts already on screen come from. `read_implants` covers `/characters/{id}/implants/`, the implants in your *active* body, which this panel doesn't show.

Implant **names** resolve from `item_types` in the SDE, so the list adds no ESI call either.

## Verified against real data

Checked in a browser against the live account: 11 jump clones, names resolving (`Low-grade Virtue Alpha/Beta/Delta`), the implant list expanding, buttons present on every card, and the medical clone rendering as name / location / jumps with an empty implant slot.

`tsc` clean both sides, eslint clean, build clean, 136 server tests pass.