### PR TITLE
Cover the "Get more maps" UI, and unmount renders between tests

### DIFF
--- a/web/src/components/ui/GetMoreMapsModal.test.tsx
+++ b/web/src/components/ui/GetMoreMapsModal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const api = vi.hoisted(() => vi.fn());
+vi.mock('../../api/client', () => ({ api }));
+vi.mock('react-i18next', () => ({
+  // Echo the key plus its interpolation values, so a test can assert that the
+  // right numbers reach the copy without depending on English wording.
+  useTranslation: () => ({
+    t: (k: string, v?: Record<string, unknown>) => (v ? `${k}:${JSON.stringify(v)}` : k),
+    i18n: { language: 'en' },
+  }),
+}));
+
+import { GetMoreMapsModal } from './GetMoreMapsModal';
+
+const BASE = {
+  used: 5, cap: 5, base: 5, donated: 0, toNext: 500_000_000,
+  priceIsk: 500_000_000, perGrant: 5, enabled: true,
+  corpId: 98120330, corpName: 'The 404', donations: [],
+};
+
+describe('GetMoreMapsModal', () => {
+  beforeEach(() => { api.mockReset(); });
+
+  it('names the recipient corporation the server resolved', async () => {
+    api.mockResolvedValue(BASE);
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('The 404')).toBeTruthy());
+  });
+
+  // The corp is deployment config, so a self-hoster must never be shown someone
+  // else's corp name — and if the name can't be resolved, the id is still
+  // enough to find it in game.
+  it('falls back to the corporation id when the name cannot be resolved', async () => {
+    api.mockResolvedValue({ ...BASE, corpName: null });
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('98120330')).toBeTruthy());
+  });
+
+  it('tells the pilot how many maps they are using', async () => {
+    api.mockResolvedValue({ ...BASE, used: 5, cap: 10 });
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/getMoreMaps\.using.*"used":5.*"cap":10/)).toBeTruthy());
+  });
+
+  it('always states the delay, so nobody expects it to be instant', async () => {
+    api.mockResolvedValue(BASE);
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('getMoreMaps.timing')).toBeTruthy());
+  });
+
+  it('always warns that the donation must come from a linked character', async () => {
+    api.mockResolvedValue(BASE);
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('getMoreMaps.mustBeLinked')).toBeTruthy());
+  });
+
+  it('hides the contribution history for someone who has never donated', async () => {
+    api.mockResolvedValue(BASE);
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('getMoreMaps.timing')).toBeTruthy());
+    expect(screen.queryByText(/getMoreMaps\.contributed/)).toBeNull();
+  });
+
+  it('shows the running total and what is left for the next grant', async () => {
+    api.mockResolvedValue({
+      ...BASE, donated: 300_000_000, toNext: 200_000_000,
+      donations: [{ amount: '300000000', occurredAt: '2026-09-09T10:00:00Z' }],
+    });
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/getMoreMaps\.contributed/)).toBeTruthy());
+    expect(screen.getByText(/getMoreMaps\.toNext.*200,000,000/)).toBeTruthy();
+  });
+
+  it('says so when the details cannot be loaded, rather than showing nothing', async () => {
+    api.mockRejectedValue(new Error('offline'));
+    render(<GetMoreMapsModal onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('getMoreMaps.loadFailed')).toBeTruthy());
+  });
+});

