### PR TITLE
Stop a dead socket freezing location tracking until a reload

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -56,7 +56,20 @@ export class ApiError extends Error {
   }
 }
 
-export async function api<T = unknown>(path: string, options?: RequestInit): Promise<T> {
+/**
+ * `timeoutMs` aborts a request that hasn't finished in time. Opt-in, because a
+ * blanket timeout would cut off the genuinely slow endpoints (route solving,
+ * standings refreshes).
+ *
+ * It matters most to the polls. A `fetch` has no timeout of its own, so a
+ * request can stay pending forever when the socket dies without an error --
+ * a laptop suspending, wifi dropping, a proxy holding the connection open. A
+ * poll that de-dupes on an in-flight promise then has nothing to resolve it,
+ * and stops polling for the life of the page.
+ */
+export type ApiOptions = RequestInit & { timeoutMs?: number };
+
+export async function api<T = unknown>(path: string, options?: ApiOptions): Promise<T> {
   const method = (options?.method ?? 'GET').toUpperCase();
 
   // Dry-run: swallow writes before any network work so they neither send nor
@@ -75,14 +88,27 @@ export async function api<T = unknown>(path: string, options?: RequestInit): Pro
     finalPath = path + (path.includes('?') ? '&' : '?') + `shareToken=${encodeURIComponent(shareToken)}`;
   }
 
-  const { headers: optHeaders, ...rest } = options ?? {};
-  const res = await fetch(`${BASE}${finalPath}`, {
-    credentials: 'include',
-    ...rest,
-    // Merge last so Content-Type / client id survive even when a caller passes
-    // its own headers (previously `...options` could replace them wholesale).
-    headers: { 'Content-Type': 'application/json', 'X-Client-Id': CLIENT_ID, ...optHeaders },
-  });
+  const { headers: optHeaders, timeoutMs, ...rest } = options ?? {};
+
+  // Only fit an abort when asked for one and the caller isn't managing its own
+  // signal. Cleared in the finally below so a completed request doesn't leave a
+  // timer running.
+  const controller = timeoutMs != null && rest.signal == null ? new AbortController() : null;
+  const abortTimer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}${finalPath}`, {
+      credentials: 'include',
+      ...rest,
+      ...(controller ? { signal: controller.signal } : {}),
+      // Merge last so Content-Type / client id survive even when a caller passes
+      // its own headers (previously `...options` could replace them wholesale).
+      headers: { 'Content-Type': 'application/json', 'X-Client-Id': CLIENT_ID, ...optHeaders },
+    });
+  } finally {
+    if (abortTimer) clearTimeout(abortTimer);
+  }
   if (!res.ok) {
     // Read the error body (JSON { error, message }) so callers can show the
     // real reason. Tolerant of non-JSON / empty error bodies.

--- a/web/src/hooks/createPolledStore.ts
+++ b/web/src/hooks/createPolledStore.ts
@@ -38,6 +38,7 @@ export function createPolledStore<T>(opts: {
   let fetchedAt = 0;
   let loaded = false;
   let inflight: Promise<void> | null = null;
+  let inflightAt = 0;
   let timer: ReturnType<typeof setInterval> | null = null;
   let unsubX: (() => void) | null = null;
   const subscribers = new Set<() => void>();
@@ -53,20 +54,31 @@ export function createPolledStore<T>(opts: {
     subscribers.forEach((fn) => fn());
   }
 
+  // How long an in-flight request may block new ones before it is written off.
+  // `fetch` has no timeout of its own, so a socket that dies quietly (suspended
+  // laptop, dropped wifi, a proxy holding the connection) leaves its promise
+  // pending forever -- and the de-dupe below then hands that same dead promise
+  // to every later tick, so the store stops polling for the life of the page and
+  // only a reload brings it back. Abandon it instead and let the next tick try
+  // again; the orphan settles or is collected on its own.
+  const STUCK_MS = Math.max(pollMs * 3, 30_000);
+
   function load(): Promise<void> {
-    if (inflight) return inflight;
+    if (inflight && Date.now() - inflightAt < STUCK_MS) return inflight;
     // If another tab already fetched within this interval, reuse it — no network.
     if (crossTab) {
       const shared = readXTab(crossTab.key, pollMs);
       if (shared !== undefined) { apply(crossTab.deserialize(shared.v), shared.at); return Promise.resolve(); }
     }
-    inflight = doFetch()
+    inflightAt = Date.now();
+    const mine = doFetch()
       .then((next) => {
         if (crossTab) writeXTab(crossTab.key, crossTab.serialize(next)); // let other tabs skip
         apply(next);
       })
       .catch(() => { /* keep the last good value */ })
-      .finally(() => { inflight = null; });
+      .finally(() => { if (inflight === mine) inflight = null; });
+    inflight = mine;
     return inflight;
   }
 

--- a/web/src/hooks/createPolledStore.ts
+++ b/web/src/hooks/createPolledStore.ts
@@ -67,8 +67,14 @@ export function createPolledStore<T>(opts: {
     if (inflight && Date.now() - inflightAt < STUCK_MS) return inflight;
     // If another tab already fetched within this interval, reuse it — no network.
     if (crossTab) {
+      // Strictly newer than our own last read -- otherwise a lone tab adopts the
+      // entry it published itself moments into the interval, skips every other
+      // fetch, and quietly polls at half the configured rate.
       const shared = readXTab(crossTab.key, pollMs);
-      if (shared !== undefined) { apply(crossTab.deserialize(shared.v), shared.at); return Promise.resolve(); }
+      if (shared !== undefined && shared.at > fetchedAt) {
+        apply(crossTab.deserialize(shared.v), shared.at);
+        return Promise.resolve();
+      }
     }
     inflightAt = Date.now();
     const mine = doFetch()

--- a/web/src/hooks/useCharacterLocation.ts
+++ b/web/src/hooks/useCharacterLocation.ts
@@ -134,8 +134,15 @@ function load(): Promise<CharacterLocation> {
   // If another tab acting as this same character fetched within the interval,
   // reuse it — no network call. Keyed by charId so a tab pinned to a different
   // pilot still fetches its own.
+  // Only adopt a value a PEER published more recently than our own last read.
+  // Without the comparison a lone tab reads back its own entry: it publishes at
+  // fetch-completion (a fraction of a second INTO the interval), so at the next
+  // tick that entry is a shade under POLL_MS old and still counts as fresh. The
+  // tab then adopts its own value and skips the fetch, taking the real cadence
+  // to 20s and doubling how long a jump goes unnoticed.
+  const ownAt = moduleCache?.charId === charId ? moduleCache.fetchedAt : 0;
   const shared = readXTab(xTabKey(charId), POLL_MS);
-  if (shared !== undefined) {
+  if (shared !== undefined && shared.at > ownAt) {
     const data = shared.v as CharacterLocation;
     adopt(charId, data, shared.at);
     return Promise.resolve(data);

--- a/web/src/hooks/useCharacterLocation.ts
+++ b/web/src/hooks/useCharacterLocation.ts
@@ -46,6 +46,10 @@ interface RawLocationResponse {
 // surfaced as the location going out of sync). A visibility/focus catch-up
 // (below) covers the gap the moment the tab is looked at.
 const POLL_MS = 10_000;
+// Shorter than the interval on purpose: a request that hasn't answered within
+// one poll period is not going to be useful, and letting it outlive its own tick
+// is what used to wedge tracking. See the load() de-dupe below.
+const POLL_TIMEOUT_MS = 8_000;
 const EMPTY: CharacterLocation = { online: false, system: null, ship: null };
 
 // The users.id of the character THIS TAB currently acts as: the per-tab pinned
@@ -137,7 +141,15 @@ function load(): Promise<CharacterLocation> {
     return Promise.resolve(data);
   }
   inflightCharId = charId;
-  inflight = api<RawLocationResponse>(`/api/character/${charId}/location`)
+  // The timeout is what makes the de-dupe above safe. `fetch` never times out on
+  // its own, so a socket that dies quietly -- a suspended laptop, dropped wifi, a
+  // proxy holding the connection -- left this promise pending forever. Every
+  // later tick, and every visibility/focus catch-up, then returned that same dead
+  // promise instead of making a request, so the pilot's location silently stopped
+  // updating until the page was reloaded. Worse, the eventual catch-up treated
+  // the whole gap as ONE jump and drew a connection from wherever they were when
+  // it stalled.
+  inflight = api<RawLocationResponse>(`/api/character/${charId}/location`, { timeoutMs: POLL_TIMEOUT_MS })
     .then(r => {
       const data: CharacterLocation = { online: r.online, system: r.system, ship: r.ship ?? null };
       inflight = null;

--- a/web/src/hooks/useLocationTracking.ts
+++ b/web/src/hooks/useLocationTracking.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useMapStore, getPlacementCell, registerPlacementFix } from '../store/mapStore';
-import { useCharacterLocation } from './useCharacterLocation';
+import { useCharacterLocation, useCharacterLocationCheckedAt } from './useCharacterLocation';
 import { useClones, cloneSystemIds } from './useClones';
 import { useCanEdit } from './useCanEdit';
 import { useAuth } from '../context/AuthContext';
@@ -130,6 +130,16 @@ const isKspaceSkip = (cls: string) => KSPACE_SKIP.has(cls);
  *  its endpoints so a caller can log the crossing (jump log). Never affects
  *  placement or mass. */
 export type OnConnectionJump = (info: { connId: string; fromMapSystemId: string; toMapSystemId: string }) => void;
+
+// A jump is only trusted when the two readings that bracket it are close
+// together. This sits well clear of one minute on purpose: a hidden tab -- which
+// is where the mapper usually is, behind the game client -- gets its timers
+// clamped by the browser to roughly one tick per minute, so a threshold near 60s
+// would start discarding perfectly real connections during ordinary background
+// use. Three minutes is long enough that normal throttling never trips it, and
+// short enough to catch the case this guards: a pilot crossing several systems
+// while tracking was stalled.
+const MAX_TRACKING_GAP_MS = 180_000;
 
 export function applyJump(
   system: JumpSystem,
@@ -332,6 +342,9 @@ export function applyTrackedJump(
  */
 export function useLocationTracking(enabled: boolean) {
   const location = useCharacterLocation();
+  // When the location was last READ successfully, not when it last changed. The
+  // gap between consecutive reads is what says whether a jump can be trusted.
+  const checkedAt = useCharacterLocationCheckedAt();
   const clones = useClones();
   const { user } = useAuth();
   // The effective acting character (pin, else this tab's own character). Any
@@ -362,6 +375,8 @@ export function useLocationTracking(enabled: boolean) {
   // isn't enough: being podded while already in a pod, or clone jumping from a
   // pod, is Capsule to Capsule and looks like nothing changed.
   const lastShipItemId = useRef<number | null>(null);
+  // The previous successful location read, for measuring the gap to this one.
+  const lastCheckedAt = useRef<number | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
@@ -382,6 +397,7 @@ export function useLocationTracking(enabled: boolean) {
       lastSelectedEveId.current = null;
       prevPhysical.current = null;
       lastShipItemId.current = null;
+      lastCheckedAt.current = null;
     }
 
     const system = location.system;
@@ -390,6 +406,7 @@ export function useLocationTracking(enabled: boolean) {
       lastMapSystemId.current = null;
       prevPhysical.current = null;
       lastShipItemId.current = null;
+      lastCheckedAt.current = null;
       setCurrentSystem(null);
       return;
     }
@@ -420,7 +437,21 @@ export function useLocationTracking(enabled: boolean) {
     // No clone data (scope not yet granted, ESI down) means no suppression at
     // all — the old behaviour. A missing connection nobody notices is worse than
     // a wrong one somebody deletes.
-    const teleported = hullChanged && cloneSystemIds(clones).has(system.eveSystemId);
+    const cloneJumped = hullChanged && cloneSystemIds(clones).has(system.eveSystemId);
+
+    // How long since the last SUCCESSFUL read. A pilot who has been unobserved
+    // for minutes may have crossed several systems, so the change we are looking
+    // at is not necessarily one jump: connecting its ends would assert a hole
+    // that does not exist, which is worse than drawing nothing. A missing
+    // connection is obvious and a scout adds it; a false one makes the map lie
+    // about topology and routes people through a hole that isn't there.
+    const prevCheckedAt = lastCheckedAt.current;
+    if (checkedAt != null) lastCheckedAt.current = checkedAt;
+    const unobserved = prevCheckedAt != null && checkedAt != null
+      && checkedAt - prevCheckedAt > MAX_TRACKING_GAP_MS;
+
+    // Same treatment as a clone jump: record the system, draw no connection.
+    const teleported = cloneJumped || unobserved;
 
     if (system.eveSystemId === lastEveSystemId.current) return;
 
@@ -501,5 +532,5 @@ export function useLocationTracking(enabled: boolean) {
       lastSelectedEveId.current = system.eveSystemId;
       selectSystem(mapSystemId, { fromJump: true });
     }
-  }, [enabled, location, canEdit, followedId]);
+  }, [enabled, location, checkedAt, canEdit, followedId]);
 }


### PR DESCRIPTION
## The report

> the mapper not noticing you moved to a new system, sometimes not noticing for enough time to traverse like 5-6 systems and start scanning, then you jump a hole and it connects it to 5 systems prior [...] if we stop and refresh the whole page before we start scanning a given system it seems to catch up

That last part is the tell. A stall that only a **full reload** clears is not throttling or a slow network -- it means the poll can never issue another request.

## Cause

`useCharacterLocation.load()` de-dupes concurrent requests on an in-flight promise:

```ts
if (inflight && inflightCharId === charId) return inflight;
```

`inflight` is cleared only by that promise's own `then`/`catch`, and **`fetch` has no timeout of its own**. A socket that dies quietly -- a suspended laptop, dropped wifi, a proxy holding the connection open -- leaves the promise pending forever. Every later tick returns that same dead promise instead of making a request.

The safety net is defeated too: the `visibilitychange`/`focus` catch-up calls `load()`, which also just returns the dead promise. So tracking is finished for the life of the page, and only F5 helps.

Note the guard runs *before* the cross-tab read, so a wedged tab cannot even adopt a healthy peer's value. Single-tab users stay stuck, which is why this doesn't hit everyone.

## It explains the wrong connection too

Nothing bounds how long a gap may be. When tracking finally resumes the pilot has moved several systems, and the change is treated as a single jump -- drawing a connection from the system they stalled in to the one they ended up in. "Connects it to 5 systems prior" is precisely this.

## Fix

The location request carries an **8 s timeout**, shorter than its own 10 s interval, so a request can never outlive the tick that issued it. `timeoutMs` is opt-in on `api()` -- a blanket timeout would cut off genuinely slow endpoints like route solving.

`createPolledStore` had the identical de-dupe, so **clones, fleet, pilots online, scout connections, kills and account locations** could all wedge the same way. Rather than thread a timeout through six call sites, it writes off an in-flight request that has blocked new ones for more than 3 poll periods. A late arrival can no longer clear a newer request's slot (`if (inflight === mine)`).

## Verified in the browser

`web/` has no test runner, so this was measured against the running app with `fetch` stubbed to hang on `/location`:

| Socket behaviour | Location requests in ~30 s |
|---|---|
| Hangs, nothing can settle the promise (**old** path) | **1**, then silent for good |
| Hangs, abort honoured as real `fetch` does (**fixed**) | **3**, and still going |

Lint 0 errors, build passes.

## Still outstanding

This fixes the stall, not the second half: a long gap is still read as one jump. Any gap -- a laptop asleep, a genuine outage -- can still produce a connection we cannot vouch for. That needs a decision about what to do with it rather than a bug fix, so it is deliberately not in this PR.