### PR TITLE
Bump qs past two advisories (Dependabot 34, 35)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "extract-wormholes": "tsx scripts/extract-wormholes.ts"
   },
   "resolutions": {
-    "qs": "^6.15.2",
+    "qs": "^6.16.0",
     "esbuild": "^0.28.1",
     "undici": "^7.29.0",
     "body-parser": "^1.20.6",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1525,12 +1525,13 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-qs@^6.14.1, qs@^6.15.2, qs@~6.14.0, qs@~6.15.1:
-  version "6.15.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
-  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
+qs@^6.14.1, qs@^6.16.0, qs@~6.14.0, qs@~6.15.1:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
-    side-channel "^1.1.0"
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -1638,9 +1639,9 @@ setprototypeof@1.2.0, setprototypeof@~1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-side-channel-list@^1.0.0:
+side-channel-list@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
   integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
   dependencies:
     es-errors "^1.3.0"
@@ -1667,14 +1668,14 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz"
-  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
   dependencies:
     es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 


### PR DESCRIPTION
Two open Dependabot alerts, both `qs`, both fixed in 6.16.0.

| alert | severity | issue | vulnerable |
|---|---|---|---|
| #34 | medium | DoS via attacker-controlled `isBuffer` | `>= 2.2.5, < 6.16.0` |
| #35 | medium | array-limit bypass via bracket-key comma parsing | `>= 6.14.2, <= 6.15.3` |

## These matter more than the browserslist one

`qs` arrives through **express** and **body-parser**:

```
info => Found "qs@6.15.2"
   - "express" depends on it
   - Hoisted from "express#body-parser#qs"
```

So it parses the query string of every request — runtime code on a live site, reachable from unauthenticated input. Not a dev-time tool like browserslist.

Worth noting how it happened: the existing resolution pinned `^6.15.2`, which sits inside **both** vulnerable ranges. The pin that keeps other transitive deps in line was holding this one *on* a vulnerable version. Raised to `^6.16.0`.

## Scope of the change

Lockfile diff is `qs` 6.15.2 -> 6.16.0 plus its own two dependencies (`side-channel` 1.1.0 -> 1.1.1, `side-channel-list`). Nothing unrelated moved. Installed with yarn.

CodeQL is clean — 0 open code-scanning alerts — so these two were the whole of it.

## Testing

`tsc` clean, 136 server tests pass.

**One thing to flag rather than bury:** `mapsContributor` > *"may NOT move or rename a system"* failed on one full run during this work. It also failed once earlier today **before** this change, passes in isolation (12/12), and passed three consecutive full runs afterwards — so it's a pre-existing flake, not fallout from the bump. It's in the contributor permission suite though, where a random failure could mask a real regression, so it's worth chasing on its own. Happy to take it.