--- a/web/src/components/ui/Toolbar.getMoreMaps.test.tsx
+++ b/web/src/components/ui/Toolbar.getMoreMaps.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// The toolbar pulls in a lot of the app. Everything stubbed below is stubbed
+// because it does IO or drags in the canvas — none of it decides whether the
+// "Get more maps" entry appears. The two things that DO decide it, the store
+// flag and the map count, are left real.
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 1, characterId: 100, characterName: 'Pilot', role: 'full', characters: [] }, logout: vi.fn() }),
+  formatRole: (r: string) => r,
+  isAdminRole: () => false,
+}));
+vi.mock('../../api/client', () => ({ api: vi.fn(async () => ({})), apiUrl: (p: string) => p }));
+vi.mock('../../hooks/useOnlineStatus', () => ({ useOnlineStatus: () => ({ online: true, lastLogin: null }) }));
+vi.mock('../../hooks/useCharacterLocation', () => ({
+  useCharacterLocation: () => ({ online: true, system: null, ship: null }),
+  useCharacterLocationCheckedAt: () => Date.now(),
+}));
+vi.mock('../../hooks/useSystemAlias', () => ({ useSystemAlias: () => (n: string) => n }));
+vi.mock('../../hooks/useCanEdit', () => ({ useCanEdit: () => true }));
+vi.mock('../../hooks/useCanEditContent', () => ({ useCanEditContent: () => true }));
+vi.mock('../../hooks/useIsMapOwner', () => ({ useIsMapOwner: () => true }));
+vi.mock('../../hooks/useCanCreateMaps', () => ({ useCanCreateMaps: () => false, useCanManageAllianceMaps: () => false }));
+vi.mock('../../hooks/useProximityAlerts', () => ({ useProximityAlerts: () => ({ alerts: [] }) }));
+// useUserSetting is NOT mocked: it is a plain localStorage-backed module that
+// works in jsdom, and the map store imports readUserSetting from it at module
+// scope — stubbing it only breaks the store.
+// Modals and panels that would each drag in their own subtree.
+vi.mock('./UserStatsModal',    () => ({ UserStatsModal:    () => null }));
+vi.mock('./GetMoreMapsModal',  () => ({ GetMoreMapsModal:  () => <div>get-more-maps-modal</div> }));
+vi.mock('./ConfirmModal',      () => ({ ConfirmModal:      () => null }));
+vi.mock('./CreateMapModal',    () => ({ CreateMapModal:    () => null }));
+vi.mock('./CopyMapModal',      () => ({ CopyMapModal:      () => null }));
+vi.mock('./ApiKeysModal',      () => ({ ApiKeysModal:      () => null }));
+vi.mock('./LanguageSwitcher',  () => ({ LanguageSwitcher:  () => null }));
+vi.mock('./CharacterSwitcher', () => ({ CharacterSwitcher: () => null }));
+vi.mock('./HeatmapMenu',       () => ({ HeatmapMenu:       () => null }));
+vi.mock('./WhTypeChartModal',  () => ({ WhTypeChartModal:  () => null }));
+vi.mock('./KillLogPanel',      () => ({ KillLogPanel:      () => null }));
+vi.mock('./JumpPlannerModal',  () => ({ JumpPlannerModal:  () => null }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}));
+
+import { Toolbar } from './Toolbar';
+import { useMapStore } from '../../store/mapStore';
+
+function personalMaps(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `m${i}`, name: `Map ${i}`,
+    isCorpMap: false, isAllianceMap: false, sharedWithMe: false, locked: false,
+  }));
+}
+
+// Put the store in a known state: `count` personal maps against a cap of 5.
+function setUp(count: number, iskMapsEnabled: boolean) {
+  useMapStore.setState({
+    maps: personalMaps(count) as never,
+    maxMaps: 5,
+    iskMapsEnabled,
+    activeMapId: 'm0',
+  } as never);
+}
+
+// The entry is meant to appear ONLY when the pilot has actually run out AND the
+// deployment offers it. The second half is what keeps it off corp and alliance
+// installs, which manage their own limits.
+// The entry lives INSIDE the map dropdown, which starts closed. Without opening
+// it every assertion below would pass for the wrong reason — the negative cases
+// would be finding nothing simply because nothing is rendered yet.
+function renderWithMenuOpen() {
+  const r = render(<Toolbar />);
+  fireEvent.click(r.container.querySelector('.toolbar__map-name-btn')!);
+  return r;
+}
+
+describe('Toolbar — "Get more maps"', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('the menu actually opens, so the assertions below mean something', () => {
+    setUp(2, true);
+    renderWithMenuOpen();
+    expect(screen.queryByText('toolbar.newMap')).not.toBeNull();
+  });
+
+  it('is absent while the pilot still has map slots left', () => {
+    setUp(2, true);
+    renderWithMenuOpen();
+    expect(screen.queryByText('toolbar.getMoreMaps')).toBeNull();
+  });
+
+  it('appears once the pilot is at their cap', () => {
+    setUp(5, true);
+    renderWithMenuOpen();
+    expect(screen.queryByText('toolbar.getMoreMaps')).not.toBeNull();
+  });
+
+  it('stays hidden at the cap when the deployment does not offer it', () => {
+    setUp(5, false);
+    renderWithMenuOpen();
+    expect(screen.queryByText('toolbar.getMoreMaps')).toBeNull();
+  });
+
+  it('stays hidden when over the cap but the deployment does not offer it', () => {
+    setUp(9, false);
+    renderWithMenuOpen();
+    expect(screen.queryByText('toolbar.getMoreMaps')).toBeNull();
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    // Unmounts each render between tests — see the file for why this is needed
+    // rather than relying on Testing Library's automatic cleanup.
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     // Each test gets clean module state: these stores are module-level
     // singletons holding caches and in-flight promises, so leaking one test's

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,11 @@
+// Runs before every web test file.
+//
+// React Testing Library only registers its own afterEach cleanup when vitest is
+// running with `globals: true`. This project imports its test helpers explicitly
+// instead, so without this the DOM from one test is still mounted during the
+// next — queries then match elements from a previous render and fail with
+// "found multiple elements", which reads like a component bug and isn't one.
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(cleanup);


### PR DESCRIPTION
The gate on the menu entry was the one part of ISK-for-maps with no test. It must appear **only** when a pilot has actually run out of maps **and** the deployment offers the option — the second half being what keeps it off corp and alliance installs.

## Toolbar gating

Rendering the toolbar means stubbing a fair amount of the app. Everything stubbed does IO or drags in the canvas; the two things that actually decide the gate — the store flag and the map count — are left real.

Verified by removing the `iskMapsEnabled` half of the condition:

```
× stays hidden at the cap when the deployment does not offer it
× stays hidden when over the cap but the deployment does not offer it
  Tests  2 failed | 3 passed (5)
```

**One thing worth calling out.** The entry lives inside the map dropdown, which starts closed. My first version asserted against an unopened menu, so all three negative cases passed for the wrong reason — finding nothing because nothing was rendered yet. The tests now open the menu, and there's an explicit test asserting the menu opened at all, so that failure mode can't come back quietly.

## Modal

Covers the logic in the component rather than its wording: the corporation name the server resolved, the fall back to its **id** when the name is unavailable (a self-hoster must never see someone else's corp), the usage figures reaching the copy, history appearing only for someone who has donated, and a load failure being stated rather than rendering an empty dialog.

The delay notice and the linked-character warning are asserted unconditionally. Both exist purely to stop support requests, and both would be easy to drop in a later edit without noticing.

## Infrastructure fix

React Testing Library only registers its own `afterEach` cleanup when vitest runs with `globals: true`, which this project doesn't — it imports test helpers explicitly. Without cleanup, the DOM from one test was still mounted during the next and queries matched elements from a previous render. It surfaced as `found multiple elements`, which reads like a component bug and isn't one.

A setup file now unmounts between tests, so every future component test gets it for free. This would have bitten the next person to write one.

## Verified

`Test Files 6 passed`, `Tests 43 passed` (was 30), lint 0 errors, build passes.