### PR TITLE
Show who a shared map belongs to

### DIFF
--- a/web/src/components/ui/Toolbar.tsx
+++ b/web/src/components/ui/Toolbar.tsx
@@ -394,7 +394,14 @@ export function Toolbar() {
               const active = maps.find((m) => m.id === activeMapId);
               if (!active) return null;
               if (active.sharedWithMe) {
-                return <span className="toolbar__map-type toolbar__map-type--shared">{t('toolbar.mapType.shared')}</span>;
+                return (
+                  <span
+                    className="toolbar__map-type toolbar__map-type--shared"
+                    data-tooltip={active.ownerName ? t('toolbar.sharedBy', { name: active.ownerName }) : undefined}
+                  >
+                    {t('toolbar.mapType.shared')}
+                  </span>
+                );
               }
               if (active.isAllianceMap) {
                 return <span className="toolbar__map-type toolbar__map-type--alliance">{t('toolbar.mapType.alliance')}</span>;
@@ -443,6 +450,12 @@ export function Toolbar() {
                   {!m.sharedWithMe && m.isCorpMap && <span className="map-dropdown__badge map-dropdown__badge--corp">{t('toolbar.mapType.corp')}</span>}
                   {m.locked    && <span className="map-dropdown__badge map-dropdown__badge--lock">🔒</span>}
                   {m.name}
+                  {/* Whose map this is. Only for shares: on your own maps the
+                      owner is you, and on corp/alliance maps the badge already
+                      says who it belongs to. */}
+                  {m.sharedWithMe && m.ownerName && (
+                    <span className="map-dropdown__owner">{m.ownerName}</span>
+                  )}
                 </button>
               ))}
               <div className="map-dropdown__divider" />

--- a/web/src/i18n/locales/de/common.json
+++ b/web/src/i18n/locales/de/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "Update verfügbar",
     "updateAvailableVersion": "Update verfügbar: v{{version}}",
     "copyThisMap": "Diese Karte kopieren",
-    "getMoreMaps": "+ Mehr Karten erhalten"
+    "getMoreMaps": "+ Mehr Karten erhalten",
+    "sharedBy": "Geteilt von {{name}}"
   },
   "landing": {
     "tagline": "Wurmloch-Kettenkartierung für EVE Online",

--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -1457,7 +1457,8 @@
       "threat": "Threat",
       "closest": "Closest {{label}} system"
     },
