### PR TITLE
Refuse to start a test run while another holds the test database

### DIFF
--- a/server/src/test/globalSetup.ts
+++ b/server/src/test/globalSetup.ts
@@ -1,0 +1,76 @@
+// Runs ONCE per `yarn test` invocation (vitest globalSetup), in the main process
+// — before any worker, and separately from vitest.setup.ts.
+//
+// Why this exists: every integration suite shares ONE `*_test` database and
+// TRUNCATEs it between tests. Nothing stopped two test runs from overlapping on
+// the same machine (a stray `yarn test` still finishing, a backgrounded run, two
+// terminals), and when they do, each run's TRUNCATE wipes the other's fixtures
+// mid-request. That surfaces as failures scattered across unrelated suites — or,
+// when the overlap is brief, as a SINGLE assertion failing for no visible reason
+// and passing on the next run. It reads exactly like a flaky test and isn't one.
+//
+// So: take a session-level advisory lock for the whole run. A second concurrent
+// run fails immediately with an explanation instead of silently corrupting both.
+// The lock is held by a dedicated connection, so it cannot go stale — if the run
+// crashes or is killed, the connection drops and Postgres releases it.
+//
+// CI is unaffected: each job has its own database and the lock is always free.
+import { config as loadDotenv } from 'dotenv';
+import { Client } from 'pg';
+
+// Arbitrary but fixed key, scoped per database — the lock only collides with
+// another run against the same test DB.
+const LOCK_KEY = 0x6e78_7401; // "nxt" + 1
+
+let holder: Client | null = null;
+
+export async function setup(): Promise<void> {
+  loadDotenv();
+
+  // Mirror vitest.setup.ts's redirect: guard the same database the workers use.
+  const current = process.env.PG_DB ?? 'eve_nexum';
+  const database = process.env.PG_TEST_DB ?? (current.endsWith('_test') ? current : `${current}_test`);
+
+  const client = new Client({
+    host:     process.env.PG_HOST ?? 'localhost',
+    port:     parseInt(process.env.PG_PORT ?? '5432'),
+    database,
+    user:     process.env.PG_USER,
+    password: process.env.PG_PASSWORD,
+    connectionTimeoutMillis: 5_000,
+  });
+
+  try {
+    await client.connect();
+  } catch {
+    // No test DB reachable. The integration suites already skip in that case
+    // (ensureIntegrationDb returns false), so there is nothing to guard.
+    await client.end().catch(() => {});
+    return;
+  }
+
+  const { rows } = await client.query<{ locked: boolean }>(
+    'SELECT pg_try_advisory_lock($1) AS locked', [LOCK_KEY],
+  );
+
+  if (!rows[0].locked) {
+    await client.end().catch(() => {});
+    throw new Error(
+      `Another test run is already using the "${database}" database.\n` +
+      'The integration suites TRUNCATE shared tables, so two runs at once corrupt each\n' +
+      "other's fixtures and fail in unrelated places. Wait for the other run to finish\n" +
+      '(or kill it: pkill -f vitest) and try again.',
+    );
+  }
+
+  holder = client; // hold the connection — and the lock — for the whole run
+}
+
+export async function teardown(): Promise<void> {
+  if (!holder) return;
+  // Ending the connection releases the advisory lock; unlock first so the intent
+  // is explicit rather than a side effect of disconnecting.
+  await holder.query('SELECT pg_advisory_unlock($1)', [LOCK_KEY]).catch(() => {});
+  await holder.end().catch(() => {});
+  holder = null;
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     // Loads .env, relaxes prod guards, and redirects the pool to a *_test DB.
     setupFiles: ['./vitest.setup.ts'],
+    // Runs once per invocation: refuses to start when another test run already
+    // holds the shared *_test database (see the file for why that matters).
+    globalSetup: ['./src/test/globalSetup.ts'],
     // The *.integration.test.ts suites share one test database and TRUNCATE
     // between tests, so files must not run in parallel or they clobber each
     // other. The suite is small, so serial files cost little.


### PR DESCRIPTION
## What this chases

A test in the contributor permission suite -- `mapsContributor` > *"may NOT move or rename a system"* -- failed twice locally and could not be reproduced afterwards. This is the cause, and it was never in that test.

## What it turned out to be

Every integration suite shares one `*_test` database and `TRUNCATE`s it between tests. Nothing stopped two runs overlapping on the same machine: a backgrounded run still finishing, two terminals, a stray process. When they overlap, each run's `TRUNCATE` wipes the other's fixtures mid-request.

Reproduced deliberately by starting three overlapping runs -- 23, 28 and 11 failures, scattered across suites that have nothing to do with each other:

```
race 1: Tests  23 failed | 113 passed (136)
race 2: Tests  28 failed | 108 passed (136)
race 3: Tests  11 failed |  71 passed (82)
```

A long overlap looks like that. A *brief* one drops a single assertion in whichever test happened to be mid-flight, and it passes on the next run -- which is exactly what was seen.

## Why it's worth a guard rather than a shrug

The failure is indistinguishable from a flaky test, so the habit it builds is re-running and moving on. In a permission suite that habit is the actual risk: it trains you to wave through the assertions that would catch a real authz regression.

## The fix

A vitest `globalSetup` takes a session-level advisory lock for the run. A second concurrent run against the same database now fails immediately:

```
Error: Another test run is already using the "eve_nexum_test" database.
The integration suites TRUNCATE shared tables, so two runs at once corrupt each
other's fixtures and fail in unrelated places. Wait for the other run to finish
(or kill it: pkill -f vitest) and try again.
```

The lock is held by a dedicated connection, so it cannot go stale -- if the run crashes or is killed, Postgres drops the connection and releases it. No cleanup step to forget.

## Verified

| Path | Result |
|---|---|
| Normal run | `Tests 136 passed (136)` |
| Concurrent run started 5s into another | intruder exits 1 with the message above; **incumbent still `136 passed`** |
| Lock after the run ends | `0` advisory locks held |
| No Postgres reachable (`PG_HOST=127.0.0.1 PG_PORT=1`) | `46 passed | 90 skipped` -- guard is a no-op, unit suites still run |
| `tsc --noEmit` | clean |

## Ruled out along the way

Worth recording, since these were the plausible suspects:

- **The `qs` bump** (#634) -- it failed once *before* that change.
- **A cold database** -- dropped and recreated `eve_nexum_test`, ran clean.
- **Parallel suite execution** -- `fileParallelism: false`, files are already serial.
- **Connection-pool exhaustion** -- peak was 1 connection during a full run, against a pool max of 20.
- **A product bug in the PATCH handler** -- 10 consecutive clean full runs.

## Not reproducible in CI, by design

CI gives each job its own database, so the lock is always free there and nothing changes. Consistent with the record: of the last 30 CI runs, the only 2 failures were the `solar_systems` errors already fixed -- this flake has never appeared in CI, only locally.