### PR TITLE
Stop Pilots Online leaking presence between strangers on a public install

### DIFF
--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -264,6 +264,12 @@ async function readCharacterSystem(userId: number, characterId: number): Promise
 // appearing on a list of everyone's whereabouts would make that setting a lie.
 const PILOTS_ONLINE_WINDOW_MIN = 5;
 
+// EVE allocates NPC corporation ids below 2,000,000; player corporations start
+// at 98,000,000. The rookie/starter corps in that range hold tens of thousands
+// of unrelated pilots, so an NPC corp is not an organisation and must never be
+// treated as one for presence.
+const MIN_PLAYER_CORP_ID = 2_000_000;
+
 // ── Clone locations ──────────────────────────────────────────────────────────
 // Where a character's medical clone and jump clones are. Two consumers: the
 // Clones panel, and location tracking — which needs to know a clone jump from a
@@ -405,11 +411,22 @@ characterRouter.get('/pilots-online', async (req, res) => {
   const me = req.session;
   if (!me.userId) { res.status(401).json({ error: 'Not authenticated' }); return; }
 
-  // Alliance installs scope to the alliance, corp installs to the corp. Neither
-  // set means a solo install, where there is nobody else to list.
-  const scopeCol = config.allianceMode && me.userAllianceId ? 'alliance_id' : 'corp_id';
-  const scopeVal = scopeCol === 'alliance_id' ? me.userAllianceId : me.userCorpId;
+  // Presence is an ORG feature: it only means anything where Nexum is deployed
+  // for a corp or an alliance. This used to fall back to the caller's corp_id
+  // whichever way the install was configured, which on a PUBLIC install grouped
+  // unrelated strangers by their in-game corp and showed each of them the
+  // others' ship and current system. In EVE a pilot's current system is hunting
+  // intel, so that is a leak and not a cosmetic bug.
+  //
+  // Scope only to an org the install is actually deployed for; anything else
+  // lists nobody. NPC corps never count, even on a corp install: EVE's starter
+  // corps hold tens of thousands of pilots with no relationship to each other.
+  const useAlliance = config.allianceMode && me.userAllianceId != null;
+  const scopeCol    = useAlliance ? 'alliance_id' : 'corp_id';
+  const scopeVal    = useAlliance ? me.userAllianceId
+                    : (config.corpMode ? me.userCorpId : null);
   if (scopeVal == null) { res.json([]); return; }
+  if (!useAlliance && scopeVal < MIN_PLAYER_CORP_ID) { res.json([]); return; }
 
   try {
     const { rows } = await db.query(

--- a/server/src/routes/pilotsOnline.integration.test.ts
+++ b/server/src/routes/pilotsOnline.integration.test.ts
@@ -13,7 +13,9 @@ import { db } from '../db.js';
 import { characterRouter } from './character.js';
 
 const dbReady = await ensureIntegrationDb();
-const CORP = 1000, OTHER_CORP = 2000, ALLY = 5000;
+// Real EVE id ranges matter here: player corps start at 98,000,000 and anything
+// below 2,000,000 is an NPC corp, which presence deliberately refuses to scope to.
+const CORP = 98000001, OTHER_CORP = 98000002, ALLY = 99000001, NPC_CORP = 1000045;
 
 function appFor(userId: number, corpId: number | null, allianceId: number | null = null) {
   const app = express();
@@ -65,6 +67,25 @@ describe.skipIf(!dbReady)('pilots-online (integration)', () => {
     expect(res.body[0].shipName).toBe('Scout One');
     expect(res.body[0].systemName).toBe('Jita');
     expect(res.body[0].regionName).toBe('The Forge');
+  });
+
+  // Regression: presence used to fall back to the caller's corp_id whatever the
+  // install was, so on a PUBLIC deployment two strangers who happened to share an
+  // NPC starter corp saw each other's ship and current system.
+  it('lists nobody on a public install, even for corp mates', async () => {
+    state.over = { corpMode: false, allianceMode: false, restrictedMode: true };
+    const mate = await seedUser({ characterId: 20, corpId: CORP, role: 'full' });
+    await seen(mate, 1, { ship: 'Heron' });
+    const res = await request(appFor(me, CORP)).get('/api/character/pilots-online').expect(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('lists nobody when the caller is in an NPC corp', async () => {
+    state.over = { corpMode: true, allianceMode: false, corpIds: [NPC_CORP], restrictedMode: true };
+    const npcMate = await seedUser({ characterId: 21, corpId: NPC_CORP, role: 'full' });
+    await seen(npcMate, 1, { ship: 'Ibis' });
+    const res = await request(appFor(me, NPC_CORP)).get('/api/character/pilots-online').expect(200);
+    expect(res.body).toEqual([]);
   });
 
   it('excludes anyone not seen inside the window', async () => {

--- a/web/src/components/ui/Sidebar.tsx
+++ b/web/src/components/ui/Sidebar.tsx
@@ -15,6 +15,7 @@ import { WatchlistBlock } from './WatchlistBlock';
 import { ChainsPane } from './ChainsPane';
 import { CaretLeftIcon, CaretRightIcon, ArrowLineLeftIcon, ArrowLineRightIcon } from '../../icons';
 import { useUserSetting } from '../../hooks/useUserSetting';
+import { useAuth } from '../../context/AuthContext';
 
 const SIDE_KEY      = 'nexum.sidebar.side';
 const COLLAPSED_KEY = 'nexum.sidebar.collapsed';
@@ -57,6 +58,7 @@ function sanitiseOrder(raw: unknown): PanelId[] {
 
 export function Sidebar() {
   const { t } = useTranslation();
+  const { user } = useAuth();
   const panelTitle: Record<PanelId, string> = {
     watchlist: t('sidebar.watchlist'),
     chains:  t('sidebar.chains'),
@@ -140,6 +142,17 @@ export function Sidebar() {
     );
   }
 
+  // Presence is an org feature: the server lists nobody unless Nexum is deployed
+  // for a corp or an alliance (see the pilots-online route). Rendering the panel
+  // regardless would leave a permanently empty card holding sidebar space on a
+  // personal or public install. Hide it there instead.
+  //
+  // Filtered at render rather than removed from the saved order, so it reappears
+  // in the position the user put it if the deployment later gains a corp or
+  // alliance.
+  const orgInstall   = !!user?.corpMode || !!user?.allianceMode;
+  const visibleOrder = order.filter((id) => id !== 'pilotsOnline' || orgInstall);
+
   const cards: Record<PanelId, ReactNode> = {
     watchlist: <WatchlistBlock />,
     chains:  <ChainsPane />,
@@ -187,9 +200,9 @@ export function Sidebar() {
       </div>
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAxis]} onDragEnd={handleDragEnd}>
-        <SortableContext items={order} strategy={verticalListSortingStrategy}>
+        <SortableContext items={visibleOrder} strategy={verticalListSortingStrategy}>
           <div className="sidebar__content">
-            {order.map(id => (
+            {visibleOrder.map(id => (
               <DraggableCard key={id} id={id} title={panelTitle[id]}>
                 {cards[id]}
               </DraggableCard>


### PR DESCRIPTION
## The bug

Pilots Online picked its scope like this:

```ts
const scopeCol = config.allianceMode && me.userAllianceId ? 'alliance_id' : 'corp_id';
const scopeVal = scopeCol === 'alliance_id' ? me.userAllianceId : me.userCorpId;
if (scopeVal == null) { res.json([]); return; }
```

The corp branch is taken whenever alliance mode is off, and it reads the caller's **in-game** `corp_id` regardless of whether the install is deployed for a corp at all. The comment directly above claimed *"neither set means a solo install, where there is nobody else to list"* -- but nothing implemented that. `userCorpId` is always populated from ESI, so the early return never fired.

## Why it matters

On a public deployment the `users` table holds unrelated strangers who share nothing but the game. Grouping them by in-game corp showed each of them the others' **ship and current system**. In EVE a pilot's current system is hunting intel, so this is a disclosure bug, not a cosmetic one.

EVE's rookie corps make it concrete: every new player starts in one of a handful of NPC corps holding tens of thousands of pilots, so two strangers on a public install were near-guaranteed to collide.

## Reproduced on production

The live instance runs `corpMode: false, allianceMode: false`. Against a **personal map that was never shared with anyone**, `/api/character/pilots-online` returned:

```
pilotsCount: 2
  Perfect Hanomaa       -> 2JJ-0E
  Ovori Sukka Shikkoken -> Ouranienen
```

The caller's corp is `1000045` -- an NPC starter corp. Neither pilot has any relationship to the caller or the map.

## The fix

Scope only to an org the install is actually deployed for:

| Install | Scope |
|---|---|
| Alliance mode on | the caller's alliance |
| Corp mode on | the caller's corp |
| Neither (public/solo) | **nobody** |

NPC corps are refused even under corp mode -- an id below 2,000,000 (player corps start at 98,000,000) is a starter corp, not an organisation.

## Tests

The existing tests used corp ids `1000` and `2000`, which are themselves inside the NPC range, so they now use realistic player-corp ids. Two regression tests cover the leak directly:

- a public install lists nobody, even for a genuine corp mate
- an NPC-corp caller lists nobody

`Tests 138 passed (138)`, `tsc --noEmit` clean.

## Known consequence

On **eve-nexum.com** the panel will now list nobody, because it is a public install. That is correct -- it is the leak being closed -- but it does mean the feature is inert there. Making it useful on a public install needs presence scoped to *people who share the map you are looking at* rather than to an org, which is a separate change: the endpoint currently takes no `mapId` at all.