-    "getMoreMaps": "+ Get more maps"
+    "getMoreMaps": "+ Get more maps",
+    "sharedBy": "Shared by {{name}}"
   },
   "landing": {
     "tagline": "Wormhole chain mapping for EVE Online",

--- a/web/src/i18n/locales/es/common.json
+++ b/web/src/i18n/locales/es/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "Actualización disponible",
     "updateAvailableVersion": "Actualización disponible: v{{version}}",
     "copyThisMap": "Copiar este mapa",
-    "getMoreMaps": "+ Obtener más mapas"
+    "getMoreMaps": "+ Obtener más mapas",
+    "sharedBy": "Compartido por {{name}}"
   },
   "landing": {
     "tagline": "Cartografía de cadenas de agujeros de gusano para EVE Online",

--- a/web/src/i18n/locales/fr/common.json
+++ b/web/src/i18n/locales/fr/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "Mise à jour disponible",
     "updateAvailableVersion": "Mise à jour disponible : v{{version}}",
     "copyThisMap": "Copier cette carte",
-    "getMoreMaps": "+ Obtenir plus de cartes"
+    "getMoreMaps": "+ Obtenir plus de cartes",
+    "sharedBy": "Partagée par {{name}}"
   },
   "landing": {
     "tagline": "Cartographie de chaînes de trous de ver pour EVE Online",

--- a/web/src/i18n/locales/ja/common.json
+++ b/web/src/i18n/locales/ja/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "アップデートが利用可能",
     "updateAvailableVersion": "アップデートが利用可能: v{{version}}",
     "copyThisMap": "このマップをコピー",
-    "getMoreMaps": "+ マップを追加する"
+    "getMoreMaps": "+ マップを追加する",
+    "sharedBy": "{{name}} が共有"
   },
   "landing": {
     "tagline": "EVE Online のためのワームホールチェーン・マッピング",

--- a/web/src/i18n/locales/ko/common.json
+++ b/web/src/i18n/locales/ko/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "업데이트 사용 가능",
     "updateAvailableVersion": "업데이트 사용 가능: v{{version}}",
     "copyThisMap": "이 지도 복사",
-    "getMoreMaps": "+ 맵 추가하기"
+    "getMoreMaps": "+ 맵 추가하기",
+    "sharedBy": "{{name}} 님이 공유"
   },
   "landing": {
     "tagline": "EVE Online을 위한 웜홀 체인 지도 작성",

--- a/web/src/i18n/locales/pt/common.json
+++ b/web/src/i18n/locales/pt/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "Atualização disponível",
     "updateAvailableVersion": "Atualização disponível: v{{version}}",
     "copyThisMap": "Copiar este mapa",
-    "getMoreMaps": "+ Obter mais mapas"
+    "getMoreMaps": "+ Obter mais mapas",
+    "sharedBy": "Partilhado por {{name}}"
   },
   "landing": {
     "tagline": "Cartografia de cadeias de buracos de minhoca para EVE Online",

--- a/web/src/i18n/locales/ru/common.json
+++ b/web/src/i18n/locales/ru/common.json
@@ -1424,7 +1424,8 @@
     "updateAvailable": "Доступно обновление",
     "updateAvailableVersion": "Доступно обновление: v{{version}}",
     "copyThisMap": "Копировать эту карту",
-    "getMoreMaps": "+ Получить больше карт"
+    "getMoreMaps": "+ Получить больше карт",
+    "sharedBy": "Поделился {{name}}"
   },
   "landing": {
     "tagline": "Картирование цепочек червоточин для EVE Online",

--- a/web/src/i18n/locales/zh/common.json
+++ b/web/src/i18n/locales/zh/common.json
@@ -1386,7 +1386,8 @@
     "updateAvailable": "有可用更新",
     "updateAvailableVersion": "有可用更新：v{{version}}",
     "copyThisMap": "复制此地图",
-    "getMoreMaps": "+ 获取更多地图"
+    "getMoreMaps": "+ 获取更多地图",
+    "sharedBy": "由 {{name}} 共享"
   },
   "landing": {
     "tagline": "EVE Online 的虫洞链路绘图",

--- a/web/src/styles/overlays.css
+++ b/web/src/styles/overlays.css
@@ -168,6 +168,19 @@
 .map-dropdown__badge--corp { background: rgba(100,160,255,0.15); color: var(--accent-light); border: 1px solid rgba(100,160,255,0.3); }
 .map-dropdown__badge--alliance { background: rgba(245,166,35,0.15); color: var(--warning-alt); border: 1px solid rgba(245,166,35,0.3); }
 .map-dropdown__badge--shared { background: rgba(192,132,252,0.15); color: var(--accent-violet); border: 1px solid rgba(192,132,252,0.3); }
+
+/* Who a shared map belongs to, after its name in the map list. Muted, with a
+   separator dot, so it reads as an attribution rather than part of the name.
+   Deliberately inline: the row is display:block and shared with the action
+   items, so it is not turned into a flex container just for this. */
+/* Its own line under the map name. Inline, it competed with the name for a
+   narrow dropdown and broke it mid-word ("Shared catch / me - addelee"); a
+   deliberate second line reads as an attribution instead of a wrap. No
+   font-size of its own — it inherits, so the user's text scaling still applies. */
+.map-dropdown__owner {
+  display: block;
+  color: var(--text-dim);
+}
 .map-dropdown__badge--lock { background: transparent; border: none; font-size: calc(12px * var(--font-scale, 1)); }
 
 .toolbar__actions { display: flex; gap: 8px; }


### PR DESCRIPTION
A map shared with you was labelled **Shared** and nothing else, so there was no way to tell whose chain you were looking at — or which of two similarly named maps came from whom.

## Display only

The owning character's name was already in the maps payload (`ownerName`, joined for the merge picker), so there's no query change and no extra request.

Two places, because they answer different questions:

| Where | What it answers |
|---|---|
| Map list | A line under each shared map — which one do I want? |
| Toolbar badge tooltip | Whose is the map I'm already on? |

Only on shares. On your own maps the owner is you, and corp/alliance maps already say who they belong to on the badge.

## One thing worth seeing

The name started out **inline** after the map name. That reads fine as markup and broke the name mid-word in the real dropdown, because the two competed for a narrow row:

```
[Shared] catch
me · addelee
```

It's a deliberate second line instead, which reads as an attribution rather than a wrap:

```
[Solo]   Demo Map
[Shared] catch me
         addelee
```

Checked in the browser against a genuinely shared map, not by reasoning about the markup. It sets no `font-size` of its own, so the user's text scaling still applies.

## Verified

Rendered against a real shared map on the dev instance: badge tooltip reads `Shared by addelee`, the row shows the owner on its own line, and the owner line is absent on the pilot's own map. Lint 0 errors, build passes, all 9 locales translated and parity checked.

## No test

The natural home is the Toolbar harness in #641, which isn't merged yet — adding a second copy of that scaffolding here would collide with it. Happy to add the case once #641 lands.